### PR TITLE
v2.0 — EA overhaul, deterministic load order, two-pass early autoloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,23 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
 
 ---
 
-## Requirements
-
-- Road to Vostok (PC, Steam)
-- Mods packaged as `.vmz` or `.pck` files
-
----
-
 ## Installation
 
-1. Copy `override.cfg` into the game installation folder:
-   ```
-   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
-   ```
+Both files go in the **game installation folder** (next to `RTV.exe`):
 
-2. Copy `modloader.gd` into the game's data folder:
-   ```
-   C:\Users\<your username>\AppData\Roaming\Road to Vostok\
-   ```
+```
+C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
+```
 
-3. Create a `mods` folder inside the game installation folder if it doesn't exist:
-   ```
-   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods\
-   ```
+1. Copy `override.cfg` and `modloader.gd` into the game folder.
 
-4. Place your `.vmz` mod files inside the `mods` folder.
+2. Create a `mods` folder inside the game folder if it doesn't exist.
 
-5. Launch the game normally. The mod loader UI will appear before the main menu.
+3. Place your `.vmz` mod files inside the `mods` folder.
+
+4. Launch the game normally. The mod loader UI will appear before the main menu.
+
+**That's it.** No AppData setup needed — everything lives in one folder.
 
 ---
 
@@ -38,44 +28,62 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
 
 Drop `.vmz` mod files into the `mods` folder. The mod loader finds them automatically on next launch.
 
-`.pck` files are also supported but have no mod.txt parsing, autoloads, or update checking.
-
-**Note:** If a mod was distributed as a `.zip` file, rename it to `.vmz` before placing it in the mods folder. The mod loader will not load `.zip` files directly.
+If a mod was distributed as a `.zip` file, rename it to `.vmz` before placing it in the mods folder.
 
 ---
 
-## The Launcher UI
+## Using the Launcher
 
 When you start the game, the mod loader window opens with two tabs:
 
 ### Mods
-Lists all detected mods. Use the checkbox to enable or disable each one. The **Load Order** number controls priority — higher number loads later and wins when two mods change the same file. The **Load Order** panel on the right shows the final order in real time.
-
-A **Developer Mode** checkbox in the toolbar enables extra features for mod creators:
-- **Conflict report** — full log saved to `modloader_conflicts.txt` after each launch
-- **Debug logging** — verbose `[Debug]` lines covering load order and mount state
-- **Loose folder loading** — unzipped mod folders in the mods directory are treated as mods
+Enable or disable mods with checkboxes. The **priority number** controls load order — higher number loads later and wins when two mods change the same file. The **Load Order** panel on the right shows the final order in real time.
 
 ### Updates
-If your mods include ModWorkshop update info in their `mod.txt`, click **Check for Updates** to fetch the latest versions and download updates directly.
+Click **Check for Updates** to see if any of your mods have newer versions available on ModWorkshop.
 
-Click **Launch Game** (or close the window) when you are ready to play.
+Click **Launch Game** when you're ready to play.
+
+---
+
+## Troubleshooting
+
+If the game crashes or gets stuck after enabling mods:
+
+- **Wait it out.** After 2 failed launches, the mod loader automatically resets to a clean state.
+- **Manual reset:** Create an empty file named `modloader_safe_mode` (no file extension) in the game folder. On next launch, the mod loader resets and deletes the file.
+- **Full reset:** Delete `override.cfg` from the game folder and replace it with a fresh copy from the mod loader release.
+
+---
+
+## Uninstalling
+
+Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder and its contents can be removed separately.
+
+Settings are stored in `%APPDATA%\Road to Vostok\mod_config.cfg` and can be deleted safely.
+
+---
+---
+
+# For Mod Authors
+
+Everything below is for mod developers.
 
 ---
 
 ## mod.txt Reference
 
-Mods should include a `mod.txt` at the root of their archive to register autoloads, set metadata, and enable update checking:
+Mod archives must contain a `mod.txt` file at their root:
 
 ```ini
 [mod]
-name=My Mod
-id=my_mod
-version=1.0.0
+name="My Mod"
+id="my_mod"
+version="1.0.0"
 priority=0
 
 [autoload]
-MyModMain=res://Scripts/MyModMain.gd
+MyModMain="res://MyMod/Main.gd"
 
 [updates]
 modworkshop=12345
@@ -83,18 +91,17 @@ modworkshop=12345
 
 | Field | Description |
 |---|---|
-| `name` | Display name shown in the UI |
+| `name` | Display name shown in the UI (must be quoted) |
 | `id` | Unique identifier — duplicates are skipped |
 | `version` | Semver string used for update comparison |
-| `priority` | Load order number. Higher = loads later = wins. Default 0. |
-| `[autoload]` | `Name=res://path/to/script.gd` — instantiated as a Node after all mods mount |
+| `priority` | Load order number. Higher = loads later = wins. Default 0 |
+| `[autoload]` | `Name="res://path/to/script.gd"` — instantiated as a Node after all mods mount |
+| `[autoload]` `!` prefix | `Name="!res://path.gd"` — loads **before** game autoloads (see Early Autoloads) |
 | `[updates] modworkshop` | ModWorkshop mod ID for update checking |
 
-Mods without `mod.txt` will still mount but may not work correctly — the mod loader will show a warning.
+String values must be quoted. Mods without `mod.txt` will mount but show a warning.
 
----
-
-## Supported Archive Formats
+### Supported archive formats
 
 | Format | Notes |
 |--------|-------|
@@ -102,41 +109,89 @@ Mods without `mod.txt` will still mount but may not work correctly — the mod l
 | `.zip` | Must be renamed to `.vmz` before use |
 | `.pck` | Godot PCK — mount only, no mod.txt or autoloads |
 
+### Load priority
+
+Higher number = loads later = wins any file conflict. Default is `0`. Equal priority sorts alphabetically.
+
+Priority controls both which archive's files win *and* which mod's `take_over_path()` executes last — it's the main tool for resolving conflicts between mods that touch the same scripts.
+
 ---
 
-## Understanding the Conflict Report
+## Early Autoloads (Two-Pass Loading)
 
-After each launch (with developer mode enabled), a full conflict log is written to:
+Most mods load **after** the game's core systems (Loader, Database, Simulation) are already initialized. If your mod needs to run **before** those systems — for example, to modify the shelter list before `Loader._ready()` validates saves — prefix its autoload path with `!`:
 
+```ini
+[autoload]
+ShelterFix="!res://ShelterMod/Fix.gd"
 ```
-%APPDATA%\Road to Vostok\modloader_conflicts.txt
-```
 
-### What the messages mean
+When the mod loader detects `!` prefix autoloads, it:
 
-- **CONFLICT: {path}** — Two mods shipped the same file. The last-loaded mod wins. Adjust load order if the wrong one is winning.
-- **DATABASE OVERRIDE: {mod}** — A mod replaced `Database.gd`. This is normal for overhaul mods.
-- **BAD ZIP: {mod}** — The archive has broken file paths (common with Windows repacking). Re-download or re-pack using 7-Zip.
+1. Shows the config UI as usual
+2. Writes a temporary `override.cfg` that tells the engine to load these mods first
+3. Restarts the game automatically (~5 seconds)
+4. On the second launch, mods load before game autoloads — no UI is shown
 
----
-
-## For Mod Authors
-
-- **Always package mods as `.vmz`** (renamed zip with forward-slash paths). The mod loader blocks `.zip` files to prevent users from accidentally extracting them.
-- **Include a `mod.txt`** at the root of your archive. Without it, autoloads won't run and the mod loader will flag the mod as invalid.
-- **Conflicts are load-order dependent.** Test with other mods installed and check the conflict report.
-- **If you replace Database.gd**, every `preload()` path in your version must exist or the game will break.
-- **Use `super()` in lifecycle methods.** Skipping it silently breaks any other mod that overrides the same class.
-- **Avoid `take_over_path()` on commonly-overridden scripts** when possible. The `extends + super()` pattern composes across mods; flat `take_over_path()` doesn't.
-- **`UpdateTooltip()` does not affect world items.** World-item tooltip text comes from `HUD._physics_process` reading `gameData.tooltip`.
+Mods without `!` are unaffected and never trigger a restart. Only use `!` when your mod genuinely needs to run before game autoloads — most mods don't.
 
 ---
 
-## Uninstalling
+## Conflict Report
 
-Delete `override.cfg` from the Steam installation folder and `modloader.gd` from the AppData folder. The `mods` folder and its contents can be removed separately.
+With Developer Mode enabled, a full conflict log is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch.
 
-Settings are stored in `%APPDATA%\Road to Vostok\mod_config.cfg` and can be deleted safely.
+| Message | Meaning |
+|---------|---------|
+| **CONFLICT** | Two mods ship the same file. Last-loaded wins. Adjust priorities. |
+| **SCRIPT CONFLICT** | Two mods both `take_over_path()` the same script. Hard incompatibility. |
+| **CHAIN OK / CHAIN BROKEN** | Override chain via `super()` — OK means mods stack cleanly, BROKEN means one skips `super()`. |
+| **DATABASE OVERRIDE** | A mod replaced `Database.gd`. Normal for overhauls, may block other mods' scene overrides. |
+| **OVERHAUL** | 5+ core script overrides. Likely incompatible with other overhaul mods. |
+| **NO SUPER** | Lifecycle method override without `super()`. Breaks other mods in the chain. |
+| **BAD ZIP** | Backslash file paths in the archive. Re-pack with 7-Zip. |
+
+---
+
+## Best Practices
+
+- **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes).
+- **Include a `mod.txt`** at the archive root. Without it, autoloads won't run.
+- **Use `super()` in lifecycle methods.** Skipping it breaks other mods that override the same class.
+- **Prefer `extends + super()` over `take_over_path()`** for commonly-overridden scripts. It composes across mods; flat `take_over_path()` doesn't.
+- **If you replace Database.gd**, every `preload()` path must exist or the game breaks.
+- **`UpdateTooltip()` is inventory-only.** World-item tooltips come from `HUD._physics_process` reading `gameData.tooltip`.
+- **Test with other mods installed** and check the conflict report.
+
+---
+
+## VostokMods Compatibility
+
+Mods packaged for [VostokMods](https://github.com/Ryhon0/VostokMods) generally work with this loader.
+
+| Feature | Status |
+|---------|--------|
+| `.vmz` archives | Supported |
+| `mod.txt` format | Supported |
+| `[mod] priority` | Supported |
+| Filename priority prefix (`100-ModName.vmz`) | Supported |
+| `!` early autoload prefix | Supported |
+
+### Features that require VostokMods
+
+VostokMods runs as a separate launcher before Godot starts. This loader runs inside the game, so it cannot:
+
+- **Merge `override.cfg`** — engine settings are read at startup before GDScript runs
+- **Register `class_name`** — global class cache is read-only at runtime (use path references instead)
+- **Extract native plugins** — GDExtension `.dll`/`.so` files must be on disk at startup
+
+---
+
+## Recovery (Technical Details)
+
+- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. If it persists, the mod loader increments a crash counter. After 2 crashes, it wipes `override.cfg` and all two-pass state.
+- **Safe mode:** An empty `modloader_safe_mode` file in the game folder triggers a full reset on next launch.
+- **State files:** `user://mod_pass_state.cfg` stores archive paths for the two-pass restart. Deleted after successful Pass 2.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,22 +47,15 @@ Drop `.vmz` or `.zip` mod files into the `mods` folder. The mod loader finds the
 When you start the game, the mod loader window opens with tabs:
 
 ### Mods
-Lists all detected mods. Use the checkbox to enable or disable each one. The **Priority** spinbox controls load order — higher value loads later and wins any file conflicts. The **Load Order** panel on the right shows the final order in real time.
+Lists all detected mods. Use the checkbox to enable or disable each one. The **Load Order** number controls priority — higher number loads later and wins when mods share files. The **Load Order** panel on the right shows the final order in real time.
+
+A **Developer Mode** checkbox in the toolbar enables extra features for mod creators:
+- **Conflict report** — full log saved to `modloader_conflicts.txt` after each launch
+- **Debug logging** — verbose `[Debug]` lines covering load order and mount state
+- **Loose folder loading** — unzipped mod folders in the mods directory are treated as mods
 
 ### Updates
 If your mods include ModWorkshop update info in their `mod.txt`, click **Check for Updates** to fetch the latest versions and download updates directly.
-
-### Compatibility
-*(Developer mode only)* Click **Run Analysis** to scan your enabled mods without mounting anything. Reports script conflicts, broken override chains, overhaul mod warnings, and Database.gd replacement issues before they affect your game.
-
-### Settings
-Toggle developer mode on/off. Developer mode enables:
-- **Compatibility tab** — static analysis of override conflicts
-- **Compile check** — loads each override script before launch to catch parse errors
-- **Override audit** — warns when `overrideScript()` targets have zero live nodes in the scene tree
-- **Conflict report** — full log saved to `modloader_conflicts.txt` after each launch
-- **Debug logging** — verbose `[Debug]` lines covering load order, override timing, and mount state
-- **Loose folder loading** — unzipped mod folders in the mods directory are treated as mods
 
 Click **Launch Game** (or close the window) when you are ready to play.
 
@@ -91,7 +84,7 @@ modworkshop=12345
 | `name` | Display name shown in the UI |
 | `id` | Unique identifier — duplicates are skipped |
 | `version` | Semver string used for update comparison |
-| `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
+| `priority` | Load order number. Higher = loads later = wins. Default 0. |
 | `[autoload]` | `Name=res://path/to/script.gd` — instantiated as a Node after all mods mount |
 | `[updates] modworkshop` | ModWorkshop mod ID for update checking |
 
@@ -103,8 +96,8 @@ Mods without `mod.txt` are still mounted as resource packs — their files overr
 
 | Format | Notes |
 |--------|-------|
-| `.vmz` | Road to Vostok's native format (renamed zip) |
-| `.zip` | Standard zip — must use forward-slash paths internally |
+| `.vmz` | Road to Vostok's native mod format (renamed zip) |
+| `.zip` | Must be renamed to `.vmz` before use |
 | `.pck` | Godot PCK — mount only, no mod.txt or autoloads |
 
 ---
@@ -119,17 +112,9 @@ After each launch (with developer mode enabled), a full conflict log is written 
 
 ### What the messages mean
 
-- **CONFLICT: {path}** — Two mods shipped the same file. The last-loaded mod wins. Adjust priorities if the wrong one is winning.
-- **Script Conflict: {file}** — Two mods both call `take_over_path()` on the same script. Only the last-loaded version is active.
-- **Chain Broken: {file}** — Mods using `overrideScript()` can stack via `extends + super()`. A mod in the chain is missing `super()` calls, so earlier mods' logic gets dropped.
-- **Database.gd Replaced** — A mod replaced `Database.gd`. Scene overrides from other mods may not take effect due to `preload()` caching.
-- **Likely Incompatible / Overlap** — Two mods modify many of the same files. The more overlap, the less likely they'll work together.
-- **Method Overlap** — Two mods override the same function on the same script. Even with `super()`, their changes may interfere.
-- **Bad Archive: {mod}** — The zip has backslash file paths (common with Windows repacking). Re-pack using 7-Zip.
-- **class_name Crash: {name}** — Two mods override a script with `class_name`. Godot bug [#83542](https://github.com/godotengine/godot/issues/83542) causes a fatal engine crash. Disable all but one.
-- **Missing Script: {file}** — A mod extends a script that no longer exists. The game may have been updated.
-- **Uses base(): {mod}** — A mod calls `base()` which is a Godot 3 pattern. Should be `super()` in Godot 4.
-- **Stale preload(): {file}** — A mod uses `preload()` on a file that another mod replaces. Use `load()` instead.
+- **CONFLICT: {path}** — Two mods shipped the same file. The last-loaded mod wins. Adjust load order if the wrong one is winning.
+- **DATABASE OVERRIDE: {mod}** — A mod replaced `Database.gd`. This is normal for overhaul mods.
+- **BAD ZIP: {mod}** — The archive has broken file paths (common with Windows repacking). Re-download or re-pack using 7-Zip.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder
 Settings are stored in `%APPDATA%\Road to Vostok\mod_config.cfg` and can be deleted safely.
 
 ---
----
 
 # For Mod Authors
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Road to Vostok — Community Mod Loader
 
-A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher UI before the game starts, letting you enable/disable mods, set load order priority, check for updates, and preview compatibility issues before they cause problems in-game.
+A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher UI before the game starts, letting you enable/disable mods, set load order, and check for updates.
 
 ---
 
 ## Requirements
 
 - Road to Vostok (PC, Steam)
-- Mods packaged as `.zip`, `.vmz`, or `.pck` files
+- Mods packaged as `.vmz` or `.pck` files
 
 ---
 
@@ -28,7 +28,7 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
    C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods\
    ```
 
-4. Place your `.vmz` or `.zip` mod files inside the `mods` folder.
+4. Place your `.vmz` mod files inside the `mods` folder.
 
 5. Launch the game normally. The mod loader UI will appear before the main menu.
 
@@ -36,18 +36,20 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
 
 ## Installing Mods
 
-Drop `.vmz` or `.zip` mod files into the `mods` folder. The mod loader finds them automatically on next launch.
+Drop `.vmz` mod files into the `mods` folder. The mod loader finds them automatically on next launch.
 
-`.pck` files are also supported (can be enabled/disabled and prioritized in the UI, but no mod.txt parsing, autoloads, or update checking).
+`.pck` files are also supported but have no mod.txt parsing, autoloads, or update checking.
+
+**Note:** If a mod was distributed as a `.zip` file, rename it to `.vmz` before placing it in the mods folder. The mod loader will not load `.zip` files directly.
 
 ---
 
 ## The Launcher UI
 
-When you start the game, the mod loader window opens with tabs:
+When you start the game, the mod loader window opens with two tabs:
 
 ### Mods
-Lists all detected mods. Use the checkbox to enable or disable each one. The **Load Order** number controls priority — higher number loads later and wins when mods share files. The **Load Order** panel on the right shows the final order in real time.
+Lists all detected mods. Use the checkbox to enable or disable each one. The **Load Order** number controls priority — higher number loads later and wins when two mods change the same file. The **Load Order** panel on the right shows the final order in real time.
 
 A **Developer Mode** checkbox in the toolbar enables extra features for mod creators:
 - **Conflict report** — full log saved to `modloader_conflicts.txt` after each launch
@@ -63,7 +65,7 @@ Click **Launch Game** (or close the window) when you are ready to play.
 
 ## mod.txt Reference
 
-Mods can include a `mod.txt` at the root of their archive to register autoloads, set metadata, and enable update checking:
+Mods should include a `mod.txt` at the root of their archive to register autoloads, set metadata, and enable update checking:
 
 ```ini
 [mod]
@@ -88,7 +90,7 @@ modworkshop=12345
 | `[autoload]` | `Name=res://path/to/script.gd` — instantiated as a Node after all mods mount |
 | `[updates] modworkshop` | ModWorkshop mod ID for update checking |
 
-Mods without `mod.txt` are still mounted as resource packs — their files override vanilla resources, but no autoloads run.
+Mods without `mod.txt` will still mount but may not work correctly — the mod loader will show a warning.
 
 ---
 
@@ -120,12 +122,13 @@ After each launch (with developer mode enabled), a full conflict log is written 
 
 ## For Mod Authors
 
+- **Always package mods as `.vmz`** (renamed zip with forward-slash paths). The mod loader blocks `.zip` files to prevent users from accidentally extracting them.
+- **Include a `mod.txt`** at the root of your archive. Without it, autoloads won't run and the mod loader will flag the mod as invalid.
 - **Conflicts are load-order dependent.** Test with other mods installed and check the conflict report.
 - **If you replace Database.gd**, every `preload()` path in your version must exist or the game will break.
 - **Use `super()` in lifecycle methods.** Skipping it silently breaks any other mod that overrides the same class.
 - **Avoid `take_over_path()` on commonly-overridden scripts** when possible. The `extends + super()` pattern composes across mods; flat `take_over_path()` doesn't.
 - **`UpdateTooltip()` does not affect world items.** World-item tooltip text comes from `HUD._physics_process` reading `gameData.tooltip`.
-- **Windows zip repacking** — use 7-Zip or a tool that writes forward-slash entry paths. .NET `ZipFile.CreateFromDirectory()` writes backslash paths by default, which Godot can't resolve.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Enable or disable mods with checkboxes. The **priority number** controls load or
 ### Updates
 Click **Check for Updates** to see if any of your mods have newer versions available on ModWorkshop.
 
+### Settings
+Toggle **Developer Mode** to enable the Compatibility tab and verbose conflict logging. Off by default — only needed for mod authors or troubleshooting.
+
 Click **Launch Game** when you're ready to play.
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Road to Vostok — Community Mod Loader
 
-A community-built mod loader for **Road to Vostok Demo** (Godot 4). Adds a launcher UI before the game starts, letting you enable/disable mods, set load order priority, check for updates, and preview compatibility issues before they cause problems in-game.
+A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher UI before the game starts, letting you enable/disable mods, set load order priority, check for updates, and preview compatibility issues before they cause problems in-game.
 
 ---
 
 ## Requirements
 
-- Road to Vostok Demo (PC, Steam)
+- Road to Vostok(PC, Steam)
 - Mods packaged as `.zip`, `.vmz`, or `.pck` files
 
 ---
@@ -15,17 +15,17 @@ A community-built mod loader for **Road to Vostok Demo** (Godot 4). Adds a launc
 
 1. Copy `override.cfg` into the game installation folder:
    ```
-   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok Demo\
+   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
    ```
 
 2. Copy `modloader.gd` into the game's data folder:
    ```
-   C:\Users\<your username>\AppData\Roaming\Road to Vostok Demo\
+   C:\Users\<your username>\AppData\Roaming\Road to Vostok\
    ```
 
 3. Create a `mods` folder inside the game installation folder if it doesn't exist:
    ```
-   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok Demo\mods\
+   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods\
    ```
 
 4. Place your `.vmz` or `.zip` mod files inside the `mods` folder.
@@ -114,7 +114,7 @@ Mods without `mod.txt` are still mounted as resource packs — their files overr
 After each launch (with developer mode enabled), a full conflict log is written to:
 
 ```
-%APPDATA%\Road to Vostok Demo\modloader_conflicts.txt
+%APPDATA%\Road to Vostok\modloader_conflicts.txt
 ```
 
 ### What the messages mean
@@ -148,7 +148,7 @@ After each launch (with developer mode enabled), a full conflict log is written 
 
 Delete `override.cfg` from the Steam installation folder and `modloader.gd` from the AppData folder. The `mods` folder and its contents can be removed separately.
 
-Settings are stored in `%APPDATA%\Road to Vostok Demo\mod_config.cfg` and can be deleted safely.
+Settings are stored in `%APPDATA%\Road to Vostok\mod_config.cfg` and can be deleted safely.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
 
 ## Requirements
 
-- Road to Vostok(PC, Steam)
+- Road to Vostok (PC, Steam)
 - Mods packaged as `.zip`, `.vmz`, or `.pck` files
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A community-built mod loader for **Road to Vostok Demo** (Godot 4). Adds a launc
 ## Requirements
 
 - Road to Vostok Demo (PC, Steam)
-- Mods packaged as `.zip` or `.vmz` files
+- Mods packaged as `.zip`, `.vmz`, or `.pck` files
 
 ---
 
@@ -38,22 +38,31 @@ A community-built mod loader for **Road to Vostok Demo** (Godot 4). Adds a launc
 
 Drop `.vmz` or `.zip` mod files into the `mods` folder. The mod loader finds them automatically on next launch.
 
-`.pck` files are also supported (mounted silently, no UI controls or update checking).
+`.pck` files are also supported (can be enabled/disabled and prioritized in the UI, but no mod.txt parsing, autoloads, or update checking).
 
 ---
 
 ## The Launcher UI
 
-When you start the game, the mod loader window opens with three tabs:
+When you start the game, the mod loader window opens with tabs:
 
 ### Mods
 Lists all detected mods. Use the checkbox to enable or disable each one. The **Priority** spinbox controls load order — higher value loads later and wins any file conflicts. The **Load Order** panel on the right shows the final order in real time.
 
-### Compatibility
-Click **Run Analysis** to scan your enabled mods without mounting anything. Reports script conflicts, broken override chains, overhaul mod warnings, and Database.gd replacement issues before they affect your game.
-
 ### Updates
 If your mods include ModWorkshop update info in their `mod.txt`, click **Check for Updates** to fetch the latest versions and download updates directly.
+
+### Compatibility
+*(Developer mode only)* Click **Run Analysis** to scan your enabled mods without mounting anything. Reports script conflicts, broken override chains, overhaul mod warnings, and Database.gd replacement issues before they affect your game.
+
+### Settings
+Toggle developer mode on/off. Developer mode enables:
+- **Compatibility tab** — static analysis of override conflicts
+- **Compile check** — loads each override script before launch to catch parse errors
+- **Override audit** — warns when `overrideScript()` targets have zero live nodes in the scene tree
+- **Conflict report** — full log saved to `modloader_conflicts.txt` after each launch
+- **Debug logging** — verbose `[Debug]` lines covering load order, override timing, and mount state
+- **Loose folder loading** — unzipped mod folders in the mods directory are treated as mods
 
 Click **Launch Game** (or close the window) when you are ready to play.
 
@@ -84,9 +93,54 @@ modworkshop=12345
 | `version` | Semver string used for update comparison |
 | `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
 | `[autoload]` | `Name=res://path/to/script.gd` — instantiated as a Node after all mods mount |
-| `[updates] modworkshop` | ModWorkshop mod ID for automatic update checking |
+| `[updates] modworkshop` | ModWorkshop mod ID for update checking |
 
 Mods without `mod.txt` are still mounted as resource packs — their files override vanilla resources, but no autoloads run.
+
+---
+
+## Supported Archive Formats
+
+| Format | Notes |
+|--------|-------|
+| `.vmz` | Road to Vostok's native format (renamed zip) |
+| `.zip` | Standard zip — must use forward-slash paths internally |
+| `.pck` | Godot PCK — mount only, no mod.txt or autoloads |
+
+---
+
+## Understanding the Conflict Report
+
+After each launch (with developer mode enabled), a full conflict log is written to:
+
+```
+%APPDATA%\Road to Vostok Demo\modloader_conflicts.txt
+```
+
+### What the messages mean
+
+- **CONFLICT: {path}** — Two mods shipped the same file. The last-loaded mod wins. Adjust priorities if the wrong one is winning.
+- **Script Conflict: {file}** — Two mods both call `take_over_path()` on the same script. Only the last-loaded version is active.
+- **Chain Broken: {file}** — Mods using `overrideScript()` can stack via `extends + super()`. A mod in the chain is missing `super()` calls, so earlier mods' logic gets dropped.
+- **Database.gd Replaced** — A mod replaced `Database.gd`. Scene overrides from other mods may not take effect due to `preload()` caching.
+- **Likely Incompatible / Overlap** — Two mods modify many of the same files. The more overlap, the less likely they'll work together.
+- **Method Overlap** — Two mods override the same function on the same script. Even with `super()`, their changes may interfere.
+- **Bad Archive: {mod}** — The zip has backslash file paths (common with Windows repacking). Re-pack using 7-Zip.
+- **class_name Crash: {name}** — Two mods override a script with `class_name`. Godot bug [#83542](https://github.com/godotengine/godot/issues/83542) causes a fatal engine crash. Disable all but one.
+- **Missing Script: {file}** — A mod extends a script that no longer exists. The game may have been updated.
+- **Uses base(): {mod}** — A mod calls `base()` which is a Godot 3 pattern. Should be `super()` in Godot 4.
+- **Stale preload(): {file}** — A mod uses `preload()` on a file that another mod replaces. Use `load()` instead.
+
+---
+
+## For Mod Authors
+
+- **Conflicts are load-order dependent.** Test with other mods installed and check the conflict report.
+- **If you replace Database.gd**, every `preload()` path in your version must exist or the game will break.
+- **Use `super()` in lifecycle methods.** Skipping it silently breaks any other mod that overrides the same class.
+- **Avoid `take_over_path()` on commonly-overridden scripts** when possible. The `extends + super()` pattern composes across mods; flat `take_over_path()` doesn't.
+- **`UpdateTooltip()` does not affect world items.** World-item tooltip text comes from `HUD._physics_process` reading `gameData.tooltip`.
+- **Windows zip repacking** — use 7-Zip or a tool that writes forward-slash entry paths. .NET `ZipFile.CreateFromDirectory()` writes backslash paths by default, which Godot can't resolve.
 
 ---
 
@@ -98,12 +152,14 @@ Settings are stored in `%APPDATA%\Road to Vostok Demo\mod_config.cfg` and can be
 
 ---
 
-## Conflict Report
+## License
 
-After each launch, a full conflict log is written to:
+MIT License
 
-```
-%APPDATA%\Road to Vostok Demo\modloader_conflicts.txt
-```
+Copyright (c) 2025
 
-This includes load order, all resource path conflicts, script analysis results, and any critical warnings.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modloader.gd
+++ b/modloader.gd
@@ -146,8 +146,6 @@ func _ready() -> void:
 	if _has_loaded:
 		return
 	_has_loaded = true
-	if has_meta("_file_scope_mounts"):
-		_file_scope_mounts = get_meta("_file_scope_mounts")
 	await get_tree().process_frame
 	if "--modloader-restart" in OS.get_cmdline_user_args():
 		_run_pass_2()
@@ -222,6 +220,10 @@ func _finish_with_existing_mounts() -> void:
 		var err := get_tree().reload_current_scene()
 		if err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(err))
+			return
+		if _developer_mode:
+			await get_tree().process_frame
+			_audit_override_instances()
 
 func _finish_single_pass() -> void:
 	for entry in _pending_autoloads:
@@ -1862,7 +1864,6 @@ func _zip_folder_recursive(zp: ZIPPacker, disk_path: String, archive_prefix: Str
 
 # Update fetch helpers
 
-# Returns -1/0/1 for version comparison (a < b, equal, a > b).
 # Returns -1/0/1 for version comparison (a < b, equal, a > b).
 func compare_versions(a: String, b: String) -> int:
 	if a.is_empty() or b.is_empty():

--- a/modloader.gd
+++ b/modloader.gd
@@ -167,6 +167,8 @@ func _build_folder_entry(mods_dir: String, dir_name: String) -> Dictionary:
 	return _entry_from_config(cfg, dir_name, folder_path, "folder")
 
 
+# Future: mod.txt may support [mod] load_after = "other_mod_id" for soft dependencies.
+# This would feed into a topological sort pass before the priority/name sort.
 func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, ext: String) -> Dictionary:
 	var mod_name := file_name
 	var mod_id   := file_name
@@ -506,7 +508,7 @@ func _build_mods_tab() -> Control:
 		for child in order_list.get_children():
 			child.queue_free()
 		var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
-		sorted.sort_custom(func(a, b): return a["priority"] < b["priority"])
+		sorted.sort_custom(_compare_load_order)
 		if sorted.is_empty():
 			var lbl := Label.new()
 			lbl.text = "(none enabled)"
@@ -800,7 +802,7 @@ func _run_dry_compat_analysis(populate_cb: Callable) -> void:
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
 	var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
-	sorted.sort_custom(func(a, b): return a["priority"] < b["priority"])
+	sorted.sort_custom(_compare_load_order)
 
 	if sorted.is_empty():
 		populate_cb.call([])
@@ -1145,17 +1147,27 @@ func _load_all_mods() -> void:
 		if not entry["enabled"]:
 			continue
 		candidates.append(entry.duplicate())
-	candidates.sort_custom(func(a, b): return a["priority"] < b["priority"])
+	candidates.sort_custom(_compare_load_order)
 
 	if candidates.is_empty():
 		_log_info("No mods enabled.")
 		return
 
+	# Warn about duplicate mod names — likely a packaging mistake or fork.
+	# The sort is still deterministic (file_name tiebreaker), but users should know.
+	for i in range(1, candidates.size()):
+		if (candidates[i]["mod_name"] as String).to_lower() \
+				== (candidates[i - 1]["mod_name"] as String).to_lower():
+			_log_warning("Duplicate mod name '" + candidates[i]["mod_name"]
+					+ "' — archives '" + candidates[i - 1]["file_name"]
+					+ "' and '" + candidates[i]["file_name"]
+					+ "'. Load order tie broken by archive filename.")
+
 	_log_info("=== Load Order ===")
 	for i in candidates.size():
 		var c: Dictionary = candidates[i]
-		var tag := " [priority=" + str(c["priority"]) + "]" if c["priority"] != 0 else ""
-		_log_info("  [" + str(i + 1) + "] " + c["mod_name"] + " | " + c["file_name"] + tag)
+		_log_info("  [" + str(i + 1) + "] " + c["mod_name"] + " | " + c["file_name"]
+				+ " [priority=" + str(c["priority"]) + "]")
 	_log_info("==================")
 
 	for load_index in candidates.size():
@@ -1323,6 +1335,18 @@ func _register_claim(res_path: String, mod_name: String, archive: String,
 		"mod_name": mod_name, "archive": archive, "load_index": load_index,
 		"claim_type": claim_type, "source_path": source_path,
 	})
+
+func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
+	if a["priority"] != b["priority"]:
+		return a["priority"] < b["priority"]
+	var a_name := (a["mod_name"] as String).to_lower()
+	var b_name := (b["mod_name"] as String).to_lower()
+	if a_name != b_name:
+		return a_name < b_name
+	# file_name is the archive's disk filename — guaranteed unique by the filesystem.
+	# This final tiebreaker makes the ordering a strict total order so that Godot's
+	# unstable introsort can never shuffle "equal" elements.
+	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
 func _is_dangerous_path(res_path: String) -> bool:
 	return _vanilla_paths.has(res_path)

--- a/modloader.gd
+++ b/modloader.gd
@@ -7,6 +7,14 @@ const UI_CONFIG_PATH := "user://mod_config.cfg"
 const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
 const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
 
+# ─── Two-pass architecture constants ────────────────────────────────────────
+const PASS_STATE_PATH := "user://mod_pass_state.cfg"
+const HEARTBEAT_PATH := "user://modloader_heartbeat.txt"
+const SAFE_MODE_FILE := "modloader_safe_mode"
+const MAX_RESTART_COUNT := 2
+const MODLOADER_VERSION := "2.1.0"
+const MODLOADER_RES_PATH := "res://modloader.gd"
+
 const TRACKED_EXTENSIONS: Array[String] = ["gd", "tscn", "tres", "gdns", "gdnlib", "scn"]
 const LIFECYCLE_METHODS: Array[String] = [
 	"_ready", "_process", "_physics_process",
@@ -50,39 +58,165 @@ var _re_preload: RegEx
 var _re_filename_priority: RegEx
 
 
+# ─── File-scope archive mounting (Pass 2 only) ──────────────────────────────
+# Runs during Godot's autoload instantiation, before _init() and _ready().
+# If mod_pass_state.cfg exists, mounts all listed archives so that subsequent
+# autoloads (loaded from [autoload_prepend]) can resolve their res:// paths.
+var _pass2_mount_count: int = _try_file_scope_mount()
+
+
+static func _try_file_scope_mount() -> int:
+	var cfg := ConfigFile.new()
+	if cfg.load(PASS_STATE_PATH) != OK:
+		return 0
+	var paths: PackedStringArray = cfg.get_value("state", "archive_paths", PackedStringArray())
+	if paths.is_empty():
+		return 0
+	var count := 0
+	for path in paths:
+		if ProjectSettings.load_resource_pack(path):
+			count += 1
+		elif path.get_extension().to_lower() == "vmz":
+			var zip_path := _static_vmz_to_zip(path)
+			if not zip_path.is_empty() and ProjectSettings.load_resource_pack(zip_path):
+				count += 1
+	return count
+
+
+static func _static_vmz_to_zip(vmz_path: String) -> String:
+	var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
+	if not DirAccess.dir_exists_absolute(cache_dir):
+		DirAccess.make_dir_recursive_absolute(cache_dir)
+	var zip_name := vmz_path.get_file().get_basename() + ".zip"
+	var zip_path := cache_dir.path_join(zip_name)
+	if FileAccess.file_exists(zip_path):
+		return zip_path
+	var src := FileAccess.open(vmz_path, FileAccess.READ)
+	if src == null:
+		return ""
+	var dst := FileAccess.open(zip_path, FileAccess.WRITE)
+	if dst == null:
+		src.close()
+		return ""
+	while src.get_position() < src.get_length():
+		dst.store_buffer(src.get_buffer(65536))
+	src.close()
+	dst.close()
+	return zip_path
+
+
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
 func _ready() -> void:
 	if _has_loaded:
 		return
 	_has_loaded = true
+	# When loaded via bootstrap (metro-modloader.zip), mount count is passed via meta.
+	if has_meta("_pass2_mount_count"):
+		_pass2_mount_count = get_meta("_pass2_mount_count")
 	# Autoloads run while the scene tree is still setting up children.
 	# Wait one frame so add_child() and DisplayServer queries work correctly.
 	await get_tree().process_frame
-	_log_info("Metro Mod Loader — exe: " + OS.get_executable_path()
-			+ "  user: " + OS.get_user_data_dir())
+	if "--modloader-restart" in OS.get_cmdline_user_args():
+		_run_pass_2()
+	else:
+		await _run_pass_1()
+
+
+# ─── Pass 1: Normal launch — show UI, configure, optionally restart ─────────
+
+func _run_pass_1() -> void:
+	_log_info("Metro Mod Loader v" + MODLOADER_VERSION + " — exe: "
+			+ OS.get_executable_path() + "  user: " + OS.get_user_data_dir())
+	# Safety: crash recovery and safe mode checks before anything else.
+	_check_crash_recovery()
+	_check_safe_mode()
 	_compile_regex()
 	_load_developer_mode_setting()
 	_ui_mod_entries = _collect_mod_metadata()
 	_load_ui_config()
 	await _show_mod_ui()
 	_save_ui_config()
+	# Mount all enabled mods and collect autoload entries (populates _pending_autoloads).
 	_load_all_mods()
+	# Classify autoloads: ! prefix = early (needs [autoload_prepend]), rest = late.
+	var sections := _build_autoload_sections()
+	if sections.prepend.size() > 0:
+		# Early autoloads exist — write override.cfg, save state, restart.
+		# Do NOT instantiate autoloads yet — Pass 2 will handle that.
+		_log_info("Early autoloads detected (%d) — preparing two-pass restart..."
+				% sections.prepend.size())
+		_write_heartbeat()
+		var archive_paths := _collect_enabled_archive_paths()
+		var cfg_err := _write_override_cfg(sections.prepend)
+		if cfg_err != OK:
+			_log_critical("Failed to write override.cfg (error %d) — single-pass fallback" % cfg_err)
+			_finish_single_pass()
+			return
+		_write_pass_state(archive_paths)
+		_log_info("Restarting with [autoload_prepend]...")
+		OS.set_restart_on_exit(true, ["--", "--modloader-restart"])
+		get_tree().quit()
+		return
+	# No early autoloads — instantiate and reload (single-pass, no restart).
+	_finish_single_pass()
+
+
+# Finish single-pass: instantiate queued autoloads, reload. Called after _load_all_mods().
+func _finish_single_pass() -> void:
 	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 	if _developer_mode:
 		_log_override_timing_warnings()
 		_print_conflict_summary()
 		_write_conflict_report()
+	_delete_heartbeat()
 	# Reload so mounted resource overrides and take_over_path() apply to the scene.
-	# Needed for ALL mods that replace files, not just those with autoloads.
 	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var reload_err := get_tree().reload_current_scene()
 		if reload_err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(reload_err))
 			return
-		# Wait for the reloaded scene to be ready before auditing override instances.
-		# The modloader persists across reloads (it's an autoload), so this works.
+		if _developer_mode:
+			await get_tree().process_frame
+			_audit_override_instances()
+
+
+# ─── Pass 2: Modloader-triggered restart — archives already mounted ─────────
+
+func _run_pass_2() -> void:
+	_log_info("Metro Mod Loader v" + MODLOADER_VERSION + " — Pass 2")
+	_log_info("  %d archive(s) mounted at file-scope" % _pass2_mount_count)
+	_clear_restart_counter()
+	_compile_regex()
+	_load_developer_mode_setting()
+	_ui_mod_entries = _collect_mod_metadata()
+	_load_ui_config()
+	# Early mod autoloads are already in the scene tree (Godot loaded them
+	# from [autoload_prepend] in override.cfg). Mount remaining archives and
+	# instantiate late autoloads that aren't already present.
+	_load_all_mods("Pass 2")
+	for entry in _pending_autoloads:
+		if get_tree().root.has_node(entry["name"]):
+			_log_info("  Autoload '" + entry["name"] + "' already in tree (early) — skipped")
+			continue
+		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
+	if _developer_mode:
+		_log_override_timing_warnings()
+		_print_conflict_summary()
+		_write_conflict_report()
+	_delete_heartbeat()
+	# Clean up pass state FIRST — prevents stale file-scope mounts if next line crashes.
+	if FileAccess.file_exists(PASS_STATE_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
+	# Restore clean override.cfg so next normal launch starts fresh.
+	_restore_clean_override_cfg()
+	# Reload so mounted resource overrides and take_over_path() apply to the scene.
+	if _pass2_mount_count > 0 or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+		var reload_err := get_tree().reload_current_scene()
+		if reload_err != OK:
+			_log_critical("reload_current_scene() failed with error " + str(reload_err))
+			return
 		if _developer_mode:
 			await get_tree().process_frame
 			_audit_override_instances()
@@ -934,7 +1068,7 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 
 # ─── Main load loop ───────────────────────────────────────────────────────────
 
-func _load_all_mods() -> void:
+func _load_all_mods(pass_label: String = "") -> void:
 	_pending_autoloads.clear()
 	_loaded_mod_ids.clear()
 	_registered_autoload_names.clear()
@@ -968,12 +1102,13 @@ func _load_all_mods() -> void:
 					+ "' and '" + candidates[i]["file_name"]
 					+ "'. Load order tie broken by archive filename.")
 
-	_log_info("=== Load Order ===")
+	var header := "=== Load Order" + (" (" + pass_label + ")" if pass_label != "" else "") + " ==="
+	_log_info(header)
 	for i in candidates.size():
 		var c: Dictionary = candidates[i]
 		_log_info("  [" + str(i + 1) + "] " + c["mod_name"] + " | " + c["file_name"]
 				+ " [priority=" + str(c["priority"]) + "]")
-	_log_info("==================")
+	_log_info("=" .repeat(header.length()))
 
 	for load_index in candidates.size():
 		_process_mod_candidate(candidates[load_index], load_index)
@@ -1046,8 +1181,12 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var keys: PackedStringArray = cfg.get_section_keys("autoload")
 	for key in keys:
 		var autoload_name := str(key)
-		# Strip Godot autoload prefix (*) and VostokMods early-autoload prefix (!).
-		var res_path := str(cfg.get_value("autoload", key)).lstrip("*!").strip_edges()
+		# Strip Godot autoload prefix (*), detect early-autoload prefix (!).
+		var raw_path := str(cfg.get_value("autoload", key)).lstrip("*").strip_edges()
+		var is_early := raw_path.begins_with("!")
+		if is_early:
+			raw_path = raw_path.lstrip("!")
+		var res_path := raw_path
 
 		if res_path == "":
 			_log_warning("  Empty autoload path for '" + autoload_name + "' — skipped")
@@ -1071,8 +1210,12 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 				_log_critical("    Similar paths in archive: " + ", ".join(similar))
 			continue
 
-		_pending_autoloads.append({ "mod_name": mod_name, "name": autoload_name, "path": res_path })
-		_log_info("  Autoload queued: " + autoload_name + " -> " + res_path)
+		_pending_autoloads.append({
+			"mod_name": mod_name, "name": autoload_name, "path": res_path,
+			"is_early": is_early,
+		})
+		var early_tag := " [EARLY]" if is_early else ""
+		_log_info("  Autoload queued: " + autoload_name + " -> " + res_path + early_tag)
 		_register_claim(res_path, mod_name, file_name, load_index)
 
 
@@ -1361,6 +1504,170 @@ func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
 			if path != "":
 				out[path] = (out.get(path, 0) as int) + 1
 		stack.append_array(node.get_children())
+
+
+# ─── Two-pass helpers ─────────────────────────────────────────────────────────
+
+# Classify pending autoloads into prepend (early, ! prefix) and append (late).
+# ModLoader is always LAST in prepend — reverse insertion means last listed loads first.
+func _build_autoload_sections() -> Dictionary:
+	var prepend: Array[Dictionary] = []
+	var append: Array[Dictionary] = []
+	for entry in _pending_autoloads:
+		if entry.get("is_early", false):
+			prepend.append({ "name": entry["name"], "path": entry["path"] })
+		else:
+			append.append({ "name": entry["name"], "path": entry["path"] })
+	return { "prepend": prepend, "append": append }
+
+
+# Collect full OS paths for all enabled mod archives (for pass state file).
+func _collect_enabled_archive_paths() -> PackedStringArray:
+	var paths := PackedStringArray()
+	var candidates: Array[Dictionary] = []
+	for entry in _ui_mod_entries:
+		if not entry["enabled"]:
+			continue
+		candidates.append(entry.duplicate())
+	candidates.sort_custom(_compare_load_order)
+	for c in candidates:
+		if c["ext"] == "zip":
+			continue
+		paths.append(c["full_path"])
+	return paths
+
+
+# Write override.cfg with FileAccess (not ConfigFile — ConfigFile erases null keys).
+# ModLoader is LAST in [autoload_prepend] (reverse insertion = last listed loads first).
+# Late (non-early) autoloads are NOT written here — Godot would try to load them
+# natively before archives are mounted, causing "file not found" errors. The modloader
+# handles late autoloads via add_child() in Pass 2 instead.
+# Atomic write: write .tmp then rename.
+func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
+	var exe_dir := OS.get_executable_path().get_base_dir()
+	var path := exe_dir.path_join("override.cfg")
+	var tmp := path + ".tmp"
+	var lines := PackedStringArray()
+	if prepend_autoloads.size() > 0:
+		lines.append("[autoload_prepend]")
+		for entry in prepend_autoloads:
+			lines.append('%s="*%s"' % [entry["name"], entry["path"]])
+		# ModLoader LAST = loads FIRST (reverse insertion).
+		lines.append('ModLoader="*' + MODLOADER_RES_PATH + '"')
+		lines.append("")
+	# Only ModLoader in [autoload] — late mod autoloads are handled by Pass 2 via add_child().
+	lines.append("[autoload]")
+	if prepend_autoloads.is_empty():
+		lines.append('ModLoader="*' + MODLOADER_RES_PATH + '"')
+	lines.append("")
+	var f := FileAccess.open(tmp, FileAccess.WRITE)
+	if f == null:
+		return FileAccess.get_open_error()
+	f.store_string("\n".join(lines) + "\n")
+	f.close()
+	var dir := DirAccess.open(exe_dir)
+	if dir == null:
+		DirAccess.remove_absolute(tmp)
+		return ERR_CANT_OPEN
+	var rename_err := dir.rename(tmp.get_file(), path.get_file())
+	if rename_err != OK:
+		DirAccess.remove_absolute(tmp)
+	return rename_err
+
+
+# Persist archive paths and restart metadata for file-scope mounting in Pass 2.
+func _write_pass_state(archive_paths: PackedStringArray) -> void:
+	var cfg := ConfigFile.new()
+	cfg.load(PASS_STATE_PATH)  # OK if doesn't exist
+	var count: int = cfg.get_value("state", "restart_count", 0)
+	cfg.set_value("state", "restart_count", count + 1)
+	cfg.set_value("state", "mods_hash", _compute_mods_hash())
+	cfg.set_value("state", "archive_paths", archive_paths)
+	cfg.set_value("state", "modloader_version", MODLOADER_VERSION)
+	cfg.set_value("state", "timestamp", Time.get_unix_time_from_system())
+	var save_err := cfg.save(PASS_STATE_PATH)
+	if save_err != OK:
+		_log_critical("Failed to save pass state (error %d) — two-pass restart will fail" % save_err)
+
+
+func _compute_mods_hash() -> String:
+	var dir := DirAccess.open(_mods_dir)
+	if dir == null:
+		return ""
+	var entries := PackedStringArray()
+	dir.list_dir_begin()
+	var fname := dir.get_next()
+	while fname != "":
+		if not fname.begins_with("."):
+			entries.append(fname)
+		fname = dir.get_next()
+	dir.list_dir_end()
+	entries.sort()
+	return str(entries).md5_text()
+
+
+# Write heartbeat to detect crashes. Deleted on successful completion.
+func _write_heartbeat() -> void:
+	var f := FileAccess.open(HEARTBEAT_PATH, FileAccess.WRITE)
+	if f:
+		f.store_string("started:%d" % Time.get_unix_time_from_system())
+		f.close()
+
+
+func _delete_heartbeat() -> void:
+	if FileAccess.file_exists(HEARTBEAT_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(HEARTBEAT_PATH))
+
+
+# If heartbeat exists from a previous launch, the game crashed. Increment counter.
+# After MAX_RESTART_COUNT crashes, wipe override.cfg to clean state.
+func _check_crash_recovery() -> void:
+	if not FileAccess.file_exists(HEARTBEAT_PATH):
+		return
+	_log_warning("Heartbeat file found — previous launch may have crashed")
+	var cfg := ConfigFile.new()
+	if cfg.load(PASS_STATE_PATH) == OK:
+		var count: int = cfg.get_value("state", "restart_count", 0)
+		if count >= MAX_RESTART_COUNT:
+			_log_critical("Restart loop detected (%d crashes) — restoring clean override.cfg" % count)
+			_restore_clean_override_cfg()
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
+			_delete_heartbeat()
+			return
+	_delete_heartbeat()
+
+
+# User can create an empty "modloader_safe_mode" file in the game dir to force recovery.
+func _check_safe_mode() -> void:
+	var exe_dir := OS.get_executable_path().get_base_dir()
+	var safe_mode_path := exe_dir.path_join(SAFE_MODE_FILE)
+	if not FileAccess.file_exists(safe_mode_path):
+		return
+	_log_warning("Safe mode file detected — restoring clean override.cfg")
+	_restore_clean_override_cfg()
+	if FileAccess.file_exists(PASS_STATE_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
+	_delete_heartbeat()
+	DirAccess.remove_absolute(safe_mode_path)
+
+
+# Write minimal override.cfg that only registers ModLoader.
+func _restore_clean_override_cfg() -> void:
+	var exe_dir := OS.get_executable_path().get_base_dir()
+	var f := FileAccess.open(exe_dir.path_join("override.cfg"), FileAccess.WRITE)
+	if f == null:
+		_log_critical("Cannot restore override.cfg — game dir may be read-only: " + exe_dir)
+		return
+	f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n")
+	f.close()
+
+
+func _clear_restart_counter() -> void:
+	var cfg := ConfigFile.new()
+	if cfg.load(PASS_STATE_PATH) == OK:
+		cfg.set_value("state", "restart_count", 0)
+		cfg.save(PASS_STATE_PATH)
+
 
 
 # ─── Conflict summary ─────────────────────────────────────────────────────────

--- a/modloader.gd
+++ b/modloader.gd
@@ -7,7 +7,6 @@ const UI_CONFIG_PATH := "user://mod_config.cfg"
 const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
 const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
 
-const VANILLA_SCAN_DIRS: Array[String] = ["res://Scripts", "res://Scenes"]
 const TRACKED_EXTENSIONS: Array[String] = ["gd", "tscn", "tres", "gdns", "gdnlib", "scn"]
 const LIFECYCLE_METHODS: Array[String] = [
 	"_ready", "_process", "_physics_process",
@@ -16,9 +15,6 @@ const LIFECYCLE_METHODS: Array[String] = [
 
 # ─── Tuning constants ────────────────────────────────────────────────────────
 
-const OVERLAP_FILE_THRESHOLD := 5       # shared files to flag "Likely Incompatible"
-const OVERLAP_VANILLA_THRESHOLD := 3    # shared vanilla files for critical severity
-const MAX_DISPLAYED_FILENAMES := 6      # truncate file lists in conflict cards
 const MODWORKSHOP_BATCH_SIZE := 100     # mod IDs per API request
 const API_CHECK_TIMEOUT := 15.0         # seconds for version-check requests
 const API_DOWNLOAD_TIMEOUT := 30.0      # seconds for mod download requests
@@ -27,22 +23,20 @@ const PRIORITY_MAX := 999
 
 # ─── State ────────────────────────────────────────────────────────────────────
 
-var _vanilla_paths: Dictionary = {}
-var _database_path: String = ""
 var _database_replaced_by: String = ""
 var _override_registry: Dictionary = {}
 var _mod_script_analysis: Dictionary = {}
 var _archive_file_sets: Dictionary = {}
-var _bad_zips: Array[Dictionary] = []      # {mod_name, count, example}
 var _report_lines: Array[String] = []
 var _pending_autoloads: Array[Dictionary] = []
 var _loaded_mod_ids: Dictionary = {}
 var _registered_autoload_names: Dictionary = {}
 
 # Populated before any mounting. Each entry:
-# { file_name, full_path, ext, mod_name, mod_id, priority, enabled, cfg, has_mod_txt }
+# { file_name, full_path, ext, mod_name, mod_id, priority, enabled, cfg, mod_txt_status, warnings }
 var _ui_mod_entries: Array[Dictionary] = []
 
+var _last_mod_txt_status: String = "none"
 var _developer_mode: bool = false
 var _has_loaded: bool = false
 var _mods_dir: String = ""
@@ -74,8 +68,6 @@ func _ready() -> void:
 	await _show_mod_ui()
 	_save_ui_config()
 	_load_all_mods()
-	if _developer_mode:
-		_preflight_compile_check()
 	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 	if _developer_mode:
@@ -85,7 +77,10 @@ func _ready() -> void:
 	# Reload so mounted resource overrides and take_over_path() apply to the scene.
 	# Needed for ALL mods that replace files, not just those with autoloads.
 	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
-		get_tree().reload_current_scene()
+		var reload_err := get_tree().reload_current_scene()
+		if reload_err != OK:
+			_log_critical("reload_current_scene() failed with error " + str(reload_err))
+			return
 		# Wait for the reloaded scene to be ready before auditing override instances.
 		# The modloader persists across reloads (it's an autoload), so this works.
 		if _developer_mode:
@@ -146,9 +141,9 @@ func _collect_mod_metadata() -> Array[Dictionary]:
 		entries.append(_build_archive_entry(_mods_dir, entry_name, ext))
 	dir.list_dir_end()
 	if skipped_files.size() > 0:
-		_log_warning("Skipped " + str(skipped_files.size()) + " non-mod file(s) in mods dir:")
+		_log_debug("Skipped " + str(skipped_files.size()) + " non-mod file(s) in mods dir:")
 		for sf in skipped_files:
-			_log_warning("  " + sf + "  (not .zip/.vmz/.pck)")
+			_log_debug("  " + sf + "  (not .vmz/.pck)")
 	if entries.size() == 0:
 		_log_warning("No mods found in: " + _mods_dir)
 	else:
@@ -161,14 +156,20 @@ func _collect_mod_metadata() -> Array[Dictionary]:
 
 func _build_archive_entry(mods_dir: String, file_name: String, ext: String) -> Dictionary:
 	var full_path := mods_dir.path_join(file_name)
+	if ext == "pck":
+		_last_mod_txt_status = "pck"
 	var cfg: ConfigFile = _read_mod_config(full_path) if ext != "pck" else null
-	return _entry_from_config(cfg, file_name, full_path, ext)
+	var entry := _entry_from_config(cfg, file_name, full_path, ext)
+	entry["warnings"] = _build_entry_warnings(entry)
+	return entry
 
 
 func _build_folder_entry(mods_dir: String, dir_name: String) -> Dictionary:
 	var folder_path := mods_dir.path_join(dir_name)
 	var cfg: ConfigFile = _read_mod_config_folder(folder_path)
-	return _entry_from_config(cfg, dir_name, folder_path, "folder")
+	var entry := _entry_from_config(cfg, dir_name, folder_path, "folder")
+	entry["warnings"] = _build_entry_warnings(entry)
+	return entry
 
 
 # Future: mod.txt may support [mod] load_after = "other_mod_id" for soft dependencies.
@@ -201,12 +202,34 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 			priority = filename_priority
 	elif has_filename_priority:
 		priority = filename_priority
-	return {
+	priority = clampi(priority, PRIORITY_MIN, PRIORITY_MAX)
+	var entry := {
 		"file_name": file_name, "full_path": full_path, "ext": ext,
 		"mod_name": mod_name, "mod_id": mod_id,
 		"priority": priority, "enabled": true,
-		"cfg": cfg, "has_mod_txt": cfg != null,
+		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
 	}
+	if ext == "zip":
+		entry["enabled"] = false
+	return entry
+
+
+func _build_entry_warnings(entry: Dictionary) -> Array[String]:
+	var warnings: Array[String] = []
+	var ext: String = entry["ext"]
+	if ext == "zip":
+		warnings.append("Rename this file from .zip to .vmz to use it")
+		return warnings
+	if ext == "pck" or ext == "folder":
+		return warnings
+	var status: String = entry.get("mod_txt_status", "none")
+	if status == "none":
+		warnings.append("Invalid mod — may not work correctly. Try re-downloading.")
+	elif status == "parse_error":
+		warnings.append("Invalid mod — may not work correctly. Try re-downloading.")
+	elif status.begins_with("nested:"):
+		warnings.append("Invalid mod — packaged incorrectly. Try re-downloading.")
+	return warnings
 
 
 # ─── Config persistence ───────────────────────────────────────────────────────
@@ -227,6 +250,8 @@ func _load_ui_config() -> void:
 	for entry in _ui_mod_entries:
 		var fn: String = entry["file_name"]
 		entry["enabled"] = bool(cfg.get_value("enabled", fn, true))
+		if entry["ext"] == "zip":
+			entry["enabled"] = false
 		if cfg.has_section_key("priority", fn):
 			entry["priority"] = int(str(cfg.get_value("priority", fn)))
 
@@ -301,8 +326,8 @@ func _show_mod_ui() -> void:
 	root.add_child(bottom)
 
 	var hint := Label.new()
-	hint.text = "Higher priority = loads last = wins conflicts.  " \
-			+ "Mods: " + ProjectSettings.globalize_path(_mods_dir) + "  (.zip / .vmz / .pck)"
+	hint.text = "Higher number loads later and wins when mods share files.\n" \
+			+ "Developer Mode: verbose logging, conflict report, and loose folder loading."
 	hint.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	hint.add_theme_font_size_override("font_size", 11)
@@ -333,36 +358,13 @@ func _show_mod_ui() -> void:
 	# Closing the window with X should behave the same as clicking Launch.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
 
-	var mods_tab := _build_mods_tab()
+	var mods_tab := _build_mods_tab(tabs)
 	mods_tab.name = "Mods"
 	tabs.add_child(mods_tab)
 
 	var updates_tab := _build_updates_tab()
 	updates_tab.name = "Updates"
 	tabs.add_child(updates_tab)
-
-	var compat_tab := _build_compat_tab()
-	compat_tab.name = "Compatibility"
-	tabs.add_child(compat_tab)
-	var compat_idx := compat_tab.get_index()
-	tabs.set_tab_hidden(compat_idx, not _developer_mode)
-
-	var rebuild_mods_tab := func():
-		_ui_mod_entries = _collect_mod_metadata()
-		_load_ui_config()
-		var old := tabs.get_node("Mods")
-		var idx := old.get_index()
-		tabs.remove_child(old)
-		old.queue_free()
-		var new_tab := _build_mods_tab()
-		new_tab.name = "Mods"
-		tabs.add_child(new_tab)
-		tabs.move_child(new_tab, idx)
-		tabs.current_tab = tabs.get_node("Settings").get_index()
-
-	var settings_tab := _build_settings_tab(tabs, compat_idx, rebuild_mods_tab)
-	settings_tab.name = "Settings"
-	tabs.add_child(settings_tab)
 
 	await launch_btn.pressed
 	win.queue_free()
@@ -461,7 +463,7 @@ func _make_dark_theme() -> Theme:
 	return t
 
 
-func _build_mods_tab() -> Control:
+func _build_mods_tab(tabs: TabContainer) -> Control:
 	var outer := VBoxContainer.new()
 	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
@@ -474,6 +476,33 @@ func _build_mods_tab() -> Control:
 	toolbar.add_child(open_btn)
 	open_btn.pressed.connect(func():
 		OS.shell_open(ProjectSettings.globalize_path(_mods_dir))
+	)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	toolbar.add_child(spacer)
+
+	var dev_check := CheckBox.new()
+	dev_check.text = "Developer Mode"
+	dev_check.tooltip_text = "Enables verbose logging, conflict report, and loose folder loading"
+	dev_check.button_pressed = _developer_mode
+	dev_check.add_theme_font_size_override("font_size", 11)
+	dev_check.modulate = Color(0.45, 0.45, 0.45)
+	toolbar.add_child(dev_check)
+
+	dev_check.toggled.connect(func(on: bool):
+		_developer_mode = on
+		_ui_mod_entries = _collect_mod_metadata()
+		_load_ui_config()
+		var old := tabs.get_node("Mods")
+		var idx := old.get_index()
+		tabs.remove_child(old)
+		old.queue_free()
+		var new_tab := _build_mods_tab(tabs)
+		new_tab.name = "Mods"
+		tabs.add_child(new_tab)
+		tabs.move_child(new_tab, idx)
+		tabs.current_tab = idx
 	)
 
 	outer.add_child(HSeparator.new())
@@ -563,7 +592,7 @@ func _build_mods_tab() -> Control:
 	header_row.add_child(h_name)
 
 	var h_prio := Label.new()
-	h_prio.text = "Priority"
+	h_prio.text = "Load Order"
 	h_prio.custom_minimum_size.x = 100
 	h_prio.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	header_row.add_child(h_prio)
@@ -574,7 +603,7 @@ func _build_mods_tab() -> Control:
 
 	if _ui_mod_entries.is_empty():
 		var empty := Label.new()
-		empty.text = "No mods found.\n\nPlace .zip, .vmz, or .pck files in:\n" \
+		empty.text = "No mods found.\n\nPlace .vmz or .pck files in:\n" \
 				+ ProjectSettings.globalize_path(_mods_dir)
 		empty.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 		empty.modulate = Color(0.5, 0.5, 0.5)
@@ -606,18 +635,23 @@ func _build_mods_tab() -> Control:
 			dev_lbl.modulate = Color(0.9, 0.3, 0.3)
 			dev_lbl.add_theme_font_size_override("font_size", 11)
 			name_col.add_child(dev_lbl)
-		if not entry["has_mod_txt"]:
+		for warn_text: String in entry.get("warnings", []):
 			var warn := Label.new()
-			warn.text = "no mod.txt — mount only"
+			warn.text = warn_text
 			warn.modulate = Color(1.0, 0.6, 0.2)
 			warn.add_theme_font_size_override("font_size", 11)
 			name_col.add_child(warn)
+
+		if entry["ext"] == "zip":
+			check.disabled = true
 
 		var spin := SpinBox.new()
 		spin.min_value = PRIORITY_MIN
 		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
+		if entry["ext"] == "zip":
+			spin.editable = false
 		row.add_child(spin)
 
 		list.add_child(HSeparator.new())
@@ -638,215 +672,6 @@ func _build_mods_tab() -> Control:
 	refresh_order.call()
 	return outer
 
-
-func _build_compat_tab() -> Control:
-	var margin := MarginContainer.new()
-	margin.add_theme_constant_override("margin_left", 8)
-	margin.add_theme_constant_override("margin_right", 8)
-	margin.add_theme_constant_override("margin_top", 6)
-	margin.add_theme_constant_override("margin_bottom", 6)
-
-	var container := VBoxContainer.new()
-	container.add_theme_constant_override("separation", 6)
-	margin.add_child(container)
-
-	var toolbar := HBoxContainer.new()
-	toolbar.add_theme_constant_override("separation", 8)
-	container.add_child(toolbar)
-
-	var info := Label.new()
-	info.text = "Dry-scans enabled archives without mounting. Shows override conflicts, broken chains, and crash risks."
-	info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	info.add_theme_font_size_override("font_size", 12)
-	info.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	toolbar.add_child(info)
-
-	var scan_btn := Button.new()
-	scan_btn.text = "Run Analysis"
-	toolbar.add_child(scan_btn)
-
-	container.add_child(HSeparator.new())
-
-	# Split: issue list on the left, detail view on the right.
-	# split_offset offsets from center when both sides have SIZE_EXPAND_FILL.
-	# 94 = center(~470) + 94 = divider at ~564px → right panel gets ~40% of width.
-	var split := HSplitContainer.new()
-	split.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	split.split_offset = 94
-	container.add_child(split)
-
-	# ── Left: clickable issue list ────────────────────────────────────────────
-
-	var list_scroll := ScrollContainer.new()
-	list_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	list_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	split.add_child(list_scroll)
-
-	var issue_list := VBoxContainer.new()
-	issue_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	issue_list.add_theme_constant_override("separation", 2)
-	list_scroll.add_child(issue_list)
-
-	var placeholder := Label.new()
-	placeholder.text = "Click 'Run Analysis' to scan mods."
-	placeholder.modulate = Color(0.6, 0.6, 0.6)
-	issue_list.add_child(placeholder)
-
-	# ── Right: issue detail panel ─────────────────────────────────────────────
-
-	var detail_bg := PanelContainer.new()
-	detail_bg.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	var detail_style := StyleBoxFlat.new()
-	detail_style.bg_color = Color(0.09, 0.09, 0.09)
-	detail_style.content_margin_left = 12
-	detail_style.content_margin_right = 12
-	detail_style.content_margin_top = 10
-	detail_style.content_margin_bottom = 10
-	detail_bg.add_theme_stylebox_override("panel", detail_style)
-	split.add_child(detail_bg)
-
-	var detail_scroll := ScrollContainer.new()
-	detail_bg.add_child(detail_scroll)
-
-	var detail_vbox := VBoxContainer.new()
-	detail_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	detail_vbox.add_theme_constant_override("separation", 8)
-	detail_scroll.add_child(detail_vbox)
-
-	var detail_title := Label.new()
-	detail_title.text = "Select an issue to see details."
-	detail_title.modulate = Color(0.65, 0.65, 0.65)
-	detail_title.add_theme_font_size_override("font_size", 14)
-	detail_vbox.add_child(detail_title)
-
-	var detail_what_hdr := Label.new()
-	detail_what_hdr.text = "What's happening"
-	detail_what_hdr.add_theme_font_size_override("font_size", 11)
-	detail_what_hdr.modulate = Color(0.75, 0.75, 0.75)
-	detail_what_hdr.visible = false
-	detail_vbox.add_child(detail_what_hdr)
-
-	var detail_what := Label.new()
-	detail_what.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	detail_what.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	detail_what.visible = false
-	detail_vbox.add_child(detail_what)
-
-	var detail_fix_hdr := Label.new()
-	detail_fix_hdr.text = "How to fix"
-	detail_fix_hdr.add_theme_font_size_override("font_size", 11)
-	detail_fix_hdr.modulate = Color(0.75, 0.75, 0.75)
-	detail_fix_hdr.visible = false
-	detail_vbox.add_child(detail_fix_hdr)
-
-	var detail_fix := Label.new()
-	detail_fix.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	detail_fix.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	detail_fix.visible = false
-	detail_vbox.add_child(detail_fix)
-
-	var detail_mods_hdr := Label.new()
-	detail_mods_hdr.text = "Affected mods"
-	detail_mods_hdr.add_theme_font_size_override("font_size", 11)
-	detail_mods_hdr.modulate = Color(0.75, 0.75, 0.75)
-	detail_mods_hdr.visible = false
-	detail_vbox.add_child(detail_mods_hdr)
-
-	var detail_mods_lbl := Label.new()
-	detail_mods_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	detail_mods_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	detail_mods_lbl.visible = false
-	detail_vbox.add_child(detail_mods_lbl)
-
-	var detail_labels := [detail_what_hdr, detail_what, detail_fix_hdr,
-			detail_fix, detail_mods_hdr, detail_mods_lbl]
-
-	var show_detail := func(issue: Dictionary):
-		detail_title.text = issue["title"]
-		var sev: String = issue["severity"]
-		detail_title.modulate = Color(0.85, 0.32, 0.32) if sev == "critical" \
-				else (Color(0.85, 0.70, 0.28) if sev == "warning" else Color(0.80, 0.80, 0.80))
-		detail_what.text = issue["what"]
-		detail_fix.text = issue["fix"]
-		detail_mods_lbl.text = ", ".join(issue["mods"])
-		for lbl in detail_labels:
-			lbl.visible = true
-
-	var populate_issues := func(issues: Array[Dictionary]):
-		for child in issue_list.get_children():
-			child.queue_free()
-		if issues.is_empty():
-			var lbl := Label.new()
-			lbl.text = "No issues detected."
-			lbl.modulate = Color(0.80, 0.80, 0.80)
-			issue_list.add_child(lbl)
-			return
-		for issue: Dictionary in issues:
-			var sev: String = issue["severity"]
-			var btn := Button.new()
-			btn.text = issue["title"]
-			btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
-			btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-			btn.modulate = Color(0.85, 0.38, 0.38) if sev == "critical" \
-					else (Color(0.85, 0.72, 0.30) if sev == "warning" else Color(0.72, 0.72, 0.72))
-			var iss := issue
-			btn.pressed.connect(func(): show_detail.call(iss))
-			issue_list.add_child(btn)
-
-	scan_btn.pressed.connect(func():
-		scan_btn.disabled = true
-		scan_btn.text = "Scanning..."
-		_run_dry_compat_analysis(populate_issues)
-		scan_btn.disabled = false
-		scan_btn.text = "Run Analysis"
-	)
-
-	return margin
-
-
-# Scans all enabled archives in load order without mounting anything, then
-# calls the populate callback with structured issue data for the UI.
-# The main _report_lines array is swapped out so dry-run noise doesn't
-# pollute the real launch log.
-#
-# IMPORTANT: This calls _scan_and_register_archive_claims (read-only scan via
-# ZIPReader) — NOT _process_mod_candidate (which mounts packs and queues
-# autoloads). Calling _process_mod_candidate here would have side effects
-# that corrupt the real launch. _load_all_mods() clears all state before the
-# real load, so stale dry-analysis data does not leak.
-func _run_dry_compat_analysis(populate_cb: Callable) -> void:
-	_override_registry.clear()
-	_mod_script_analysis.clear()
-	_archive_file_sets.clear()
-	_bad_zips.clear()
-	_database_replaced_by = ""
-	_database_path = ""
-	_scan_vanilla_paths()
-	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
-
-	var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
-	sorted.sort_custom(_compare_load_order)
-
-	if sorted.is_empty():
-		populate_cb.call([])
-		return
-
-	var saved_lines := _report_lines
-	var dry_lines: Array[String] = []
-	_report_lines = dry_lines
-
-	for i in sorted.size():
-		var entry: Dictionary = sorted[i]
-		var scan_path: String = entry["full_path"]
-		if entry["ext"] == "folder":
-			scan_path = _zip_folder_to_temp(entry["full_path"])
-			if scan_path == "":
-				continue
-		_scan_and_register_archive_claims(scan_path, entry["mod_name"], entry["file_name"], i)
-
-	var issues := _collect_conflict_issues()
-	_report_lines = saved_lines
-	populate_cb.call(issues)
 
 
 func _build_updates_tab() -> Control:
@@ -1036,51 +861,6 @@ func _build_updates_tab() -> Control:
 	return margin
 
 
-func _build_settings_tab(tabs: TabContainer, compat_idx: int, rebuild_mods_tab: Callable) -> Control:
-	var margin := MarginContainer.new()
-	margin.add_theme_constant_override("margin_left", 8)
-	margin.add_theme_constant_override("margin_right", 8)
-	margin.add_theme_constant_override("margin_top", 6)
-	margin.add_theme_constant_override("margin_bottom", 6)
-
-	var container := VBoxContainer.new()
-	container.add_theme_constant_override("separation", 8)
-	margin.add_child(container)
-
-	var hdr := Label.new()
-	hdr.text = "Developer Mode"
-	hdr.add_theme_font_size_override("font_size", 13)
-	container.add_child(hdr)
-	container.add_child(HSeparator.new())
-
-	var dev_check := CheckBox.new()
-	dev_check.text = "Enable Developer Mode"
-	dev_check.button_pressed = _developer_mode
-	container.add_child(dev_check)
-
-	var desc := Label.new()
-	desc.text = "Enables:\n" \
-			+ "  - Compatibility tab (scan for override conflicts without launching)\n" \
-			+ "  - Compile check (loads each override script to catch parse errors early)\n" \
-			+ "  - Override audit (warns if overrideScript() targets have 0 live nodes)\n" \
-			+ "  - Conflict report saved to modloader_conflicts.txt after each launch\n" \
-			+ "  - Verbose [Debug] logging for load order, timing, and override state\n" \
-			+ "  - Loose mod folders loaded from the mods directory\n" \
-			+ "\nOff by default — adds ~1s to launch for scanning."
-	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	desc.add_theme_font_size_override("font_size", 11)
-	desc.modulate = Color(0.5, 0.5, 0.5)
-	desc.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	container.add_child(desc)
-
-	dev_check.toggled.connect(func(on: bool):
-		_developer_mode = on
-		tabs.set_tab_hidden(compat_idx, not on)
-		rebuild_mods_tab.call()
-	)
-
-	return margin
-
 
 func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn: Button) -> void:
 	var ids: Array[int] = []
@@ -1090,6 +870,9 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 		return
 
 	var latest := await _fetch_latest_modworkshop_versions(ids)
+
+	if not is_instance_valid(check_btn):
+		return
 
 	for fn: String in status_info:
 		var info: Dictionary = status_info[fn]
@@ -1126,6 +909,8 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 				lbl.text = "downloading..."
 				check_btn.disabled = true
 				var ok := await _download_and_replace_mod(full_path, mw_id)
+				if not is_instance_valid(check_btn):
+					return
 				check_btn.disabled = false
 				if ok:
 					lbl.text = "updated — restart to apply"
@@ -1158,10 +943,7 @@ func _load_all_mods() -> void:
 	_database_replaced_by = ""
 	_mod_script_analysis.clear()
 	_archive_file_sets.clear()
-	_bad_zips.clear()
 
-	if _developer_mode:
-		_scan_vanilla_paths()
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
 	# Build the candidate list from UI-configured entries (already filtered and trusted).
@@ -1197,40 +979,6 @@ func _load_all_mods() -> void:
 		_process_mod_candidate(candidates[load_index], load_index)
 
 
-# Try to load() each .gd file from mounted archives that extends a vanilla script.
-# Catches real Godot compile errors with zero false positives.
-func _preflight_compile_check() -> void:
-	var checked := 0
-	var fail_count := 0
-	for archive_name: String in _archive_file_sets:
-		var file_set: Dictionary = _archive_file_sets[archive_name]
-		for res_path: String in file_set:
-			if not (res_path as String).ends_with(".gd"): continue
-			# Look up which mod owns this file to get its extends_paths.
-			if not _override_registry.has(res_path): continue
-			var owner_name: String = (_override_registry[res_path][0] as Dictionary)["mod_name"]
-			if not _mod_script_analysis.has(owner_name): continue
-			var analysis: Dictionary = _mod_script_analysis[owner_name]
-			# Only check scripts that extend another script (override scripts).
-			if (analysis["extends_paths"] as Array).is_empty(): continue
-			# Try to compile. Check both load() returning null AND whether
-			# the script can actually be instantiated (catches broken but non-null scripts).
-			checked += 1
-			var script: Resource = load(res_path)
-			var failed := script == null
-			if not failed and script is GDScript:
-				failed = not (script as GDScript).can_instantiate()
-			if failed:
-				fail_count += 1
-				_log_critical("Pre-flight: " + owner_name + " — " + res_path
-						+ " failed to compile. See error above.")
-	if fail_count > 0:
-		_log_warning("Pre-flight: " + str(fail_count) + " of " + str(checked)
-				+ " override script(s) failed to compile.")
-	elif checked > 0:
-		_log_info("Pre-flight: " + str(checked) + " override script(s) compiled OK.")
-
-
 func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var file_name: String = c["file_name"]
 	var full_path: String = c["full_path"]
@@ -1240,6 +988,10 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var cfg               = c["cfg"]
 
 	_log_info("--- [" + str(load_index + 1) + "] " + mod_name + " (" + file_name + ")")
+
+	if ext == "zip":
+		_log_warning("Skipping .zip file: " + file_name + " — rename to .vmz to use")
+		return
 
 	if ext != "pck" and _loaded_mod_ids.has(mod_id):
 		_log_warning("Duplicate mod id '" + mod_id + "' — skipped: " + file_name)
@@ -1275,9 +1027,15 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 				_log_debug("  Mount verification: no files accessible via FileAccess/ResourceLoader (may be normal)")
 				_log_debug("  Will attempt load() directly when needed")
 
-	if ext == "pck" or not c["has_mod_txt"]:
-		if not c["has_mod_txt"] and ext != "pck":
-			_log_warning("  No mod.txt — autoloads skipped")
+	if ext == "pck" or cfg == null:
+		if cfg == null and ext != "pck":
+			var status: String = c.get("mod_txt_status", "none")
+			if status.begins_with("nested:"):
+				_log_warning("  Invalid mod — packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
+			elif status == "parse_error":
+				_log_warning("  Invalid mod — mod.txt failed to parse")
+			else:
+				_log_warning("  No mod.txt — autoloads skipped")
 		return
 
 	_loaded_mod_ids[mod_id] = true
@@ -1315,7 +1073,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 		_pending_autoloads.append({ "mod_name": mod_name, "name": autoload_name, "path": res_path })
 		_log_info("  Autoload queued: " + autoload_name + " -> " + res_path)
-		_register_claim(res_path, mod_name, file_name, load_index, "autoload")
+		_register_claim(res_path, mod_name, file_name, load_index)
 
 
 # ─── Logging ──────────────────────────────────────────────────────────────────
@@ -1349,7 +1107,7 @@ func _log_debug(msg: String) -> void:
 # ─── Override registry ────────────────────────────────────────────────────────
 
 func _register_claim(res_path: String, mod_name: String, archive: String,
-		load_index: int, claim_type: String, source_path: String = "") -> void:
+		load_index: int) -> void:
 	if not _override_registry.has(res_path):
 		_override_registry[res_path] = []
 	for existing in _override_registry[res_path]:
@@ -1357,7 +1115,6 @@ func _register_claim(res_path: String, mod_name: String, archive: String,
 			return
 	_override_registry[res_path].append({
 		"mod_name": mod_name, "archive": archive, "load_index": load_index,
-		"claim_type": claim_type, "source_path": source_path,
 	})
 
 func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
@@ -1371,53 +1128,6 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 	# This final tiebreaker makes the ordering a strict total order so that Godot's
 	# unstable introsort can never shuffle "equal" elements.
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
-
-func _is_dangerous_path(res_path: String) -> bool:
-	return _vanilla_paths.has(res_path)
-
-func _classify_claim(res_path: String) -> String:
-	var lower := res_path.to_lower()
-	if lower.ends_with(".gd"):                               return "script"
-	if lower.ends_with(".tscn") or lower.ends_with(".scn"):  return "scene"
-	if lower.ends_with(".tres"):                             return "resource"
-	return "file"
-
-
-# ─── Vanilla path scan ────────────────────────────────────────────────────────
-
-func _scan_vanilla_paths() -> void:
-	_vanilla_paths.clear()
-	_database_path = ""
-	for dir_path in VANILLA_SCAN_DIRS:
-		_scan_vanilla_dir(dir_path)
-	for path: String in _vanilla_paths:
-		if path.get_extension().to_lower() == "gd" \
-				and path.get_file().get_basename().to_lower() == "database":
-			_database_path = path
-			_log_info("Vanilla scan: scene registry -> " + _database_path)
-			break
-	if _vanilla_paths.is_empty():
-		_log_warning("Vanilla scan: 0 files found — falling back to filename heuristics.")
-	else:
-		_log_info("Vanilla scan: " + str(_vanilla_paths.size()) + " game files indexed")
-
-func _scan_vanilla_dir(dir_path: String) -> void:
-	var dir := DirAccess.open(dir_path)
-	if dir == null:
-		return
-	dir.list_dir_begin()
-	while true:
-		var entry := dir.get_next()
-		if entry == "":
-			break
-		if entry.begins_with("."):
-			continue
-		var full := dir_path.path_join(entry)
-		if dir.current_is_dir():
-			_scan_vanilla_dir(full)
-		elif entry.get_extension().to_lower() in TRACKED_EXTENSIONS:
-			_vanilla_paths[full] = true
-	dir.list_dir_end()
 
 
 # ─── Archive scanner ──────────────────────────────────────────────────────────
@@ -1441,12 +1151,10 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 			if example_bad == "":
 				example_bad = f
 	if backslash_count > 0:
-		_bad_zips.append({"mod_name": mod_name, "count": backslash_count, "example": example_bad})
 		_log_critical("  BAD ZIP: " + str(backslash_count) + " entries use Windows backslash paths.")
 		_log_critical("    Re-pack with 7-Zip. Example bad entry: '" + example_bad + "'")
 
 	var tracked_count := 0
-	var dangerous_count := 0
 	var path_set: Dictionary = {}
 	var gd_analysis: Dictionary = {
 		"take_over_literal_paths": [],
@@ -1474,30 +1182,24 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 
 		path_set[res_path] = true
 		tracked_count += 1
-		_register_claim(res_path, mod_name, archive_file, load_index, _classify_claim(res_path), f)
+		_register_claim(res_path, mod_name, archive_file, load_index)
 
 		var bare_name := res_path.get_file().get_basename().to_lower()
 		var is_db_file := bare_name == "database" and res_path.get_extension().to_lower() == "gd"
 
-		if (res_path == _database_path and _database_path != "") or (is_db_file and _database_path == ""):
+		if is_db_file:
 			if _database_replaced_by == "":
 				_database_replaced_by = mod_name
-			_log_critical("  DATABASE OVERRIDE: " + mod_name + " replaces Database.gd")
-			_log_warning("    All preload() paths in this file must exist or parsing will fail.")
-		elif is_db_file:
-			_log_warning("  DATABASE COPY: " + mod_name + " bundles a private Database.gd at " + res_path)
-			_log_warning("    Hardcoded preload() paths may break if companion mods aren't present.")
-		elif _is_dangerous_path(res_path):
-			dangerous_count += 1
+				_log_info("  DATABASE OVERRIDE: " + mod_name + " replaces Database.gd")
+			else:
+				_log_warning("  DATABASE COPY: " + mod_name + " bundles a private Database.gd at " + res_path)
+				_log_warning("    Hardcoded preload() paths may break if companion mods aren't present.")
 
 	zr.close()
 	_mod_script_analysis[mod_name] = gd_analysis
 	_archive_file_sets[archive_file] = path_set
 
-	var summary := "  " + str(tracked_count) + " resource path(s)"
-	if dangerous_count > 0:
-		summary += " [" + str(dangerous_count) + " replace vanilla files]"
-	_log_info(summary)
+	_log_info("  " + str(tracked_count) + " resource path(s)")
 
 	if gd_analysis["total_gd_files"] > 0:
 		var override_count: int = (gd_analysis["take_over_literal_paths"] as Array).size() \
@@ -1600,393 +1302,6 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 				(analysis["lifecycle_no_super"] as Array).append(func_name)
 
 
-func _analyze_script_conflicts() -> void:
-	var issues := _collect_conflict_issues()
-	for issue: Dictionary in issues:
-		var sev: String = issue["severity"]
-		var log_fn := _log_info if sev == "info" else (_log_critical if sev == "critical" else _log_warning)
-		log_fn.call(issue["title"] + " — " + ", ".join(issue["mods"]))
-
-
-func _find_database_affected_mods() -> Array[String]:
-	var affected: Array[String] = []
-	for res_path: String in _override_registry:
-		if res_path == _database_path: continue
-		var lower := res_path.to_lower()
-		if not (lower.ends_with(".tscn") or lower.ends_with(".scn")): continue
-		# Only count scene overrides that replace vanilla files. A mod shipping its
-		# own scenes under mods/MyMod/ is not affected by Database preload caching.
-		if not _is_dangerous_path(res_path): continue
-		for claim in (_override_registry[res_path] as Array):
-			var cn: String = claim["mod_name"]
-			if cn != _database_replaced_by and cn not in affected:
-				affected.append(cn)
-	return affected
-
-
-# Returns structured issue data for the compatibility tab UI. Operates on
-# whatever state is currently in _mod_script_analysis and _override_registry
-# (populated by _scan_and_register_archive_claims).
-func _collect_conflict_issues() -> Array[Dictionary]:
-	var issues: Array[Dictionary] = []
-
-	# 1. Literal take_over_path() conflicts — only one version of that script can be active.
-	var literal_claims: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		for path in (_mod_script_analysis[mod_name]["take_over_literal_paths"] as Array):
-			if not literal_claims.has(path): literal_claims[path] = []
-			if mod_name not in literal_claims[path]:
-				(literal_claims[path] as Array).append(mod_name)
-
-	for path: String in literal_claims:
-		var mods: Array = literal_claims[path]
-		if mods.size() <= 1: continue
-		issues.append({
-			"severity": "critical",
-			"title": "Script Conflict: " + path.get_file(),
-			"what": "Both mods call take_over_path() on the same script:\n  " + path
-					+ "\n\nOnly the last-loaded version is active. The other mod's "
-					+ "changes to this script are silently replaced.",
-			"fix": "Use priority to control which mod wins (higher = loads last = wins).\n\n"
-					+ "To fix: one mod should switch to the extends + super() pattern "
-					+ "so both can coexist in a chain.",
-			"mods": mods,
-		})
-
-	# 2. Dynamic overrideScript() chains — compose correctly only if all mods call super().
-	var extends_claims: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		if not analysis["uses_dynamic_override"]: continue
-		for path in (analysis["extends_paths"] as Array):
-			if not extends_claims.has(path): extends_claims[path] = []
-			if mod_name not in extends_claims[path]:
-				(extends_claims[path] as Array).append(mod_name)
-
-	for path: String in extends_claims:
-		var claimants: Array = extends_claims[path]
-		if claimants.size() <= 1: continue
-		var bad_mods: Array = []
-		for cmod: String in claimants:
-			if not (_mod_script_analysis[cmod]["lifecycle_no_super"] as Array).is_empty():
-				bad_mods.append(cmod)
-		if bad_mods.is_empty():
-			continue
-		var bad_methods: Array[String] = []
-		for bm: String in bad_mods:
-			var methods: Array = _mod_script_analysis[bm]["lifecycle_no_super"]
-			bad_methods.append(bm + " (" + ", ".join(methods) + ")")
-		issues.append({
-			"severity": "warning",
-			"title": "Chain Broken: " + path.get_file(),
-			"what": "These mods both override " + path.get_file() + " using extends, "
-					+ "but " + ", ".join(bad_mods) + " is missing super() calls:\n  "
-					+ "\n  ".join(bad_methods)
-					+ "\n\nWithout super(), the override chain breaks — other mods' logic "
-					+ "for those methods never runs.",
-			"fix": "Workaround: give " + ", ".join(bad_mods)
-					+ " a lower priority so it loads first (limits the damage).\n\n"
-					+ "Fix: add super() at the start of each listed method.",
-			"mods": claimants,
-		})
-
-	# 2b. Informational card for overrideScript() mods — even without chain conflicts,
-	# mod authors need to understand the timing constraint.
-	for mod_name: String in _mod_script_analysis:
-		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		if not analysis["uses_dynamic_override"]:
-			continue
-		var targets: Array = analysis["extends_paths"]
-		if targets.is_empty():
-			continue
-		# Skip if this mod already appeared in a chain conflict above.
-		var already_flagged := false
-		for iss in issues:
-			if mod_name in (iss["mods"] as Array) and "Chain" in (iss["title"] as String):
-				already_flagged = true
-				break
-		if already_flagged:
-			continue
-		var target_list := ", ".join(targets.map(func(p): return (p as String).get_file()))
-		issues.append({
-			"severity": "info",
-			"title": "Uses overrideScript(): " + mod_name,
-			"what": mod_name + " uses overrideScript() to extend:\n  " + target_list
-					+ "\n\noverrideScript() only affects nodes instantiated after the "
-					+ "override is registered. Nodes already in the scene tree at launch "
-					+ "(e.g. containers, HUD elements) will keep the original script.",
-			"fix": "This is expected behavior, not a bug. If the mod doesn't seem to "
-					+ "work, check that its target nodes are spawned at runtime rather "
-					+ "than placed in the scene at export time.\n\n"
-					+ "Enable Developer Mode and check the conflict report for "
-					+ "'Override registered but 0 matching nodes found' warnings.",
-			"mods": [mod_name],
-		})
-
-	# 3. File overlap grouped by mod pair — one card per conflicting pair, not per file.
-	# Build per-mod path sets from the override registry.
-	var mod_paths: Dictionary = {}  # mod_name -> Dictionary of res_paths
-	for res_path: String in _override_registry:
-		var claims: Array = _override_registry[res_path]
-		for claim in claims:
-			var mn: String = claim["mod_name"]
-			if not mod_paths.has(mn):
-				mod_paths[mn] = {}
-			(mod_paths[mn] as Dictionary)[res_path] = true
-
-	# Compare every pair of mods for shared files.
-	var mod_list: Array = mod_paths.keys()
-	var seen_pairs: Dictionary = {}
-	for i in mod_list.size():
-		for j in range(i + 1, mod_list.size()):
-			var mod_a: String = mod_list[i]
-			var mod_b: String = mod_list[j]
-			var pair_key := mod_a + "|" + mod_b
-			if seen_pairs.has(pair_key): continue
-			seen_pairs[pair_key] = true
-
-			var shared: Array[String] = []
-			var shared_vanilla: Array[String] = []
-			for p: String in (mod_paths[mod_a] as Dictionary):
-				if (mod_paths[mod_b] as Dictionary).has(p):
-					shared.append(p)
-					if _is_dangerous_path(p):
-						shared_vanilla.append(p)
-
-			if shared.is_empty(): continue
-
-			# Build a readable list of conflicting filenames.
-			var file_names: Array[String] = []
-			for p in shared:
-				var fname: String = p.get_file()
-				if fname not in file_names:
-					file_names.append(fname)
-			file_names.sort()
-			var file_list := ", ".join(file_names)
-			if file_names.size() > MAX_DISPLAYED_FILENAMES:
-				file_list = ", ".join(file_names.slice(0, MAX_DISPLAYED_FILENAMES)) + " + " \
-						+ str(file_names.size() - MAX_DISPLAYED_FILENAMES) + " more"
-
-			# Determine severity and wording based on overlap scale.
-			var sev := "critical" if shared_vanilla.size() > 0 else "warning"
-			var title := ""
-			var what := ""
-			var fix := ""
-
-			if shared.size() >= OVERLAP_FILE_THRESHOLD and shared_vanilla.size() >= OVERLAP_VANILLA_THRESHOLD:
-				title = "Likely Incompatible: " + mod_a + " + " + mod_b
-				what = "Both mods change " + str(shared.size()) + " of the same game files (" \
-						+ str(shared_vanilla.size()) + " core scripts):\n  " + file_list \
-						+ "\n\nThis much overlap almost always means these mods will " \
-						+ "break each other. One mod's changes will be lost."
-				fix = "Disable one of these mods. Some overhaul mods already include " \
-						+ "smaller mods — check the mod descriptions."
-			else:
-				title = "Overlap: " + mod_a + " + " + mod_b
-				what = str(shared.size()) + " shared file(s):\n  " + file_list
-				if shared_vanilla.size() > 0:
-					what += "\n\n" + str(shared_vanilla.size()) + " of these are game files. " \
-							+ "The mod with higher priority wins — the other mod's " \
-							+ "version of these files is ignored."
-				else:
-					what += "\n\nBoth mods include these files. The mod with higher " \
-							+ "priority wins for each shared file."
-				fix = "Try changing the priority order on the Mods tab to see which " \
-						+ "arrangement works best. If both mods need these files, " \
-						+ "they can't be used together."
-
-			issues.append({
-				"severity": sev,
-				"title": title,
-				"what": what,
-				"fix": fix,
-				"mods": [mod_a, mod_b],
-			})
-
-	# 4. Database.gd replaced — preload() caches paths before resource overrides take effect.
-	if _database_replaced_by != "":
-		var affected := _find_database_affected_mods()
-		if not affected.is_empty():
-			var all_mods: Array[String] = [_database_replaced_by]
-			all_mods.append_array(affected)
-			issues.append({
-				"severity": "critical",
-				"title": "Database.gd Replaced",
-				"what": _database_replaced_by + " replaces Database.gd, which preload()s all "
-						+ "item and scene paths at parse time.\n\nScene overrides from other mods "
-						+ "may not take effect because Database.gd caches the original paths "
-						+ "before those mods mount.",
-				"fix": "Potentially affected mods:\n  " + ", ".join(affected)
-						+ "\n\nIf scenes or items are missing, the load order between "
-						+ _database_replaced_by + " and scene-override mods may need adjusting.",
-				"mods": all_mods,
-			})
-
-	# 5. class_name double override — Godot bug #83542, fatal crash at startup.
-	# Only fires when 2+ mods with uses_dynamic_override both extend-by-class_name
-	# on the same class AND that class_name is declared by a mod (not a Godot built-in).
-	var declared_class_names: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		for cn in (_mod_script_analysis[mod_name]["class_names"] as Array):
-			declared_class_names[cn] = true
-	var cn_override_claims: Dictionary = {}  # class_name -> Array[mod_name]
-	for mod_name: String in _mod_script_analysis:
-		var cn_analysis: Dictionary = _mod_script_analysis[mod_name]
-		if not cn_analysis["uses_dynamic_override"]: continue
-		for cn in (cn_analysis["extends_class_names"] as Array):
-			# Skip if no mod declares this class_name — it's a Godot built-in (Node,
-			# Resource, Control, etc.) or a game class we can't verify. The bug only
-			# matters for class_name scripts that get take_over_path'd by mods.
-			if not declared_class_names.has(cn):
-				continue
-			if not cn_override_claims.has(cn): cn_override_claims[cn] = []
-			if mod_name not in cn_override_claims[cn]:
-				(cn_override_claims[cn] as Array).append(mod_name)
-	for cn: String in cn_override_claims:
-		var cn_mods: Array = cn_override_claims[cn]
-		if cn_mods.size() <= 1: continue
-		issues.append({
-			"severity": "critical",
-			"title": "class_name Crash: " + cn,
-			"what": "These mods both override a script that uses class_name '" + cn + "'.\n\n"
-					+ "Godot bug #83542: take_over_path() on class_name scripts can only "
-					+ "succeed once. A second override causes a fatal engine crash at startup.",
-			"fix": "Only one mod can override a class_name script. Disable all but one.\n\n"
-					+ "To fix: mod authors should use extends \"res://path.gd\" instead of "
-					+ "extends " + cn + " to avoid the class_name limitation.",
-			"mods": cn_mods,
-		})
-
-	# 6. Broken extends paths — mod extends a script that doesn't exist anywhere.
-	# Use FileAccess + ResourceLoader to check the live filesystem rather than
-	# relying on directory scanning, which can miss paths outside Scripts/Scenes.
-	for mod_name: String in _mod_script_analysis:
-		for ext_path in (_mod_script_analysis[mod_name]["extends_paths"] as Array):
-			var p: String = ext_path
-			if FileAccess.file_exists(p) or ResourceLoader.exists(p):
-				continue
-			issues.append({
-				"severity": "warning",
-				"title": "Missing Script: " + p.get_file(),
-				"what": mod_name + " extends a script that no longer exists:\n  " + p
-						+ "\n\nThis override will silently fail — " + mod_name + "'s changes "
-						+ "to this script won't apply. The game may have been updated "
-						+ "and this script was renamed or moved.",
-				"fix": mod_name + " needs an update for the current game version. "
-						+ "The mod will still load but features that depend on this "
-						+ "script won't work.",
-				"mods": [mod_name],
-			})
-
-	# 7. base() calls — Godot 3 pattern or removed parent method. Will fail at runtime.
-	for mod_name: String in _mod_script_analysis:
-		if not _mod_script_analysis[mod_name]["calls_base"]: continue
-		issues.append({
-			"severity": "warning",
-			"title": "Uses base(): " + mod_name,
-			"what": mod_name + " calls base() which is not a GDScript 4 built-in.\n\n"
-					+ "If this was meant to call the parent method, it should be super(). "
-					+ "If base() was a method on the game script, it may have been "
-					+ "removed or renamed in the current version.",
-			"fix": "The mod author needs to replace base() with super() or update "
-					+ "for the current game version.",
-			"mods": [mod_name],
-		})
-
-	# 8. Method-level collisions — two mods override the same method on the same script.
-	var method_claims: Dictionary = {}  # extends_path -> {method_name -> Array[mod_name]}
-	for mod_name: String in _mod_script_analysis:
-		var om: Dictionary = _mod_script_analysis[mod_name]["override_methods"]
-		for ext_path: String in om:
-			if not method_claims.has(ext_path):
-				method_claims[ext_path] = {}
-			for method_name in (om[ext_path] as Array):
-				if not (method_claims[ext_path] as Dictionary).has(method_name):
-					(method_claims[ext_path] as Dictionary)[method_name] = []
-				var claimers: Array = (method_claims[ext_path] as Dictionary)[method_name]
-				if mod_name not in claimers:
-					claimers.append(mod_name)
-
-	# Group shared methods by mod pair to avoid spamming one card per method.
-	var method_pair_issues: Dictionary = {}  # "modA|modB" -> {script, methods}
-	for ext_path: String in method_claims:
-		for method_name: String in (method_claims[ext_path] as Dictionary):
-			var method_mods: Array = (method_claims[ext_path] as Dictionary)[method_name]
-			if method_mods.size() <= 1: continue
-			for mi in method_mods.size():
-				for mj in range(mi + 1, method_mods.size()):
-					var mpk: String = str(method_mods[mi]) + "|" + str(method_mods[mj])
-					if not method_pair_issues.has(mpk):
-						method_pair_issues[mpk] = {
-							"mod_a": method_mods[mi], "mod_b": method_mods[mj], "scripts": {}
-						}
-					var mp: Dictionary = method_pair_issues[mpk]
-					if not (mp["scripts"] as Dictionary).has(ext_path):
-						(mp["scripts"] as Dictionary)[ext_path] = []
-					var ml: Array = (mp["scripts"] as Dictionary)[ext_path]
-					if method_name not in ml:
-						ml.append(method_name)
-
-	for mpk: String in method_pair_issues:
-		var mp_data: Dictionary = method_pair_issues[mpk]
-		var mp_mod_a: String = mp_data["mod_a"]
-		var mp_mod_b: String = mp_data["mod_b"]
-		var mp_scripts: Dictionary = mp_data["scripts"]
-		var detail_lines: Array[String] = []
-		for sp: String in mp_scripts:
-			detail_lines.append(sp.get_file() + ": " + ", ".join(mp_scripts[sp]))
-		issues.append({
-			"severity": "warning",
-			"title": "Method Overlap: " + mp_mod_a + " + " + mp_mod_b,
-			"what": "Both mods override the same method(s) on the same script(s):\n  "
-					+ "\n  ".join(detail_lines)
-					+ "\n\nEven with correct super() calls, both mods are modifying the same "
-					+ "function. Changes may interfere depending on load order.",
-			"fix": "Test with both priority orderings to find which works. If neither "
-					+ "works, these mods need author coordination to split their changes "
-					+ "across different methods.",
-			"mods": [mp_mod_a, mp_mod_b],
-		})
-
-	# 9. Stale preload() — mod preloads a path that another mod overrides via file replacement.
-	var all_override_paths: Dictionary = {}
-	for res_path: String in _override_registry:
-		var pl_claims: Array = _override_registry[res_path]
-		if pl_claims.size() >= 1:
-			all_override_paths[res_path] = (pl_claims[pl_claims.size() - 1] as Dictionary)["mod_name"]
-	for mod_name: String in _mod_script_analysis:
-		for pl_path in (_mod_script_analysis[mod_name]["preload_paths"] as Array):
-			if not all_override_paths.has(pl_path): continue
-			var overrider: String = all_override_paths[pl_path]
-			if overrider == mod_name: continue
-			issues.append({
-				"severity": "warning",
-				"title": "Stale preload(): " + (pl_path as String).get_file(),
-				"what": mod_name + " uses preload(\"" + pl_path + "\") but " + overrider
-						+ " replaces that file.\n\npreload() caches at compile time, before "
-						+ "mods mount. " + mod_name + " will get the vanilla version, not "
-						+ overrider + "'s replacement.",
-				"fix": "Replace preload() with load() in " + mod_name + "'s script. "
-						+ "load() runs at runtime and respects mounted mod files.",
-				"mods": [mod_name, overrider],
-			})
-
-	# 10. BAD ZIP — Windows backslash paths in archive. Godot can't resolve them.
-	for bz: Dictionary in _bad_zips:
-		issues.append({
-			"severity": "critical",
-			"title": "Bad Archive: " + bz["mod_name"],
-			"what": bz["mod_name"] + " has " + str(bz["count"])
-					+ " entries with backslash (\\) path separators.\n\n"
-					+ "Godot requires forward slashes. These files will silently fail "
-					+ "to load.\n\nExample: " + bz["example"],
-			"fix": "Re-pack with 7-Zip (which uses forward slashes). This typically "
-					+ "happens when using Windows ZipFile.CreateFromDirectory().",
-			"mods": [bz["mod_name"]],
-		})
-
-	return issues
-
 
 # ─── Override diagnostics (developer mode) ───────────────────────────────────
 
@@ -2031,9 +1346,8 @@ func _audit_override_instances() -> void:
 			_log_debug("Override applied: " + target_path.get_file()
 					+ " — " + str(live_script_paths[target_path]) + " node(s) [" + mod_name + "]")
 		else:
-			_log_warning("Override registered but 0 nodes use " + target_path.get_file()
-					+ " in current scene [" + mod_name + "]")
-			_log_warning("  Target may be spawned later at runtime, or the path may be wrong.")
+			_log_debug("Override registered but 0 nodes use " + target_path.get_file()
+					+ " in current scene — likely spawned at runtime [" + mod_name + "]")
 
 
 func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
@@ -2059,16 +1373,12 @@ func _print_conflict_summary() -> void:
 	_log_info("Mods loaded:  " + str(_loaded_mod_ids.size()))
 
 	var conflicted_paths: Array[String] = []
-	var critical_conflicts: Array[String] = []
 	for res_path: String in _override_registry:
 		var claims: Array = _override_registry[res_path]
 		if claims.size() > 1:
 			conflicted_paths.append(res_path)
-			if _is_dangerous_path(res_path) or res_path == _database_path:
-				critical_conflicts.append(res_path)
 
 	_log_info("Conflicting resource paths: " + str(conflicted_paths.size()))
-	_log_info("Critical conflicts:         " + str(critical_conflicts.size()))
 
 	if conflicted_paths.is_empty():
 		_log_info("No resource path conflicts — all mods appear compatible.")
@@ -2083,14 +1393,6 @@ func _print_conflict_summary() -> void:
 				var marker := " <-- wins" if claim == winner else ""
 				_log_info("    [" + str(claim["load_index"] + 1) + "] "
 						+ claim["mod_name"] + " via " + claim["archive"] + marker)
-
-	if _database_replaced_by != "":
-		var affected := _find_database_affected_mods()
-		if not affected.is_empty():
-			_log_warning("DATABASE: " + _database_replaced_by + " replaced Database.gd.")
-			_log_warning("  Scene overrides from [" + ", ".join(affected) + "] may not take effect.")
-
-	_analyze_script_conflicts()
 
 	_log_info("============================================")
 	_log_info("")
@@ -2135,8 +1437,12 @@ func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: St
 
 	if resource is PackedScene:
 		var instance: Node = (resource as PackedScene).instantiate()
+		if instance == null:
+			_log_critical("PackedScene.instantiate() returned null: " + autoload_name
+					+ " -> " + res_path + " [" + mod_name + "]")
+			return
 		instance.name = autoload_name
-		get_tree().root.call_deferred("add_child", instance)
+		get_tree().root.add_child(instance)
 		_log_info("Autoload instantiated (scene): " + autoload_name + " [" + mod_name + "]")
 		return
 
@@ -2153,10 +1459,15 @@ func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: St
 			return
 		if inst is Node:
 			(inst as Node).name = autoload_name
-			get_tree().root.call_deferred("add_child", inst as Node)
+			get_tree().root.add_child(inst as Node)
 			_log_info("Autoload instantiated (script): " + autoload_name + " [" + mod_name + "]")
 			return
-		_log_warning("Autoload is not a Node — not added to tree: " + autoload_name)
+		_log_warning("Autoload is not a Node — not added to tree: " + autoload_name
+				+ " [" + mod_name + "]")
+		return
+
+	_log_warning("Autoload is not a PackedScene or GDScript: " + autoload_name
+			+ " -> " + res_path + " [" + mod_name + "]")
 
 
 # ─── Mount helper ─────────────────────────────────────────────────────────────
@@ -2183,18 +1494,31 @@ func _try_mount_pack(path: String) -> bool:
 # ─── mod.txt parser ───────────────────────────────────────────────────────────
 
 func _read_mod_config(path: String) -> ConfigFile:
+	_last_mod_txt_status = "none"
 	var zr := ZIPReader.new()
 	if zr.open(path) != OK:
 		return null
 	if not zr.file_exists("mod.txt"):
+		# Scan for nested mod.txt (e.g. "SubFolder/mod.txt").
+		for f: String in zr.get_files():
+			if f.get_file() == "mod.txt":
+				_last_mod_txt_status = "nested:" + f
+				zr.close()
+				return null
 		zr.close()
 		return null
 	var text := zr.read_file("mod.txt").get_string_from_utf8()
 	zr.close()
-	return _parse_mod_txt(text)
+	var cfg := _parse_mod_txt(text)
+	if cfg == null:
+		_last_mod_txt_status = "parse_error"
+		return null
+	_last_mod_txt_status = "ok"
+	return cfg
 
 
 func _read_mod_config_folder(folder_path: String) -> ConfigFile:
+	_last_mod_txt_status = "none"
 	var mod_txt_path := folder_path.path_join("mod.txt")
 	if not FileAccess.file_exists(mod_txt_path):
 		return null
@@ -2203,7 +1527,12 @@ func _read_mod_config_folder(folder_path: String) -> ConfigFile:
 		return null
 	var text := f.get_as_text()
 	f.close()
-	return _parse_mod_txt(text)
+	var cfg := _parse_mod_txt(text)
+	if cfg == null:
+		_last_mod_txt_status = "parse_error"
+		return null
+	_last_mod_txt_status = "ok"
+	return cfg
 
 
 func _parse_mod_txt(text: String) -> ConfigFile:
@@ -2297,6 +1626,7 @@ func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 	var req := HTTPRequest.new()
 	req.timeout = API_DOWNLOAD_TIMEOUT
+	req.download_body_size_limit = 256 * 1024 * 1024
 	add_child(req)
 	var err := req.request(MODWORKSHOP_DOWNLOAD_URL_TEMPLATE % str(modworkshop_id))
 	if err != OK:

--- a/modloader.gd
+++ b/modloader.gd
@@ -148,7 +148,7 @@ func _ready() -> void:
 	_has_loaded = true
 	await get_tree().process_frame
 	if "--modloader-restart" in OS.get_cmdline_user_args():
-		_run_pass_2()
+		await _run_pass_2()
 	else:
 		await _run_pass_1()
 
@@ -179,7 +179,7 @@ func _run_pass_1() -> void:
 
 	if new_hash == old_hash and not new_hash.is_empty():
 		_log_info("Mod state unchanged — skipping restart")
-		_finish_with_existing_mounts()
+		await _finish_with_existing_mounts()
 		return
 
 	if archive_paths.size() > 0:
@@ -190,10 +190,10 @@ func _run_pass_1() -> void:
 		var err := _write_override_cfg(sections.prepend)
 		if err != OK:
 			_log_critical("Failed to write override.cfg (error %d) — single-pass fallback" % err)
-			_finish_single_pass()
+			await _finish_single_pass()
 			return
 		if _write_pass_state(archive_paths, new_hash) != OK:
-			_finish_single_pass()
+			await _finish_single_pass()
 			return
 		OS.set_restart_on_exit(true, ["--", "--modloader-restart"])
 		get_tree().quit()
@@ -203,7 +203,7 @@ func _run_pass_1() -> void:
 	if FileAccess.file_exists(PASS_STATE_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		_restore_clean_override_cfg()
-	_finish_single_pass()
+	await _finish_single_pass()
 
 func _finish_with_existing_mounts() -> void:
 	for entry in _pending_autoloads:
@@ -1078,6 +1078,8 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 				check_btn.disabled = true
 				var ok := await download_and_replace_mod(full_path, mw_id)
 				if not is_instance_valid(check_btn):
+					return
+				if not is_instance_valid(dl_btn):
 					return
 				check_btn.disabled = false
 				if ok:

--- a/modloader.gd
+++ b/modloader.gd
@@ -14,44 +14,82 @@ const LIFECYCLE_METHODS: Array[String] = [
 	"_input", "_unhandled_input", "_unhandled_key_input",
 ]
 
+# ─── Tuning constants ────────────────────────────────────────────────────────
+
+const OVERLAP_FILE_THRESHOLD := 5       # shared files to flag "Likely Incompatible"
+const OVERLAP_VANILLA_THRESHOLD := 3    # shared vanilla files for critical severity
+const MAX_DISPLAYED_FILENAMES := 6      # truncate file lists in conflict cards
+const MODWORKSHOP_BATCH_SIZE := 100     # mod IDs per API request
+const API_CHECK_TIMEOUT := 15.0         # seconds for version-check requests
+const API_DOWNLOAD_TIMEOUT := 30.0      # seconds for mod download requests
+const PRIORITY_MIN := -999
+const PRIORITY_MAX := 999
+
 # ─── State ────────────────────────────────────────────────────────────────────
 
 var _vanilla_paths: Dictionary = {}
 var _database_path: String = ""
 var _database_replaced_by: String = ""
-var override_registry: Dictionary = {}
+var _override_registry: Dictionary = {}
 var _mod_script_analysis: Dictionary = {}
 var _archive_file_sets: Dictionary = {}
+var _bad_zips: Array[Dictionary] = []      # {mod_name, count, example}
 var _report_lines: Array[String] = []
-var pending_autoloads: Array[Dictionary] = []
-var loaded_mod_ids: Dictionary = {}
-var registered_autoload_names: Dictionary = {}
+var _pending_autoloads: Array[Dictionary] = []
+var _loaded_mod_ids: Dictionary = {}
+var _registered_autoload_names: Dictionary = {}
 
 # Populated before any mounting. Each entry:
 # { file_name, full_path, ext, mod_name, mod_id, priority, enabled, cfg, has_mod_txt }
 var _ui_mod_entries: Array[Dictionary] = []
 
+var _developer_mode: bool = false
+var _has_loaded: bool = false
+var _mods_dir: String = ""
+
 var _re_take_over: RegEx
 var _re_extends: RegEx
+var _re_extends_classname: RegEx
+var _re_class_name: RegEx
 var _re_func: RegEx
+var _re_preload: RegEx
 
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
 
 func _ready() -> void:
+	if _has_loaded:
+		return
+	_has_loaded = true
 	# Autoloads run while the scene tree is still setting up children.
 	# Wait one frame so add_child() and DisplayServer queries work correctly.
 	await get_tree().process_frame
+	_log_info("Metro Mod Loader — exe: " + OS.get_executable_path()
+			+ "  user: " + OS.get_user_data_dir())
 	_compile_regex()
+	_load_developer_mode_setting()
 	_ui_mod_entries = _collect_mod_metadata()
 	_load_ui_config()
 	await _show_mod_ui()
 	_save_ui_config()
 	_load_all_mods()
-	for entry in pending_autoloads:
+	if _developer_mode:
+		_preflight_compile_check()
+	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
-	_print_conflict_summary()
-	_write_conflict_report()
+	if _developer_mode:
+		_log_override_timing_warnings()
+		_print_conflict_summary()
+		_write_conflict_report()
+	# Reload so mounted resource overrides and take_over_path() apply to the scene.
+	# Needed for ALL mods that replace files, not just those with autoloads.
+	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+		get_tree().reload_current_scene()
+		# Wait for the reloaded scene to be ready before auditing override instances.
+		# The modloader persists across reloads (it's an autoload), so this works.
+		if _developer_mode:
+			await get_tree().process_frame
+			_audit_override_instances()
 
 
 func _compile_regex() -> void:
@@ -59,54 +97,103 @@ func _compile_regex() -> void:
 	_re_take_over.compile('take_over_path\\s*\\(\\s*"(res://[^"]+)"')
 	_re_extends = RegEx.new()
 	_re_extends.compile('(?m)^extends\\s+"(res://[^"]+)"')
+	_re_extends_classname = RegEx.new()
+	_re_extends_classname.compile('(?m)^extends\\s+([A-Z]\\w+)\\s*$')
+	_re_class_name = RegEx.new()
+	_re_class_name.compile('(?m)^class_name\\s+(\\w+)')
 	_re_func = RegEx.new()
-	_re_func.compile('(?m)^func\\s+(\\w+)\\s*\\(')
+	_re_func.compile('(?m)^(?:static\\s+)?func\\s+(\\w+)\\s*\\(')
+	_re_preload = RegEx.new()
+	_re_preload.compile('preload\\s*\\(\\s*"(res://[^"]+)"\\s*\\)')
 
 
 # ─── Mod metadata collection (no mounting) ────────────────────────────────────
 
 func _collect_mod_metadata() -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
-	var mods_dir := OS.get_executable_path().get_base_dir().path_join(MOD_DIR)
-	DirAccess.make_dir_recursive_absolute(mods_dir)
-	var dir := DirAccess.open(mods_dir)
+	_mods_dir = OS.get_executable_path().get_base_dir().path_join(MOD_DIR)
+	_log_info("Scanning mods dir: " + _mods_dir)
+	DirAccess.make_dir_recursive_absolute(_mods_dir)
+	var dir := DirAccess.open(_mods_dir)
 	if dir == null:
+		_log_critical("Failed to open mods dir: " + _mods_dir
+				+ " (error " + str(DirAccess.get_open_error()) + ")")
 		return entries
 	var seen: Dictionary = {}
+	var skipped_files: Array[String] = []
 	dir.list_dir_begin()
 	while true:
-		var file_name := dir.get_next()
-		if file_name == "":
+		var entry_name := dir.get_next()
+		if entry_name == "":
 			break
 		if dir.current_is_dir():
+			if _developer_mode and not entry_name.begins_with("."):
+				if not seen.has(entry_name):
+					seen[entry_name] = true
+					entries.append(_build_folder_entry(_mods_dir, entry_name))
 			continue
-		var ext := file_name.get_extension().to_lower()
+		var ext := entry_name.get_extension().to_lower()
 		if ext not in ["vmz", "zip", "pck"]:
+			skipped_files.append(entry_name)
 			continue
-		if seen.has(file_name):
+		if seen.has(entry_name):
 			continue
-		seen[file_name] = true
-		var full_path := mods_dir.path_join(file_name)
-		var cfg: ConfigFile = _read_mod_config(full_path) if ext != "pck" else null
-		var mod_name := file_name
-		var mod_id   := file_name
-		var priority := 0
-		if cfg:
-			mod_name = str(cfg.get_value("mod", "name", file_name))
-			mod_id   = str(cfg.get_value("mod", "id",   file_name))
-			if cfg.has_section_key("mod", "priority"):
-				priority = int(str(cfg.get_value("mod", "priority")))
-		entries.append({
-			"file_name": file_name, "full_path": full_path, "ext": ext,
-			"mod_name": mod_name, "mod_id": mod_id,
-			"priority": priority, "enabled": true,
-			"cfg": cfg, "has_mod_txt": cfg != null,
-		})
+		seen[entry_name] = true
+		entries.append(_build_archive_entry(_mods_dir, entry_name, ext))
 	dir.list_dir_end()
+	if skipped_files.size() > 0:
+		_log_warning("Skipped " + str(skipped_files.size()) + " non-mod file(s) in mods dir:")
+		for sf in skipped_files:
+			_log_warning("  " + sf + "  (not .zip/.vmz/.pck)")
+	if entries.size() == 0:
+		_log_warning("No mods found in: " + _mods_dir)
+	else:
+		_log_info("Found " + str(entries.size()) + " mod(s):")
+		for e in entries:
+			var tag := " [folder]" if e["ext"] == "folder" else ""
+			_log_info("  " + e["file_name"] + " (" + e["mod_name"] + ")" + tag)
 	return entries
 
 
+func _build_archive_entry(mods_dir: String, file_name: String, ext: String) -> Dictionary:
+	var full_path := mods_dir.path_join(file_name)
+	var cfg: ConfigFile = _read_mod_config(full_path) if ext != "pck" else null
+	return _entry_from_config(cfg, file_name, full_path, ext)
+
+
+func _build_folder_entry(mods_dir: String, dir_name: String) -> Dictionary:
+	var folder_path := mods_dir.path_join(dir_name)
+	var cfg: ConfigFile = _read_mod_config_folder(folder_path)
+	return _entry_from_config(cfg, dir_name, folder_path, "folder")
+
+
+func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, ext: String) -> Dictionary:
+	var mod_name := file_name
+	var mod_id   := file_name
+	var priority := 0
+	if cfg:
+		mod_name = str(cfg.get_value("mod", "name", file_name))
+		mod_id   = str(cfg.get_value("mod", "id",   file_name))
+		if cfg.has_section_key("mod", "priority"):
+			priority = int(str(cfg.get_value("mod", "priority")))
+	return {
+		"file_name": file_name, "full_path": full_path, "ext": ext,
+		"mod_name": mod_name, "mod_id": mod_id,
+		"priority": priority, "enabled": true,
+		"cfg": cfg, "has_mod_txt": cfg != null,
+	}
+
+
 # ─── Config persistence ───────────────────────────────────────────────────────
+
+func _load_developer_mode_setting() -> void:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return
+	_developer_mode = bool(cfg.get_value("settings", "developer_mode", false))
+	if _developer_mode:
+		_log_info("Developer mode: ON")
+
 
 func _load_ui_config() -> void:
 	var cfg := ConfigFile.new()
@@ -125,6 +212,7 @@ func _save_ui_config() -> void:
 		var fn: String = entry["file_name"]
 		cfg.set_value("enabled", fn, entry["enabled"])
 		cfg.set_value("priority", fn, entry["priority"])
+	cfg.set_value("settings", "developer_mode", _developer_mode)
 	cfg.save(UI_CONFIG_PATH)
 
 
@@ -188,7 +276,8 @@ func _show_mod_ui() -> void:
 	root.add_child(bottom)
 
 	var hint := Label.new()
-	hint.text = "Enable/disable mods and set load priority, then click Launch.  Higher priority = loads last = wins conflicts."
+	hint.text = "Higher priority = loads last = wins conflicts.  " \
+			+ "Mods: " + ProjectSettings.globalize_path(_mods_dir) + "  (.zip / .vmz / .pck)"
 	hint.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	hint.add_theme_font_size_override("font_size", 11)
@@ -198,20 +287,20 @@ func _show_mod_ui() -> void:
 	var launch_btn := Button.new()
 	launch_btn.text = "  Launch Game  "
 	launch_btn.custom_minimum_size = Vector2(130, 36)
-	var _ls_n := StyleBoxFlat.new()
-	_ls_n.bg_color = Color(0.05, 0.05, 0.05)
-	_ls_n.border_color = Color(0.28, 0.28, 0.28)
-	_ls_n.border_width_top = 1; _ls_n.border_width_bottom = 1
-	_ls_n.border_width_left = 1; _ls_n.border_width_right = 1
-	_ls_n.content_margin_left = 10; _ls_n.content_margin_right = 10
-	launch_btn.add_theme_stylebox_override("normal", _ls_n)
-	var _ls_h := _ls_n.duplicate()
-	_ls_h.bg_color = Color(0.10, 0.10, 0.10)
-	_ls_h.border_color = Color(0.55, 0.55, 0.55)
-	launch_btn.add_theme_stylebox_override("hover", _ls_h)
-	var _ls_p := _ls_n.duplicate()
-	_ls_p.bg_color = Color(0.03, 0.03, 0.03)
-	launch_btn.add_theme_stylebox_override("pressed", _ls_p)
+	var ls_n := StyleBoxFlat.new()
+	ls_n.bg_color = Color(0.05, 0.05, 0.05)
+	ls_n.border_color = Color(0.28, 0.28, 0.28)
+	ls_n.border_width_top = 1; ls_n.border_width_bottom = 1
+	ls_n.border_width_left = 1; ls_n.border_width_right = 1
+	ls_n.content_margin_left = 10; ls_n.content_margin_right = 10
+	launch_btn.add_theme_stylebox_override("normal", ls_n)
+	var ls_h := ls_n.duplicate()
+	ls_h.bg_color = Color(0.10, 0.10, 0.10)
+	ls_h.border_color = Color(0.55, 0.55, 0.55)
+	launch_btn.add_theme_stylebox_override("hover", ls_h)
+	var ls_p := ls_n.duplicate()
+	ls_p.bg_color = Color(0.03, 0.03, 0.03)
+	launch_btn.add_theme_stylebox_override("pressed", ls_p)
 	launch_btn.add_theme_color_override("font_color", Color(0.88, 0.88, 0.88))
 	launch_btn.add_theme_color_override("font_hover_color", Color(1.0, 1.0, 1.0))
 	bottom.add_child(launch_btn)
@@ -223,13 +312,32 @@ func _show_mod_ui() -> void:
 	mods_tab.name = "Mods"
 	tabs.add_child(mods_tab)
 
-	var compat_tab := _build_compat_tab()
-	compat_tab.name = "Compatibility"
-	tabs.add_child(compat_tab)
-
 	var updates_tab := _build_updates_tab()
 	updates_tab.name = "Updates"
 	tabs.add_child(updates_tab)
+
+	var compat_tab := _build_compat_tab()
+	compat_tab.name = "Compatibility"
+	tabs.add_child(compat_tab)
+	var compat_idx := compat_tab.get_index()
+	tabs.set_tab_hidden(compat_idx, not _developer_mode)
+
+	var rebuild_mods_tab := func():
+		_ui_mod_entries = _collect_mod_metadata()
+		_load_ui_config()
+		var old := tabs.get_node("Mods")
+		var idx := old.get_index()
+		tabs.remove_child(old)
+		old.queue_free()
+		var new_tab := _build_mods_tab()
+		new_tab.name = "Mods"
+		tabs.add_child(new_tab)
+		tabs.move_child(new_tab, idx)
+		tabs.current_tab = tabs.get_node("Settings").get_index()
+
+	var settings_tab := _build_settings_tab(tabs, compat_idx, rebuild_mods_tab)
+	settings_tab.name = "Settings"
+	tabs.add_child(settings_tab)
 
 	await launch_btn.pressed
 	win.queue_free()
@@ -238,11 +346,10 @@ func _show_mod_ui() -> void:
 func _make_dark_theme() -> Theme:
 	var t := Theme.new()
 
-	const C_BG    := Color(0.02, 0.02, 0.02)
 	const C_PANEL := Color(0.04, 0.04, 0.04)
 	const C_BTN   := Color(0.07, 0.07, 0.07)
 	const C_BORD  := Color(0.18, 0.18, 0.18)
-	const C_OLIVE := Color(0.90, 0.90, 0.90)
+	const C_HI    := Color(0.90, 0.90, 0.90)
 	const C_TEXT  := Color(0.84, 0.84, 0.84)
 	const C_DIM   := Color(0.42, 0.42, 0.42)
 
@@ -255,7 +362,7 @@ func _make_dark_theme() -> Theme:
 	bn.content_margin_left = 8; bn.content_margin_right = 8
 	bn.content_margin_top = 3; bn.content_margin_bottom = 3
 	var bh := bn.duplicate()
-	bh.bg_color = Color(0.10, 0.10, 0.10); bh.border_color = C_OLIVE
+	bh.bg_color = Color(0.10, 0.10, 0.10); bh.border_color = C_HI
 	var bp := bn.duplicate(); bp.bg_color = Color(0.03, 0.03, 0.03)
 	var bd := bn.duplicate()
 	bd.bg_color = Color(0.04, 0.04, 0.04); bd.border_color = Color(0.12, 0.12, 0.12)
@@ -302,7 +409,7 @@ func _make_dark_theme() -> Theme:
 	t.set_stylebox("tab_unselected", "TabContainer", tu)
 	t.set_stylebox("tab_hovered",    "TabContainer", tu.duplicate())
 	t.set_stylebox("panel",          "TabContainer", tc_panel)
-	t.set_color("font_selected_color",   "TabContainer", C_OLIVE)
+	t.set_color("font_selected_color",   "TabContainer", C_HI)
 	t.set_color("font_unselected_color", "TabContainer", C_DIM)
 	t.set_color("font_hovered_color",    "TabContainer", C_TEXT)
 
@@ -330,9 +437,26 @@ func _make_dark_theme() -> Theme:
 
 
 func _build_mods_tab() -> Control:
+	var outer := VBoxContainer.new()
+	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+	var toolbar := HBoxContainer.new()
+	toolbar.add_theme_constant_override("separation", 8)
+	outer.add_child(toolbar)
+
+	var open_btn := Button.new()
+	open_btn.text = "Open Mods Folder"
+	toolbar.add_child(open_btn)
+	open_btn.pressed.connect(func():
+		OS.shell_open(ProjectSettings.globalize_path(_mods_dir))
+	)
+
+	outer.add_child(HSeparator.new())
+
 	var split := HSplitContainer.new()
 	split.split_offset = 560
 	split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	outer.add_child(split)
 
 	# ── Left: mod list ────────────────────────────────────────────────────────
 
@@ -423,6 +547,15 @@ func _build_mods_tab() -> Control:
 
 	# ── One row per mod ───────────────────────────────────────────────────────
 
+	if _ui_mod_entries.is_empty():
+		var empty := Label.new()
+		empty.text = "No mods found.\n\nPlace .zip, .vmz, or .pck files in:\n" \
+				+ ProjectSettings.globalize_path(_mods_dir)
+		empty.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		empty.modulate = Color(0.5, 0.5, 0.5)
+		empty.add_theme_font_size_override("font_size", 12)
+		list.add_child(empty)
+
 	for entry in _ui_mod_entries:
 		var row := HBoxContainer.new()
 		list.add_child(row)
@@ -442,6 +575,12 @@ func _build_mods_tab() -> Control:
 		name_lbl.modulate = Color(0.58, 0.82, 0.38) if entry["enabled"] else Color(0.5, 0.5, 0.5)
 		name_col.add_child(name_lbl)
 
+		if entry["ext"] == "folder":
+			var dev_lbl := Label.new()
+			dev_lbl.text = "[dev folder]"
+			dev_lbl.modulate = Color(0.9, 0.3, 0.3)
+			dev_lbl.add_theme_font_size_override("font_size", 11)
+			name_col.add_child(dev_lbl)
 		if not entry["has_mod_txt"]:
 			var warn := Label.new()
 			warn.text = "no mod.txt — mount only"
@@ -450,8 +589,8 @@ func _build_mods_tab() -> Control:
 			name_col.add_child(warn)
 
 		var spin := SpinBox.new()
-		spin.min_value = -999
-		spin.max_value = 999
+		spin.min_value = PRIORITY_MIN
+		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
 		row.add_child(spin)
@@ -472,7 +611,7 @@ func _build_mods_tab() -> Control:
 		)
 
 	refresh_order.call()
-	return split
+	return outer
 
 
 func _build_compat_tab() -> Control:
@@ -491,7 +630,7 @@ func _build_compat_tab() -> Control:
 	container.add_child(toolbar)
 
 	var info := Label.new()
-	info.text = "Reads archives without mounting — shows predicted conflicts for the current load order."
+	info.text = "Dry-scans enabled archives without mounting. Shows override conflicts, broken chains, and crash risks."
 	info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	info.add_theme_font_size_override("font_size", 12)
 	info.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -644,12 +783,21 @@ func _build_compat_tab() -> Control:
 # calls the populate callback with structured issue data for the UI.
 # The main _report_lines array is swapped out so dry-run noise doesn't
 # pollute the real launch log.
+#
+# IMPORTANT: This calls _scan_and_register_archive_claims (read-only scan via
+# ZIPReader) — NOT _process_mod_candidate (which mounts packs and queues
+# autoloads). Calling _process_mod_candidate here would have side effects
+# that corrupt the real launch. _load_all_mods() clears all state before the
+# real load, so stale dry-analysis data does not leak.
 func _run_dry_compat_analysis(populate_cb: Callable) -> void:
-	override_registry.clear()
+	_override_registry.clear()
 	_mod_script_analysis.clear()
 	_archive_file_sets.clear()
+	_bad_zips.clear()
 	_database_replaced_by = ""
 	_database_path = ""
+	_scan_vanilla_paths()
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
 	var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
 	sorted.sort_custom(func(a, b): return a["priority"] < b["priority"])
@@ -664,7 +812,12 @@ func _run_dry_compat_analysis(populate_cb: Callable) -> void:
 
 	for i in sorted.size():
 		var entry: Dictionary = sorted[i]
-		_scan_and_register_archive_claims(entry["full_path"], entry["mod_name"], entry["file_name"], i)
+		var scan_path: String = entry["full_path"]
+		if entry["ext"] == "folder":
+			scan_path = _zip_folder_to_temp(entry["full_path"])
+			if scan_path == "":
+				continue
+		_scan_and_register_archive_claims(scan_path, entry["mod_name"], entry["file_name"], i)
 
 	var issues := _collect_conflict_issues()
 	_report_lines = saved_lines
@@ -858,6 +1011,52 @@ func _build_updates_tab() -> Control:
 	return margin
 
 
+func _build_settings_tab(tabs: TabContainer, compat_idx: int, rebuild_mods_tab: Callable) -> Control:
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_top", 6)
+	margin.add_theme_constant_override("margin_bottom", 6)
+
+	var container := VBoxContainer.new()
+	container.add_theme_constant_override("separation", 8)
+	margin.add_child(container)
+
+	var hdr := Label.new()
+	hdr.text = "Developer Mode"
+	hdr.add_theme_font_size_override("font_size", 13)
+	container.add_child(hdr)
+	container.add_child(HSeparator.new())
+
+	var dev_check := CheckBox.new()
+	dev_check.text = "Enable Developer Mode"
+	dev_check.button_pressed = _developer_mode
+	container.add_child(dev_check)
+
+	var desc := Label.new()
+	desc.text = "Enables:\n" \
+			+ "  - Compatibility tab (scan for override conflicts without launching)\n" \
+			+ "  - Compile check (loads each override script to catch parse errors early)\n" \
+			+ "  - Override audit (warns if overrideScript() targets have 0 live nodes)\n" \
+			+ "  - Conflict report saved to modloader_conflicts.txt after each launch\n" \
+			+ "  - Verbose [Debug] logging for load order, timing, and override state\n" \
+			+ "  - Loose mod folders loaded from the mods directory\n" \
+			+ "\nOff by default — adds ~1s to launch for scanning."
+	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc.add_theme_font_size_override("font_size", 11)
+	desc.modulate = Color(0.5, 0.5, 0.5)
+	desc.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	container.add_child(desc)
+
+	dev_check.toggled.connect(func(on: bool):
+		_developer_mode = on
+		tabs.set_tab_hidden(compat_idx, not on)
+		rebuild_mods_tab.call()
+	)
+
+	return margin
+
+
 func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn: Button) -> void:
 	var ids: Array[int] = []
 	for fn in status_info:
@@ -904,7 +1103,7 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 				var ok := await _download_and_replace_mod(full_path, mw_id)
 				check_btn.disabled = false
 				if ok:
-					lbl.text = "updated!"
+					lbl.text = "updated — restart to apply"
 					lbl.modulate = Color(0.80, 0.80, 0.80)
 					dl_btn.modulate.a = 0.0
 					dl_btn.disabled = true
@@ -913,7 +1112,7 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 					# Update cached version so next Check won't re-flag this mod.
 					info["version"] = new_ver
 					(info["ver_lbl"] as Label).text = "v" + new_ver
-					add_log.call(mod_name + " — updated to v" + new_ver + ".")
+					add_log.call(mod_name + " — updated to v" + new_ver + ". Restart game to apply.")
 				else:
 					lbl.text = "download failed"
 					lbl.modulate = Color(1.0, 0.4, 0.4)
@@ -926,16 +1125,18 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 # ─── Main load loop ───────────────────────────────────────────────────────────
 
 func _load_all_mods() -> void:
-	pending_autoloads.clear()
-	loaded_mod_ids.clear()
-	registered_autoload_names.clear()
-	override_registry.clear()
+	_pending_autoloads.clear()
+	_loaded_mod_ids.clear()
+	_registered_autoload_names.clear()
+	_override_registry.clear()
 	_report_lines.clear()
 	_database_replaced_by = ""
 	_mod_script_analysis.clear()
 	_archive_file_sets.clear()
+	_bad_zips.clear()
 
-	_scan_vanilla_paths()
+	if _developer_mode:
+		_scan_vanilla_paths()
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
 	# Build the candidate list from UI-configured entries (already filtered and trusted).
@@ -961,6 +1162,40 @@ func _load_all_mods() -> void:
 		_process_mod_candidate(candidates[load_index], load_index)
 
 
+# Try to load() each .gd file from mounted archives that extends a vanilla script.
+# Catches real Godot compile errors with zero false positives.
+func _preflight_compile_check() -> void:
+	var checked := 0
+	var fail_count := 0
+	for archive_name: String in _archive_file_sets:
+		var file_set: Dictionary = _archive_file_sets[archive_name]
+		for res_path: String in file_set:
+			if not (res_path as String).ends_with(".gd"): continue
+			# Look up which mod owns this file to get its extends_paths.
+			if not _override_registry.has(res_path): continue
+			var owner_name: String = (_override_registry[res_path][0] as Dictionary)["mod_name"]
+			if not _mod_script_analysis.has(owner_name): continue
+			var analysis: Dictionary = _mod_script_analysis[owner_name]
+			# Only check scripts that extend another script (override scripts).
+			if (analysis["extends_paths"] as Array).is_empty(): continue
+			# Try to compile. Check both load() returning null AND whether
+			# the script can actually be instantiated (catches broken but non-null scripts).
+			checked += 1
+			var script: Resource = load(res_path)
+			var failed := script == null
+			if not failed and script is GDScript:
+				failed = not (script as GDScript).can_instantiate()
+			if failed:
+				fail_count += 1
+				_log_critical("Pre-flight: " + owner_name + " — " + res_path
+						+ " failed to compile. See error above.")
+	if fail_count > 0:
+		_log_warning("Pre-flight: " + str(fail_count) + " of " + str(checked)
+				+ " override script(s) failed to compile.")
+	elif checked > 0:
+		_log_info("Pre-flight: " + str(checked) + " override script(s) compiled OK.")
+
+
 func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var file_name: String = c["file_name"]
 	var full_path: String = c["full_path"]
@@ -971,25 +1206,46 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	_log_info("--- [" + str(load_index + 1) + "] " + mod_name + " (" + file_name + ")")
 
-	if ext != "pck" and loaded_mod_ids.has(mod_id):
+	if ext != "pck" and _loaded_mod_ids.has(mod_id):
 		_log_warning("Duplicate mod id '" + mod_id + "' — skipped: " + file_name)
 		return
 
-	if not _try_mount_pack(full_path):
-		_log_critical("Failed to mount: " + file_name)
+	var mount_path := full_path
+	if ext == "folder":
+		mount_path = _zip_folder_to_temp(full_path)
+		if mount_path == "":
+			_log_critical("Failed to zip folder: " + file_name)
+			return
+
+	if not _try_mount_pack(mount_path):
+		_log_critical("Failed to mount: " + file_name + " (path: " + mount_path + ")")
 		return
 
 	_log_info("  Mounted OK")
+	_log_debug("  Mount path: " + mount_path)
 
 	if ext != "pck":
-		_scan_and_register_archive_claims(full_path, mod_name, file_name, load_index)
+		var scan_path := mount_path if ext == "folder" else full_path
+		_scan_and_register_archive_claims(scan_path, mod_name, file_name, load_index)
+		# Verify mount actually worked — check if at least one file is accessible.
+		# Debug-only: FileAccess/ResourceLoader checks are unreliable for mounted
+		# archives on some systems, so this is diagnostic info, not an error.
+		if _developer_mode and _archive_file_sets.has(file_name):
+			var verified := false
+			for res_path: String in _archive_file_sets[file_name]:
+				if FileAccess.file_exists(res_path) or ResourceLoader.exists(res_path):
+					verified = true
+					break
+			if not verified and _archive_file_sets[file_name].size() > 0:
+				_log_debug("  Mount verification: no files accessible via FileAccess/ResourceLoader (may be normal)")
+				_log_debug("  Will attempt load() directly when needed")
 
 	if ext == "pck" or not c["has_mod_txt"]:
 		if not c["has_mod_txt"] and ext != "pck":
 			_log_warning("  No mod.txt — autoloads skipped")
 		return
 
-	loaded_mod_ids[mod_id] = true
+	_loaded_mod_ids[mod_id] = true
 
 	if cfg == null or not cfg.has_section("autoload"):
 		return
@@ -997,18 +1253,31 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var keys: PackedStringArray = cfg.get_section_keys("autoload")
 	for key in keys:
 		var autoload_name := str(key)
-		var res_path := str(cfg.get_value("autoload", key))
+		var res_path := str(cfg.get_value("autoload", key)).lstrip("*").strip_edges()
 
-		if registered_autoload_names.has(autoload_name):
+		if res_path == "":
+			_log_warning("  Empty autoload path for '" + autoload_name + "' — skipped")
+			continue
+
+		if _registered_autoload_names.has(autoload_name):
 			_log_warning("Duplicate autoload name '" + autoload_name + "' — skipped")
 			continue
-		registered_autoload_names[autoload_name] = true
+		_registered_autoload_names[autoload_name] = true
 
 		if _archive_file_sets.has(file_name) and not _archive_file_sets[file_name].has(res_path):
 			_log_critical("  Autoload path not found in archive: " + res_path)
 			_log_critical("    Declared in mod.txt but missing from: " + file_name)
+			# Log similar paths to help mod authors diagnose typos / case mismatches.
+			var similar: Array[String] = []
+			var target_file := res_path.get_file().to_lower()
+			for p: String in _archive_file_sets[file_name]:
+				if p.get_file().to_lower() == target_file:
+					similar.append(p)
+			if similar.size() > 0:
+				_log_critical("    Similar paths in archive: " + ", ".join(similar))
+			continue
 
-		pending_autoloads.append({ "mod_name": mod_name, "name": autoload_name, "path": res_path })
+		_pending_autoloads.append({ "mod_name": mod_name, "name": autoload_name, "path": res_path })
 		_log_info("  Autoload queued: " + autoload_name + " -> " + res_path)
 		_register_claim(res_path, mod_name, file_name, load_index, "autoload")
 
@@ -1020,10 +1289,12 @@ func _log_info(msg: String) -> void:
 	print(line)
 	_report_lines.append(line)
 
+
 func _log_warning(msg: String) -> void:
 	var line := "[ModLoader][Warning] " + msg
 	push_warning(line)
 	_report_lines.append(line)
+
 
 func _log_critical(msg: String) -> void:
 	var line := "[ModLoader][Critical] " + msg
@@ -1031,16 +1302,24 @@ func _log_critical(msg: String) -> void:
 	_report_lines.append(line)
 
 
+func _log_debug(msg: String) -> void:
+	if not _developer_mode:
+		return
+	var line := "[ModLoader][Debug] " + msg
+	print(line)
+	_report_lines.append(line)
+
+
 # ─── Override registry ────────────────────────────────────────────────────────
 
 func _register_claim(res_path: String, mod_name: String, archive: String,
 		load_index: int, claim_type: String, source_path: String = "") -> void:
-	if not override_registry.has(res_path):
-		override_registry[res_path] = []
-	for existing in override_registry[res_path]:
+	if not _override_registry.has(res_path):
+		_override_registry[res_path] = []
+	for existing in _override_registry[res_path]:
 		if existing["mod_name"] == mod_name and existing["archive"] == archive:
 			return
-	override_registry[res_path].append({
+	_override_registry[res_path].append({
 		"mod_name": mod_name, "archive": archive, "load_index": load_index,
 		"claim_type": claim_type, "source_path": source_path,
 	})
@@ -1085,7 +1364,7 @@ func _scan_vanilla_dir(dir_path: String) -> void:
 			break
 		if entry.begins_with("."):
 			continue
-		var full := dir_path + "/" + entry
+		var full := dir_path.path_join(entry)
 		if dir.current_is_dir():
 			_scan_vanilla_dir(full)
 		elif entry.get_extension().to_lower() in TRACKED_EXTENSIONS:
@@ -1114,6 +1393,7 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 			if example_bad == "":
 				example_bad = f
 	if backslash_count > 0:
+		_bad_zips.append({"mod_name": mod_name, "count": backslash_count, "example": example_bad})
 		_log_critical("  BAD ZIP: " + str(backslash_count) + " entries use Windows backslash paths.")
 		_log_critical("    Re-pack with 7-Zip. Example bad entry: '" + example_bad + "'")
 
@@ -1126,13 +1406,19 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		"uses_dynamic_override":   false,
 		"lifecycle_no_super":      [],
 		"calls_update_tooltip":    false,
+		"class_names":             [],
+		"extends_class_names":     [],
+		"override_methods":        {},   # extends_path -> Array[method_name]
+		"preload_paths":           [],
+		"calls_base":              false, # uses base() instead of super() — Godot 3 or removed method
 		"total_gd_files":          0,
 	}
 
 	for f in files:
 		if f.get_extension().to_lower() == "gd":
 			gd_analysis["total_gd_files"] = gd_analysis["total_gd_files"] + 1
-			_scan_gd_source(zr.read_file(f).get_string_from_utf8(), gd_analysis)
+			if _developer_mode:
+				_scan_gd_source(zr.read_file(f).get_string_from_utf8(), gd_analysis)
 
 		var res_path := _normalize_to_res_path(f)
 		if res_path == "":
@@ -1197,6 +1483,19 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 		if path not in (analysis["extends_paths"] as Array):
 			(analysis["extends_paths"] as Array).append(path)
 
+	# Detect extends via class_name (e.g. "extends Weapon") — breaks override chains.
+	var m_ext_cn := _re_extends_classname.search(text)
+	if m_ext_cn:
+		var cn := m_ext_cn.get_string(1)
+		if cn not in (analysis["extends_class_names"] as Array):
+			(analysis["extends_class_names"] as Array).append(cn)
+
+	# Detect class_name declarations — Godot bug #83542: can only be overridden once.
+	for m_cn in _re_class_name.search_all(text):
+		var cn := m_cn.get_string(1)
+		if cn not in (analysis["class_names"] as Array):
+			(analysis["class_names"] as Array).append(cn)
+
 	if not analysis["uses_dynamic_override"]:
 		analysis["uses_dynamic_override"] = "get_base_script()" in text \
 				or "take_over_path(parentScript" in text
@@ -1206,11 +1505,38 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 	if not analysis["calls_update_tooltip"]:
 		analysis["calls_update_tooltip"] = "UpdateTooltip" in text
 
-	# Check each overridden lifecycle method for super(). Missing it silently breaks
-	# any overrideScript() chain — earlier mods' versions of that method never run.
+	# Detect base() calls — Godot 3 pattern or removed parent method.
+	if not analysis["calls_base"]:
+		analysis["calls_base"] = "base(" in text
+
+	# Collect preload() paths for stale-cache detection.
+	for m_pl in _re_preload.search_all(text):
+		var pl_path := m_pl.get_string(1)
+		if pl_path not in (analysis["preload_paths"] as Array):
+			(analysis["preload_paths"] as Array).append(pl_path)
+
+	# Collect ALL method declarations. If this file extends a vanilla script,
+	# track which methods it overrides — this is the key data for method-level
+	# collision detection between mods.
 	var func_matches := _re_func.search_all(text)
+
+	# Determine the extends target for this file (if any).
+	var ext_target := ""
+	if m_ext:
+		ext_target = m_ext.get_string(1)
+
 	for i in func_matches.size():
 		var func_name := func_matches[i].get_string(1)
+
+		# Track method names per extends target for collision detection.
+		if ext_target != "":
+			if not (analysis["override_methods"] as Dictionary).has(ext_target):
+				(analysis["override_methods"] as Dictionary)[ext_target] = []
+			var method_list: Array = (analysis["override_methods"] as Dictionary)[ext_target]
+			if func_name not in method_list:
+				method_list.append(func_name)
+
+		# Check lifecycle methods for super(). Missing it breaks the override chain.
 		if func_name not in LIFECYCLE_METHODS:
 			continue
 		var body_start := func_matches[i].get_end()
@@ -1223,100 +1549,34 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 
 
 func _analyze_script_conflicts() -> void:
-	if _mod_script_analysis.is_empty():
-		return
+	var issues := _collect_conflict_issues()
+	for issue: Dictionary in issues:
+		var sev: String = issue["severity"]
+		var log_fn := _log_info if sev == "info" else (_log_critical if sev == "critical" else _log_warning)
+		log_fn.call(issue["title"] + " — " + ", ".join(issue["mods"]))
 
-	# 1. Literal take_over_path conflicts
-	var literal_claims: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		for path in (_mod_script_analysis[mod_name]["take_over_literal_paths"] as Array):
-			if not literal_claims.has(path): literal_claims[path] = []
-			if mod_name not in literal_claims[path]:
-				(literal_claims[path] as Array).append(mod_name)
 
-	var found_literal := false
-	for path: String in literal_claims:
-		var mods: Array = literal_claims[path]
-		if mods.size() <= 1: continue
-		if not found_literal:
-			_log_info("")
-			_log_info("--- Script Injection Conflicts ---")
-			found_literal = true
-		_log_critical("CONFLICT: take_over_path(\"" + path + "\") used by: " + ", ".join(mods))
-		_log_critical("  Last-loaded mod wins. Use priority= in mod.txt to set order.")
-		_log_critical("  EA: coordinate with the other author, or wait for official hook support.")
-
-	# 2. Dynamic override chains — CHAIN OK if all mods call super(), CHAIN BROKEN if not.
-	var extends_claims: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		if not analysis["uses_dynamic_override"]: continue
-		for path in (analysis["extends_paths"] as Array):
-			if not extends_claims.has(path): extends_claims[path] = []
-			if mod_name not in extends_claims[path]:
-				(extends_claims[path] as Array).append(mod_name)
-
-	var found_extends := false
-	for path: String in extends_claims:
-		var claimants: Array = extends_claims[path]
-		if claimants.size() <= 1: continue
-		if not found_extends:
-			_log_info("")
-			_log_info("--- Dynamic Override Chains ---")
-			found_extends = true
-		var all_super := true
-		for cmod: String in claimants:
-			if not (_mod_script_analysis[cmod]["lifecycle_no_super"] as Array).is_empty():
-				all_super = false
-				break
-		if all_super:
-			_log_info("CHAIN OK: " + " -> ".join(claimants) + " -> vanilla  (" + path + ")")
-		else:
-			_log_warning("CHAIN BROKEN: " + path + " — " + ", ".join(claimants))
-			_log_warning("  At least one mod skips super() so earlier mods' logic is dropped.")
-			_log_warning("  Fix: add super() in lifecycle methods, or use priority= for order.")
-
-	# 3. Overhaul mods
-	for mod_name: String in _mod_script_analysis:
-		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		var total: int = (analysis["take_over_literal_paths"] as Array).size() \
-				+ (analysis["extends_paths"] as Array).size()
-		if total >= 5:
-			_log_warning("OVERHAUL: " + mod_name + " overrides " + str(total)
-					+ " core scripts — likely incompatible with other overhaul mods.")
-			_log_warning("  EA: needs refactoring to hooks/subclasses for official mod support.")
-
-	# 4. UpdateTooltip() misuse
-	var found_tooltip := false
-	for mod_name: String in _mod_script_analysis:
-		if not _mod_script_analysis[mod_name]["calls_update_tooltip"]: continue
-		if not found_tooltip:
-			_log_info("")
-			_log_info("--- UpdateTooltip() Warning ---")
-			found_tooltip = true
-		_log_warning("TOOLTIP: " + mod_name + " uses UpdateTooltip()")
-		_log_warning("  UpdateTooltip() is inventory-UI only — does not affect world-item tooltips.")
-
-	# 5. Lifecycle overrides without super()
-	var found_no_super := false
-	for mod_name: String in _mod_script_analysis:
-		var no_super: Array = _mod_script_analysis[mod_name]["lifecycle_no_super"]
-		if no_super.is_empty(): continue
-		if not found_no_super:
-			_log_info("")
-			_log_info("--- Missing super() in Lifecycle Methods ---")
-			found_no_super = true
-		_log_warning("NO SUPER: " + mod_name + " — " + ", ".join(no_super))
-		_log_warning("  Breaks overrideScript() chains. Add super() to preserve other mods' logic.")
+func _find_database_affected_mods() -> Array[String]:
+	var affected: Array[String] = []
+	for res_path: String in _override_registry:
+		if res_path == _database_path: continue
+		var lower := res_path.to_lower()
+		if not (lower.ends_with(".tscn") or lower.ends_with(".scn")): continue
+		# Only count scene overrides that replace vanilla files. A mod shipping its
+		# own scenes under mods/MyMod/ is not affected by Database preload caching.
+		if not _is_dangerous_path(res_path): continue
+		for claim in (_override_registry[res_path] as Array):
+			var cn: String = claim["mod_name"]
+			if cn != _database_replaced_by and cn not in affected:
+				affected.append(cn)
+	return affected
 
 
 # Returns structured issue data for the compatibility tab UI. Operates on
-# whatever state is currently in _mod_script_analysis and override_registry
-# (populated by _scan_and_register_archive_claims). Does not log anything.
+# whatever state is currently in _mod_script_analysis and _override_registry
+# (populated by _scan_and_register_archive_claims).
 func _collect_conflict_issues() -> Array[Dictionary]:
 	var issues: Array[Dictionary] = []
-	if _mod_script_analysis.is_empty():
-		return issues
 
 	# 1. Literal take_over_path() conflicts — only one version of that script can be active.
 	var literal_claims: Dictionary = {}
@@ -1333,9 +1593,11 @@ func _collect_conflict_issues() -> Array[Dictionary]:
 			"severity": "critical",
 			"title": "Script Conflict: " + path.get_file(),
 			"what": "Both mods call take_over_path() on the same script:\n  " + path
-					+ "\n\nOnly the last-loaded mod's version will be active. The other is silently replaced.",
-			"fix": "Set priority= in mod.txt to control which mod loads last — the higher value wins.\n"
-					+ "Long-term fix: mod authors need to coordinate, or switch to the extends + super() pattern.",
+					+ "\n\nOnly the last-loaded version is active. The other mod's "
+					+ "changes to this script are silently replaced.",
+			"fix": "Use priority to control which mod wins (higher = loads last = wins).\n\n"
+					+ "To fix: one mod should switch to the extends + super() pattern "
+					+ "so both can coexist in a chain.",
 			"mods": mods,
 		})
 
@@ -1357,101 +1619,382 @@ func _collect_conflict_issues() -> Array[Dictionary]:
 			if not (_mod_script_analysis[cmod]["lifecycle_no_super"] as Array).is_empty():
 				bad_mods.append(cmod)
 		if bad_mods.is_empty():
-			issues.append({
-				"severity": "info",
-				"title": "Chain OK: " + path.get_file(),
-				"what": "Multiple mods override the same script using the extends + super() pattern:\n  "
-						+ path + "\n\nAll mods call super() so they compose correctly.",
-				"fix": "No action needed. This is the correct multi-mod pattern.",
-				"mods": claimants,
-			})
-		else:
-			issues.append({
-				"severity": "warning",
-				"title": "Chain Broken: " + path.get_file(),
-				"what": "Multiple mods override the same script using extends + super(), but at least one "
-						+ "skips super() in lifecycle methods.\n\nMods that loaded earlier will have their "
-						+ "logic silently dropped for those methods.",
-				"fix": "These mods need to add super() to their lifecycle methods:\n  "
-						+ ", ".join(bad_mods)
-						+ "\n\nAlternatively, set a lower priority for the broken mod so it loads first.",
-				"mods": claimants,
-			})
+			continue
+		var bad_methods: Array[String] = []
+		for bm: String in bad_mods:
+			var methods: Array = _mod_script_analysis[bm]["lifecycle_no_super"]
+			bad_methods.append(bm + " (" + ", ".join(methods) + ")")
+		issues.append({
+			"severity": "warning",
+			"title": "Chain Broken: " + path.get_file(),
+			"what": "These mods both override " + path.get_file() + " using extends, "
+					+ "but " + ", ".join(bad_mods) + " is missing super() calls:\n  "
+					+ "\n  ".join(bad_methods)
+					+ "\n\nWithout super(), the override chain breaks — other mods' logic "
+					+ "for those methods never runs.",
+			"fix": "Workaround: give " + ", ".join(bad_mods)
+					+ " a lower priority so it loads first (limits the damage).\n\n"
+					+ "Fix: add super() at the start of each listed method.",
+			"mods": claimants,
+		})
 
-	# 3. Overhaul mods — 5+ core script overrides means near-certain incompatibility with others.
+	# 2b. Informational card for overrideScript() mods — even without chain conflicts,
+	# mod authors need to understand the timing constraint.
 	for mod_name: String in _mod_script_analysis:
 		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		var total: int = (analysis["take_over_literal_paths"] as Array).size() \
-				+ (analysis["extends_paths"] as Array).size()
-		if total < 5: continue
+		if not analysis["uses_dynamic_override"]:
+			continue
+		var targets: Array = analysis["extends_paths"]
+		if targets.is_empty():
+			continue
+		# Skip if this mod already appeared in a chain conflict above.
+		var already_flagged := false
+		for iss in issues:
+			if mod_name in (iss["mods"] as Array) and "Chain" in (iss["title"] as String):
+				already_flagged = true
+				break
+		if already_flagged:
+			continue
+		var target_list := ", ".join(targets.map(func(p): return (p as String).get_file()))
 		issues.append({
-			"severity": "warning",
-			"title": "Overhaul Mod: " + mod_name,
-			"what": mod_name + " overrides " + str(total) + " core scripts. Overhaul mods have a "
-					+ "large surface area and are almost certainly incompatible with other overhaul mods.",
-			"fix": "Only run one overhaul mod at a time. Check whether any other installed mods are also overhauls.",
+			"severity": "info",
+			"title": "Uses overrideScript(): " + mod_name,
+			"what": mod_name + " uses overrideScript() to extend:\n  " + target_list
+					+ "\n\noverrideScript() only affects nodes instantiated after the "
+					+ "override is registered. Nodes already in the scene tree at launch "
+					+ "(e.g. containers, HUD elements) will keep the original script.",
+			"fix": "This is expected behavior, not a bug. If the mod doesn't seem to "
+					+ "work, check that its target nodes are spawned at runtime rather "
+					+ "than placed in the scene at export time.\n\n"
+					+ "Enable Developer Mode and check the conflict report for "
+					+ "'Override registered but 0 matching nodes found' warnings.",
 			"mods": [mod_name],
 		})
 
-	# 4. UpdateTooltip() misuse — inventory-UI only, no effect on world-item tooltips.
-	for mod_name: String in _mod_script_analysis:
-		if not _mod_script_analysis[mod_name]["calls_update_tooltip"]: continue
-		issues.append({
-			"severity": "warning",
-			"title": "UpdateTooltip(): " + mod_name,
-			"what": mod_name + " overrides UpdateTooltip(), which only fires for inventory UI.\n\n"
-					+ "World-item tooltip text is written directly by HUD._physics_process from "
-					+ "gameData.tooltip. UpdateTooltip() has no effect on what you see when looking "
-					+ "at items on the ground.",
-			"fix": "If the intent is to change world-item tooltips, the mod author needs to override "
-					+ "HUD._physics_process instead of UpdateTooltip().",
-			"mods": [mod_name],
-		})
+	# 3. File overlap grouped by mod pair — one card per conflicting pair, not per file.
+	# Build per-mod path sets from the override registry.
+	var mod_paths: Dictionary = {}  # mod_name -> Dictionary of res_paths
+	for res_path: String in _override_registry:
+		var claims: Array = _override_registry[res_path]
+		for claim in claims:
+			var mn: String = claim["mod_name"]
+			if not mod_paths.has(mn):
+				mod_paths[mn] = {}
+			(mod_paths[mn] as Dictionary)[res_path] = true
 
-	# 5. Lifecycle methods without super() — silently breaks overrideScript() chains.
-	for mod_name: String in _mod_script_analysis:
-		var no_super: Array = _mod_script_analysis[mod_name]["lifecycle_no_super"]
-		if no_super.is_empty(): continue
-		issues.append({
-			"severity": "warning",
-			"title": "Missing super(): " + mod_name,
-			"what": mod_name + " overrides lifecycle method(s) without calling super():\n  "
-					+ ", ".join(no_super)
-					+ "\n\nThis silently drops any other mod's logic for those methods from the call chain.",
-			"fix": "Add super() at the start of each listed method in " + mod_name + ".\n"
-					+ "If the mod intentionally replaces rather than extends, set a high priority "
-					+ "so it loads last.",
-			"mods": [mod_name],
-		})
+	# Compare every pair of mods for shared files.
+	var mod_list: Array = mod_paths.keys()
+	var seen_pairs: Dictionary = {}
+	for i in mod_list.size():
+		for j in range(i + 1, mod_list.size()):
+			var mod_a: String = mod_list[i]
+			var mod_b: String = mod_list[j]
+			var pair_key := mod_a + "|" + mod_b
+			if seen_pairs.has(pair_key): continue
+			seen_pairs[pair_key] = true
 
-	# 6. Database.gd replaced — preload() caches paths before resource overrides take effect.
+			var shared: Array[String] = []
+			var shared_vanilla: Array[String] = []
+			for p: String in (mod_paths[mod_a] as Dictionary):
+				if (mod_paths[mod_b] as Dictionary).has(p):
+					shared.append(p)
+					if _is_dangerous_path(p):
+						shared_vanilla.append(p)
+
+			if shared.is_empty(): continue
+
+			# Build a readable list of conflicting filenames.
+			var file_names: Array[String] = []
+			for p in shared:
+				var fname: String = p.get_file()
+				if fname not in file_names:
+					file_names.append(fname)
+			file_names.sort()
+			var file_list := ", ".join(file_names)
+			if file_names.size() > MAX_DISPLAYED_FILENAMES:
+				file_list = ", ".join(file_names.slice(0, MAX_DISPLAYED_FILENAMES)) + " + " \
+						+ str(file_names.size() - MAX_DISPLAYED_FILENAMES) + " more"
+
+			# Determine severity and wording based on overlap scale.
+			var sev := "critical" if shared_vanilla.size() > 0 else "warning"
+			var title := ""
+			var what := ""
+			var fix := ""
+
+			if shared.size() >= OVERLAP_FILE_THRESHOLD and shared_vanilla.size() >= OVERLAP_VANILLA_THRESHOLD:
+				title = "Likely Incompatible: " + mod_a + " + " + mod_b
+				what = "Both mods change " + str(shared.size()) + " of the same game files (" \
+						+ str(shared_vanilla.size()) + " core scripts):\n  " + file_list \
+						+ "\n\nThis much overlap almost always means these mods will " \
+						+ "break each other. One mod's changes will be lost."
+				fix = "Disable one of these mods. Some overhaul mods already include " \
+						+ "smaller mods — check the mod descriptions."
+			else:
+				title = "Overlap: " + mod_a + " + " + mod_b
+				what = str(shared.size()) + " shared file(s):\n  " + file_list
+				if shared_vanilla.size() > 0:
+					what += "\n\n" + str(shared_vanilla.size()) + " of these are game files. " \
+							+ "The mod with higher priority wins — the other mod's " \
+							+ "version of these files is ignored."
+				else:
+					what += "\n\nBoth mods include these files. The mod with higher " \
+							+ "priority wins for each shared file."
+				fix = "Try changing the priority order on the Mods tab to see which " \
+						+ "arrangement works best. If both mods need these files, " \
+						+ "they can't be used together."
+
+			issues.append({
+				"severity": sev,
+				"title": title,
+				"what": what,
+				"fix": fix,
+				"mods": [mod_a, mod_b],
+			})
+
+	# 4. Database.gd replaced — preload() caches paths before resource overrides take effect.
 	if _database_replaced_by != "":
-		var affected: Array[String] = []
-		for res_path: String in override_registry:
-			if res_path == _database_path: continue
-			var lower := res_path.to_lower()
-			if not (lower.ends_with(".tscn") or lower.ends_with(".scn")): continue
-			for claim in (override_registry[res_path] as Array):
-				var cn: String = claim["mod_name"]
-				if cn != _database_replaced_by and cn not in affected:
-					affected.append(cn)
+		var affected := _find_database_affected_mods()
 		if not affected.is_empty():
 			var all_mods: Array[String] = [_database_replaced_by]
 			all_mods.append_array(affected)
 			issues.append({
 				"severity": "critical",
 				"title": "Database.gd Replaced",
-				"what": _database_replaced_by + " replaced Database.gd — the file the game uses to "
-						+ "preload all item and scene paths.\n\nBecause preload() caches paths at parse "
-						+ "time, scene overrides from other mods may silently fail to take effect.",
-				"fix": "Scene override mods may be broken when run alongside " + _database_replaced_by
-						+ ".\nAffected mods: " + ", ".join(affected)
-						+ ".\nContact the " + _database_replaced_by + " author, or disable the "
-						+ "scene-override mods.",
+				"what": _database_replaced_by + " replaces Database.gd, which preload()s all "
+						+ "item and scene paths at parse time.\n\nScene overrides from other mods "
+						+ "may not take effect because Database.gd caches the original paths "
+						+ "before those mods mount.",
+				"fix": "Potentially affected mods:\n  " + ", ".join(affected)
+						+ "\n\nIf scenes or items are missing, the load order between "
+						+ _database_replaced_by + " and scene-override mods may need adjusting.",
 				"mods": all_mods,
 			})
 
+	# 5. class_name double override — Godot bug #83542, fatal crash at startup.
+	# Only fires when 2+ mods with uses_dynamic_override both extend-by-class_name
+	# on the same class AND that class_name is declared by a mod (not a Godot built-in).
+	var declared_class_names: Dictionary = {}
+	for mod_name: String in _mod_script_analysis:
+		for cn in (_mod_script_analysis[mod_name]["class_names"] as Array):
+			declared_class_names[cn] = true
+	var cn_override_claims: Dictionary = {}  # class_name -> Array[mod_name]
+	for mod_name: String in _mod_script_analysis:
+		var cn_analysis: Dictionary = _mod_script_analysis[mod_name]
+		if not cn_analysis["uses_dynamic_override"]: continue
+		for cn in (cn_analysis["extends_class_names"] as Array):
+			# Skip if no mod declares this class_name — it's a Godot built-in (Node,
+			# Resource, Control, etc.) or a game class we can't verify. The bug only
+			# matters for class_name scripts that get take_over_path'd by mods.
+			if not declared_class_names.has(cn):
+				continue
+			if not cn_override_claims.has(cn): cn_override_claims[cn] = []
+			if mod_name not in cn_override_claims[cn]:
+				(cn_override_claims[cn] as Array).append(mod_name)
+	for cn: String in cn_override_claims:
+		var cn_mods: Array = cn_override_claims[cn]
+		if cn_mods.size() <= 1: continue
+		issues.append({
+			"severity": "critical",
+			"title": "class_name Crash: " + cn,
+			"what": "These mods both override a script that uses class_name '" + cn + "'.\n\n"
+					+ "Godot bug #83542: take_over_path() on class_name scripts can only "
+					+ "succeed once. A second override causes a fatal engine crash at startup.",
+			"fix": "Only one mod can override a class_name script. Disable all but one.\n\n"
+					+ "To fix: mod authors should use extends \"res://path.gd\" instead of "
+					+ "extends " + cn + " to avoid the class_name limitation.",
+			"mods": cn_mods,
+		})
+
+	# 6. Broken extends paths — mod extends a script that doesn't exist anywhere.
+	# Use FileAccess + ResourceLoader to check the live filesystem rather than
+	# relying on directory scanning, which can miss paths outside Scripts/Scenes.
+	for mod_name: String in _mod_script_analysis:
+		for ext_path in (_mod_script_analysis[mod_name]["extends_paths"] as Array):
+			var p: String = ext_path
+			if FileAccess.file_exists(p) or ResourceLoader.exists(p):
+				continue
+			issues.append({
+				"severity": "warning",
+				"title": "Missing Script: " + p.get_file(),
+				"what": mod_name + " extends a script that no longer exists:\n  " + p
+						+ "\n\nThis override will silently fail — " + mod_name + "'s changes "
+						+ "to this script won't apply. The game may have been updated "
+						+ "and this script was renamed or moved.",
+				"fix": mod_name + " needs an update for the current game version. "
+						+ "The mod will still load but features that depend on this "
+						+ "script won't work.",
+				"mods": [mod_name],
+			})
+
+	# 7. base() calls — Godot 3 pattern or removed parent method. Will fail at runtime.
+	for mod_name: String in _mod_script_analysis:
+		if not _mod_script_analysis[mod_name]["calls_base"]: continue
+		issues.append({
+			"severity": "warning",
+			"title": "Uses base(): " + mod_name,
+			"what": mod_name + " calls base() which is not a GDScript 4 built-in.\n\n"
+					+ "If this was meant to call the parent method, it should be super(). "
+					+ "If base() was a method on the game script, it may have been "
+					+ "removed or renamed in the current version.",
+			"fix": "The mod author needs to replace base() with super() or update "
+					+ "for the current game version.",
+			"mods": [mod_name],
+		})
+
+	# 8. Method-level collisions — two mods override the same method on the same script.
+	var method_claims: Dictionary = {}  # extends_path -> {method_name -> Array[mod_name]}
+	for mod_name: String in _mod_script_analysis:
+		var om: Dictionary = _mod_script_analysis[mod_name]["override_methods"]
+		for ext_path: String in om:
+			if not method_claims.has(ext_path):
+				method_claims[ext_path] = {}
+			for method_name in (om[ext_path] as Array):
+				if not (method_claims[ext_path] as Dictionary).has(method_name):
+					(method_claims[ext_path] as Dictionary)[method_name] = []
+				var claimers: Array = (method_claims[ext_path] as Dictionary)[method_name]
+				if mod_name not in claimers:
+					claimers.append(mod_name)
+
+	# Group shared methods by mod pair to avoid spamming one card per method.
+	var method_pair_issues: Dictionary = {}  # "modA|modB" -> {script, methods}
+	for ext_path: String in method_claims:
+		for method_name: String in (method_claims[ext_path] as Dictionary):
+			var method_mods: Array = (method_claims[ext_path] as Dictionary)[method_name]
+			if method_mods.size() <= 1: continue
+			for mi in method_mods.size():
+				for mj in range(mi + 1, method_mods.size()):
+					var mpk: String = str(method_mods[mi]) + "|" + str(method_mods[mj])
+					if not method_pair_issues.has(mpk):
+						method_pair_issues[mpk] = {
+							"mod_a": method_mods[mi], "mod_b": method_mods[mj], "scripts": {}
+						}
+					var mp: Dictionary = method_pair_issues[mpk]
+					if not (mp["scripts"] as Dictionary).has(ext_path):
+						(mp["scripts"] as Dictionary)[ext_path] = []
+					var ml: Array = (mp["scripts"] as Dictionary)[ext_path]
+					if method_name not in ml:
+						ml.append(method_name)
+
+	for mpk: String in method_pair_issues:
+		var mp_data: Dictionary = method_pair_issues[mpk]
+		var mp_mod_a: String = mp_data["mod_a"]
+		var mp_mod_b: String = mp_data["mod_b"]
+		var mp_scripts: Dictionary = mp_data["scripts"]
+		var detail_lines: Array[String] = []
+		for sp: String in mp_scripts:
+			detail_lines.append(sp.get_file() + ": " + ", ".join(mp_scripts[sp]))
+		issues.append({
+			"severity": "warning",
+			"title": "Method Overlap: " + mp_mod_a + " + " + mp_mod_b,
+			"what": "Both mods override the same method(s) on the same script(s):\n  "
+					+ "\n  ".join(detail_lines)
+					+ "\n\nEven with correct super() calls, both mods are modifying the same "
+					+ "function. Changes may interfere depending on load order.",
+			"fix": "Test with both priority orderings to find which works. If neither "
+					+ "works, these mods need author coordination to split their changes "
+					+ "across different methods.",
+			"mods": [mp_mod_a, mp_mod_b],
+		})
+
+	# 9. Stale preload() — mod preloads a path that another mod overrides via file replacement.
+	var all_override_paths: Dictionary = {}
+	for res_path: String in _override_registry:
+		var pl_claims: Array = _override_registry[res_path]
+		if pl_claims.size() >= 1:
+			all_override_paths[res_path] = (pl_claims[pl_claims.size() - 1] as Dictionary)["mod_name"]
+	for mod_name: String in _mod_script_analysis:
+		for pl_path in (_mod_script_analysis[mod_name]["preload_paths"] as Array):
+			if not all_override_paths.has(pl_path): continue
+			var overrider: String = all_override_paths[pl_path]
+			if overrider == mod_name: continue
+			issues.append({
+				"severity": "warning",
+				"title": "Stale preload(): " + (pl_path as String).get_file(),
+				"what": mod_name + " uses preload(\"" + pl_path + "\") but " + overrider
+						+ " replaces that file.\n\npreload() caches at compile time, before "
+						+ "mods mount. " + mod_name + " will get the vanilla version, not "
+						+ overrider + "'s replacement.",
+				"fix": "Replace preload() with load() in " + mod_name + "'s script. "
+						+ "load() runs at runtime and respects mounted mod files.",
+				"mods": [mod_name, overrider],
+			})
+
+	# 10. BAD ZIP — Windows backslash paths in archive. Godot can't resolve them.
+	for bz: Dictionary in _bad_zips:
+		issues.append({
+			"severity": "critical",
+			"title": "Bad Archive: " + bz["mod_name"],
+			"what": bz["mod_name"] + " has " + str(bz["count"])
+					+ " entries with backslash (\\) path separators.\n\n"
+					+ "Godot requires forward slashes. These files will silently fail "
+					+ "to load.\n\nExample: " + bz["example"],
+			"fix": "Re-pack with 7-Zip (which uses forward slashes). This typically "
+					+ "happens when using Windows ZipFile.CreateFromDirectory().",
+			"mods": [bz["mod_name"]],
+		})
+
 	return issues
+
+
+# ─── Override diagnostics (developer mode) ───────────────────────────────────
+
+# Logs a timing note for each mod that uses overrideScript(). Runs after
+# autoloads have been instantiated — by this point the override is registered
+# but the scene hasn't reloaded yet, so existing nodes still have the old script.
+func _log_override_timing_warnings() -> void:
+	for mod_name: String in _mod_script_analysis:
+		var analysis: Dictionary = _mod_script_analysis[mod_name]
+		if not analysis["uses_dynamic_override"]:
+			continue
+		var targets: Array = analysis["extends_paths"]
+		if targets.is_empty():
+			continue
+		var target_list := ", ".join(targets.map(func(p): return (p as String).get_file()))
+		_log_debug(mod_name + " uses overrideScript() on: " + target_list
+				+ " — applies after scene reload")
+
+
+# Walks the scene tree after reload and checks whether any live node's script
+# matches a known override target. Logs a warning for targets with zero matching
+# instances — the most common "mod does nothing" silent-failure case.
+func _audit_override_instances() -> void:
+	var override_targets: Dictionary = {}  # res_path -> mod_name
+	for mod_name: String in _mod_script_analysis:
+		var analysis: Dictionary = _mod_script_analysis[mod_name]
+		for path in (analysis["take_over_literal_paths"] as Array):
+			override_targets[path] = mod_name
+		if analysis["uses_dynamic_override"]:
+			for path in (analysis["extends_paths"] as Array):
+				override_targets[path] = mod_name
+
+	if override_targets.is_empty():
+		return
+
+	var live_script_paths: Dictionary = {}
+	_collect_live_scripts(get_tree().root, live_script_paths)
+
+	for target_path: String in override_targets:
+		var mod_name: String = override_targets[target_path]
+		if live_script_paths.has(target_path):
+			_log_debug("Override applied: " + target_path.get_file()
+					+ " — " + str(live_script_paths[target_path]) + " node(s) [" + mod_name + "]")
+		else:
+			_log_warning("Override registered but 0 nodes use " + target_path.get_file()
+					+ " in current scene [" + mod_name + "]")
+			_log_warning("  Target may be spawned later at runtime, or the path may be wrong.")
+
+
+func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
+	# Iterative traversal to avoid stack overflow on deeply nested scene trees.
+	var stack: Array[Node] = [root_node]
+	while not stack.is_empty():
+		var node: Node = stack.pop_back()
+		var script: Script = node.get_script() as Script
+		if script:
+			var path := script.resource_path
+			if path != "":
+				out[path] = (out.get(path, 0) as int) + 1
+		stack.append_array(node.get_children())
 
 
 # ─── Conflict summary ─────────────────────────────────────────────────────────
@@ -1461,12 +2004,12 @@ func _print_conflict_summary() -> void:
 	_log_info("============================================")
 	_log_info("=== ModLoader Compatibility Summary      ===")
 	_log_info("============================================")
-	_log_info("Mods loaded:  " + str(loaded_mod_ids.size()))
+	_log_info("Mods loaded:  " + str(_loaded_mod_ids.size()))
 
 	var conflicted_paths: Array[String] = []
 	var critical_conflicts: Array[String] = []
-	for res_path: String in override_registry:
-		var claims: Array = override_registry[res_path]
+	for res_path: String in _override_registry:
+		var claims: Array = _override_registry[res_path]
 		if claims.size() > 1:
 			conflicted_paths.append(res_path)
 			if _is_dangerous_path(res_path) or res_path == _database_path:
@@ -1481,7 +2024,7 @@ func _print_conflict_summary() -> void:
 		_log_info("")
 		_log_info("--- Conflicted Paths (last loader wins) ---")
 		for res_path in conflicted_paths:
-			var claims: Array = override_registry[res_path]
+			var claims: Array = _override_registry[res_path]
 			var winner: Dictionary = claims[claims.size() - 1]
 			_log_warning("CONFLICT: " + res_path)
 			for claim in claims:
@@ -1489,18 +2032,8 @@ func _print_conflict_summary() -> void:
 				_log_info("    [" + str(claim["load_index"] + 1) + "] "
 						+ claim["mod_name"] + " via " + claim["archive"] + marker)
 
-	# If Database.gd was replaced, other mods' scene overrides may be dead — the
-	# database caches scene paths via preload() before resource-path overrides take effect.
 	if _database_replaced_by != "":
-		var affected: Array[String] = []
-		for res_path: String in override_registry:
-			if res_path == _database_path: continue
-			var lower := res_path.to_lower()
-			if not (lower.ends_with(".tscn") or lower.ends_with(".scn")): continue
-			for claim in (override_registry[res_path] as Array):
-				var cn: String = claim["mod_name"]
-				if cn != _database_replaced_by and cn not in affected:
-					affected.append(cn)
+		var affected := _find_database_affected_mods()
 		if not affected.is_empty():
 			_log_warning("DATABASE: " + _database_replaced_by + " replaced Database.gd.")
 			_log_warning("  Scene overrides from [" + ", ".join(affected) + "] may not take effect.")
@@ -1519,41 +2052,56 @@ func _write_conflict_report() -> void:
 	for line in _report_lines:
 		f.store_line(line)
 	f.close()
-	print("[ModLoader][Info] Conflict report written to: " + CONFLICT_REPORT_PATH)
+	_log_info("Conflict report written to: " + CONFLICT_REPORT_PATH)
 
 
 # ─── Autoload instantiation ───────────────────────────────────────────────────
 
 func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: String) -> void:
-	# Two checks needed — Godot limitation:
-	# FileAccess works for .gd in mounted archives but misses exported .tscn → .scn remapping.
-	# ResourceLoader handles remapping but returns false for .gd in archives.
-	if not (FileAccess.file_exists(res_path) or ResourceLoader.exists(res_path)):
-		_log_critical("Autoload not found: " + res_path + " [" + mod_name + "]")
-		_log_critical("  Possible causes: Windows backslash paths in zip, or file missing from archive.")
-		return
-
+	# Neither FileAccess.file_exists() nor ResourceLoader.exists() is reliable for
+	# files in mounted archives across all systems. Try load() directly and use the
+	# existence checks only for diagnostics when load() fails.
 	var resource: Resource = load(res_path)
 	if resource == null:
-		_log_critical("Autoload failed to parse: " + autoload_name + " -> " + res_path)
-		_log_critical("  Check the Godot log above for the specific parse error.")
+		var fa := FileAccess.file_exists(res_path)
+		var rl := ResourceLoader.exists(res_path)
+		_log_critical("Autoload failed: " + autoload_name + " -> " + res_path + " [" + mod_name + "]")
+		_log_critical("  FileAccess.file_exists=" + str(fa) + "  ResourceLoader.exists=" + str(rl))
+		if not fa and not rl:
+			_log_critical("  File not accessible after mounting. Possible causes:")
+			_log_critical("    - Windows backslash paths in zip (re-pack with 7-Zip)")
+			_log_critical("    - Archive failed to mount (check for earlier errors)")
+			_log_critical("    - Path in mod.txt doesn't match actual file path in archive")
+		else:
+			_log_critical("  File exists but failed to parse. Check the Godot log above.")
 		return
+
+	# Add to root so mods can find autoloads at /root/<name>, matching real autoload behavior.
+	if get_tree().root.has_node(autoload_name):
+		_log_warning("Autoload name '" + autoload_name + "' conflicts with existing node at /root/"
+				+ autoload_name + " — Godot will rename it. [" + mod_name + "]")
 
 	if resource is PackedScene:
 		var instance: Node = (resource as PackedScene).instantiate()
 		instance.name = autoload_name
-		add_child(instance)
+		get_tree().root.call_deferred("add_child", instance)
 		_log_info("Autoload instantiated (scene): " + autoload_name + " [" + mod_name + "]")
 		return
 
 	if resource is GDScript:
-		var inst: Variant = (resource as GDScript).new()
+		var gdscript := resource as GDScript
+		if not gdscript.can_instantiate():
+			_log_critical("Autoload script failed to compile: " + autoload_name
+					+ " -> " + res_path + " [" + mod_name + "]")
+			_log_critical("  can_instantiate() returned false. Check the Godot log above for parse errors.")
+			return
+		var inst: Variant = gdscript.new()
 		if inst == null:
 			_log_warning("Autoload script returned null: " + autoload_name)
 			return
 		if inst is Node:
 			(inst as Node).name = autoload_name
-			add_child(inst as Node)
+			get_tree().root.call_deferred("add_child", inst as Node)
 			_log_info("Autoload instantiated (script): " + autoload_name + " [" + mod_name + "]")
 			return
 		_log_warning("Autoload is not a Node — not added to tree: " + autoload_name)
@@ -1591,10 +2139,68 @@ func _read_mod_config(path: String) -> ConfigFile:
 		return null
 	var text := zr.read_file("mod.txt").get_string_from_utf8()
 	zr.close()
+	return _parse_mod_txt(text)
+
+
+func _read_mod_config_folder(folder_path: String) -> ConfigFile:
+	var mod_txt_path := folder_path.path_join("mod.txt")
+	if not FileAccess.file_exists(mod_txt_path):
+		return null
+	var f := FileAccess.open(mod_txt_path, FileAccess.READ)
+	if f == null:
+		return null
+	var text := f.get_as_text()
+	f.close()
+	return _parse_mod_txt(text)
+
+
+func _parse_mod_txt(text: String) -> ConfigFile:
+	if text.begins_with("\uFEFF"):
+		text = text.substr(1)
 	var cfg := ConfigFile.new()
 	if cfg.parse(text) != OK:
 		return null
 	return cfg
+
+
+# ─── Folder → temp zip (developer mode) ──────────────────────────────────────
+
+func _zip_folder_to_temp(folder_path: String) -> String:
+	var folder_name := folder_path.get_file()
+	var tmp_zip_path := ProjectSettings.globalize_path(TMP_DIR).path_join(
+			folder_name + "_dev.zip")
+	var zp := ZIPPacker.new()
+	if zp.open(tmp_zip_path) != OK:
+		_log_critical("Failed to create temp zip: " + tmp_zip_path)
+		return ""
+	# Zip contents without a top-level wrapper — the folder's internal structure
+	# already mirrors the res:// paths the mod expects.
+	_zip_folder_recursive(zp, folder_path, "")
+	zp.close()
+	return tmp_zip_path
+
+
+func _zip_folder_recursive(zp: ZIPPacker, disk_path: String, archive_prefix: String) -> void:
+	var dir := DirAccess.open(disk_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	while true:
+		var entry := dir.get_next()
+		if entry == "":
+			break
+		if entry.begins_with("."):
+			continue
+		var full := disk_path.path_join(entry)
+		var arc_path := entry if archive_prefix == "" else archive_prefix.path_join(entry)
+		if dir.current_is_dir():
+			_zip_folder_recursive(zp, full, arc_path)
+		else:
+			var data := FileAccess.get_file_as_bytes(full)
+			zp.start_file(arc_path)
+			zp.write_file(data)
+			zp.close_file()
+	dir.list_dir_end()
 
 
 # ─── Update fetch helpers ─────────────────────────────────────────────────────
@@ -1602,8 +2208,8 @@ func _read_mod_config(path: String) -> ConfigFile:
 # Compares two dotted version strings. Returns -1 if a < b, 0 if equal, 1 if a > b.
 # "0.0.2" vs "0.0.1" → 1 (local is newer, no update needed).
 func _compare_versions(a: String, b: String) -> int:
-	var pa := a.split(".")
-	var pb := b.split(".")
+	var pa := a.lstrip("vV").split(".")
+	var pb := b.lstrip("vV").split(".")
 	var n := max(pa.size(), pb.size())
 	for i in n:
 		var va := int(pa[i]) if i < pa.size() else 0
@@ -1615,8 +2221,9 @@ func _compare_versions(a: String, b: String) -> int:
 
 func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 	var latest_versions := {}
-	for chunk_ids in _chunk_int_array(ids, 100):
+	for chunk_ids in _chunk_int_array(ids, MODWORKSHOP_BATCH_SIZE):
 		var req := HTTPRequest.new()
+		req.timeout = API_CHECK_TIMEOUT
 		add_child(req)
 		var err := req.request(MODWORKSHOP_VERSIONS_URL,
 			PackedStringArray(["Content-Type: application/json", "Accept: application/json"]),
@@ -1624,11 +2231,12 @@ func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 		if err != OK:
 			req.queue_free()
 			continue
-		var res = await req.request_completed
+		# request_completed → [result, http_code, headers, body]
+		var res: Array = await req.request_completed
 		req.queue_free()
 		if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
 			continue
-		var parsed = JSON.parse_string(res[3].get_string_from_utf8())
+		var parsed = JSON.parse_string((res[3] as PackedByteArray).get_string_from_utf8())
 		if parsed is Dictionary:
 			latest_versions.merge(parsed, true)
 	return latest_versions
@@ -1636,12 +2244,14 @@ func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 
 func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 	var req := HTTPRequest.new()
+	req.timeout = API_DOWNLOAD_TIMEOUT
 	add_child(req)
 	var err := req.request(MODWORKSHOP_DOWNLOAD_URL_TEMPLATE % str(modworkshop_id))
 	if err != OK:
 		req.queue_free()
 		return false
-	var res = await req.request_completed
+	# request_completed → [result, http_code, headers, body]
+	var res: Array = await req.request_completed
 	req.queue_free()
 
 	if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
@@ -1686,14 +2296,8 @@ func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool
 	return true
 
 
-func _chunk_int_array(arr: Array[int], size: int) -> Array:
+func _chunk_int_array(arr: Array[int], chunk_size: int) -> Array:
 	var result: Array = []
-	var current: Array[int] = []
-	for value in arr:
-		current.append(value)
-		if current.size() >= size:
-			result.append(current)
-			current = []
-	if not current.is_empty():
-		result.append(current)
+	for i in range(0, arr.size(), chunk_size):
+		result.append(arr.slice(i, i + chunk_size))
 	return result

--- a/modloader.gd
+++ b/modloader.gd
@@ -1,53 +1,48 @@
+## Metro Mod Loader — community mod loader for Road to Vostok (Godot 4.6+).
+## Loads .vmz/.pck archives from <game>/mods/ via a pre-game config window.
+## Two-pass architecture: mounts archives at file-scope, optionally restarts to
+## prepend mod autoloads before the game's own autoloads via [autoload_prepend].
 extends Node
 
+const MODLOADER_VERSION := "2.1.0"
+const MODLOADER_RES_PATH := "res://modloader.gd"
 const MOD_DIR := "mods"
 const TMP_DIR := "user://vmz_mount_cache"
-const CONFLICT_REPORT_PATH := "user://modloader_conflicts.txt"
 const UI_CONFIG_PATH := "user://mod_config.cfg"
-const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
-const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
-
-# ─── Two-pass architecture constants ────────────────────────────────────────
+const CONFLICT_REPORT_PATH := "user://modloader_conflicts.txt"
 const PASS_STATE_PATH := "user://mod_pass_state.cfg"
 const HEARTBEAT_PATH := "user://modloader_heartbeat.txt"
 const SAFE_MODE_FILE := "modloader_safe_mode"
 const MAX_RESTART_COUNT := 2
-const MODLOADER_VERSION := "2.1.0"
-const MODLOADER_RES_PATH := "res://modloader.gd"
 
+const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
+const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
+const MODWORKSHOP_BATCH_SIZE := 100
+const API_CHECK_TIMEOUT := 15.0
+const API_DOWNLOAD_TIMEOUT := 30.0
+
+const PRIORITY_MIN := -999
+const PRIORITY_MAX := 999
 const TRACKED_EXTENSIONS: Array[String] = ["gd", "tscn", "tres", "gdns", "gdnlib", "scn"]
 const LIFECYCLE_METHODS: Array[String] = [
 	"_ready", "_process", "_physics_process",
 	"_input", "_unhandled_input", "_unhandled_key_input",
 ]
 
-# ─── Tuning constants ────────────────────────────────────────────────────────
+var _mods_dir: String = ""
+var _developer_mode := false
+var _has_loaded := false
+var _last_mod_txt_status := "none"
+var _database_replaced_by := ""
 
-const MODWORKSHOP_BATCH_SIZE := 100     # mod IDs per API request
-const API_CHECK_TIMEOUT := 15.0         # seconds for version-check requests
-const API_DOWNLOAD_TIMEOUT := 30.0      # seconds for mod download requests
-const PRIORITY_MIN := -999
-const PRIORITY_MAX := 999
-
-# ─── State ────────────────────────────────────────────────────────────────────
-
-var _database_replaced_by: String = ""
+var _ui_mod_entries: Array[Dictionary] = []
+var _pending_autoloads: Array[Dictionary] = []
+var _report_lines: Array[String] = []
+var _loaded_mod_ids: Dictionary = {}
+var _registered_autoload_names: Dictionary = {}
 var _override_registry: Dictionary = {}
 var _mod_script_analysis: Dictionary = {}
 var _archive_file_sets: Dictionary = {}
-var _report_lines: Array[String] = []
-var _pending_autoloads: Array[Dictionary] = []
-var _loaded_mod_ids: Dictionary = {}
-var _registered_autoload_names: Dictionary = {}
-
-# Populated before any mounting. Each entry:
-# { file_name, full_path, ext, mod_name, mod_id, priority, enabled, cfg, mod_txt_status, warnings }
-var _ui_mod_entries: Array[Dictionary] = []
-
-var _last_mod_txt_status: String = "none"
-var _developer_mode: bool = false
-var _has_loaded: bool = false
-var _mods_dir: String = ""
 
 var _re_take_over: RegEx
 var _re_extends: RegEx
@@ -57,21 +52,59 @@ var _re_func: RegEx
 var _re_preload: RegEx
 var _re_filename_priority: RegEx
 
+# Mounts previous session's archives at file-scope (before _ready) so autoloads
+# that load after ModLoader can resolve their res:// paths.
+var _file_scope_mounts: int = _mount_previous_session()
 
-# ─── File-scope archive mounting (Pass 2 only) ──────────────────────────────
-# Runs during Godot's autoload instantiation, before _init() and _ready().
-# If mod_pass_state.cfg exists, mounts all listed archives so that subsequent
-# autoloads (loaded from [autoload_prepend]) can resolve their res:// paths.
-var _pass2_mount_count: int = _try_file_scope_mount()
-
-
-static func _try_file_scope_mount() -> int:
+static func _mount_previous_session() -> int:
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) != OK:
+		return 0
+	# Wipe stale state from a different modloader version (format may have changed).
+	var saved_ver: String = cfg.get_value("state", "modloader_version", "")
+	if saved_ver != MODLOADER_VERSION:
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		return 0
 	var paths: PackedStringArray = cfg.get_value("state", "archive_paths", PackedStringArray())
 	if paths.is_empty():
 		return 0
+
+	# Were any archives deleted since last session?
+	var any_missing := false
+	var any_stale := false
+	for path in paths:
+		var abs_path := path if not path.begins_with("res://") and not path.begins_with("user://") \
+				else ProjectSettings.globalize_path(path)
+		if FileAccess.file_exists(abs_path):
+			continue
+		# VMZ source gone — check if the zip cache survived.
+		if abs_path.get_extension().to_lower() == "vmz":
+			var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
+			var cached := cache_dir.path_join(abs_path.get_file().get_basename() + ".zip")
+			if FileAccess.file_exists(cached):
+				any_stale = true
+				continue
+		any_missing = true
+
+	if any_missing:
+		# Archive gone, no cache. Wipe override.cfg so the next boot is clean.
+		# This boot might log errors for the missing autoloads but won't crash
+		# (Godot 4.6 treats missing [autoload_prepend] scripts as non-fatal).
+		var exe_dir := OS.get_executable_path().get_base_dir()
+		var f := FileAccess.open(exe_dir.path_join("override.cfg"), FileAccess.WRITE)
+		if f:
+			f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n")
+			f.close()
+		var state_path := ProjectSettings.globalize_path(PASS_STATE_PATH)
+		if FileAccess.file_exists(state_path):
+			DirAccess.remove_absolute(state_path)
+		return 0
+
+	if any_stale:
+		# Source gone but cache works — invalidate hash so Pass 1 rewrites state.
+		cfg.set_value("state", "mods_hash", "")
+		cfg.save(PASS_STATE_PATH)
+
 	var count := 0
 	for path in paths:
 		if ProjectSettings.load_resource_pack(path):
@@ -82,7 +115,6 @@ static func _try_file_scope_mount() -> int:
 				count += 1
 	return count
 
-
 static func _static_vmz_to_zip(vmz_path: String) -> String:
 	var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
 	if not DirAccess.dir_exists_absolute(cache_dir):
@@ -90,7 +122,11 @@ static func _static_vmz_to_zip(vmz_path: String) -> String:
 	var zip_name := vmz_path.get_file().get_basename() + ".zip"
 	var zip_path := cache_dir.path_join(zip_name)
 	if FileAccess.file_exists(zip_path):
-		return zip_path
+		# Re-extract if source is newer than cache (mod was updated in-place).
+		var src_time := FileAccess.get_modified_time(vmz_path)
+		var zip_time := FileAccess.get_modified_time(zip_path)
+		if src_time <= zip_time:
+			return zip_path
 	var src := FileAccess.open(vmz_path, FileAccess.READ)
 	if src == null:
 		return ""
@@ -104,65 +140,89 @@ static func _static_vmz_to_zip(vmz_path: String) -> String:
 	dst.close()
 	return zip_path
 
-
-# ─── Entry point ──────────────────────────────────────────────────────────────
+# Entry point
 
 func _ready() -> void:
 	if _has_loaded:
 		return
 	_has_loaded = true
-	# When loaded via bootstrap (metro-modloader.zip), mount count is passed via meta.
-	if has_meta("_pass2_mount_count"):
-		_pass2_mount_count = get_meta("_pass2_mount_count")
-	# Autoloads run while the scene tree is still setting up children.
-	# Wait one frame so add_child() and DisplayServer queries work correctly.
+	if has_meta("_file_scope_mounts"):
+		_file_scope_mounts = get_meta("_file_scope_mounts")
 	await get_tree().process_frame
 	if "--modloader-restart" in OS.get_cmdline_user_args():
 		_run_pass_2()
 	else:
 		await _run_pass_1()
 
-
-# ─── Pass 1: Normal launch — show UI, configure, optionally restart ─────────
+# Pass 1: Normal launch — show UI, configure, optionally restart
 
 func _run_pass_1() -> void:
-	_log_info("Metro Mod Loader v" + MODLOADER_VERSION + " — exe: "
-			+ OS.get_executable_path() + "  user: " + OS.get_user_data_dir())
-	# Safety: crash recovery and safe mode checks before anything else.
+	_log_info("Metro Mod Loader v" + MODLOADER_VERSION)
 	_check_crash_recovery()
 	_check_safe_mode()
 	_compile_regex()
 	_load_developer_mode_setting()
-	_ui_mod_entries = _collect_mod_metadata()
+	_ui_mod_entries = collect_mod_metadata()
+	_clean_stale_cache()
 	_load_ui_config()
-	await _show_mod_ui()
+	await show_mod_ui()
 	_save_ui_config()
-	# Mount all enabled mods and collect autoload entries (populates _pending_autoloads).
-	_load_all_mods()
-	# Classify autoloads: ! prefix = early (needs [autoload_prepend]), rest = late.
+
+	load_all_mods()
 	var sections := _build_autoload_sections()
-	if sections.prepend.size() > 0:
-		# Early autoloads exist — write override.cfg, save state, restart.
-		# Do NOT instantiate autoloads yet — Pass 2 will handle that.
-		_log_info("Early autoloads detected (%d) — preparing two-pass restart..."
-				% sections.prepend.size())
+	var archive_paths := _collect_enabled_archive_paths()
+
+	# Skip restart if mod state hasn't changed since last launch.
+	var new_hash := _compute_state_hash(archive_paths, sections.prepend)
+	var old_hash := ""
+	var state_cfg := ConfigFile.new()
+	if state_cfg.load(PASS_STATE_PATH) == OK:
+		old_hash = state_cfg.get_value("state", "mods_hash", "")
+
+	if new_hash == old_hash and not new_hash.is_empty():
+		_log_info("Mod state unchanged — skipping restart")
+		_finish_with_existing_mounts()
+		return
+
+	if archive_paths.size() > 0:
+		_log_info("Preparing two-pass restart — %d archive(s)" % archive_paths.size())
+		if sections.prepend.size() > 0:
+			_log_info("  %d early autoload(s) in [autoload_prepend]" % sections.prepend.size())
 		_write_heartbeat()
-		var archive_paths := _collect_enabled_archive_paths()
-		var cfg_err := _write_override_cfg(sections.prepend)
-		if cfg_err != OK:
-			_log_critical("Failed to write override.cfg (error %d) — single-pass fallback" % cfg_err)
+		var err := _write_override_cfg(sections.prepend)
+		if err != OK:
+			_log_critical("Failed to write override.cfg (error %d) — single-pass fallback" % err)
 			_finish_single_pass()
 			return
-		_write_pass_state(archive_paths)
-		_log_info("Restarting with [autoload_prepend]...")
+		if _write_pass_state(archive_paths, new_hash) != OK:
+			_finish_single_pass()
+			return
 		OS.set_restart_on_exit(true, ["--", "--modloader-restart"])
 		get_tree().quit()
 		return
-	# No early autoloads — instantiate and reload (single-pass, no restart).
+
+	# No archives enabled. Clean up stale two-pass state if present.
+	if FileAccess.file_exists(PASS_STATE_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
+		_restore_clean_override_cfg()
 	_finish_single_pass()
 
+func _finish_with_existing_mounts() -> void:
+	for entry in _pending_autoloads:
+		if get_tree().root.has_node(entry["name"]):
+			_log_info("  Autoload '%s' already in tree — skipped" % entry["name"])
+			continue
+		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
+	if _developer_mode:
+		_log_override_timing_warnings()
+		_print_conflict_summary()
+		_write_conflict_report()
+	_delete_heartbeat()
+	if _file_scope_mounts > 0 or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+		var err := get_tree().reload_current_scene()
+		if err != OK:
+			_log_critical("reload_current_scene() failed with error " + str(err))
 
-# Finish single-pass: instantiate queued autoloads, reload. Called after _load_all_mods().
 func _finish_single_pass() -> void:
 	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
@@ -171,56 +231,45 @@ func _finish_single_pass() -> void:
 		_print_conflict_summary()
 		_write_conflict_report()
 	_delete_heartbeat()
-	# Reload so mounted resource overrides and take_over_path() apply to the scene.
 	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
-		var reload_err := get_tree().reload_current_scene()
-		if reload_err != OK:
-			_log_critical("reload_current_scene() failed with error " + str(reload_err))
+		var err := get_tree().reload_current_scene()
+		if err != OK:
+			_log_critical("reload_current_scene() failed with error " + str(err))
 			return
 		if _developer_mode:
 			await get_tree().process_frame
 			_audit_override_instances()
 
-
-# ─── Pass 2: Modloader-triggered restart — archives already mounted ─────────
+# Pass 2: Post-restart — archives already mounted at file-scope
 
 func _run_pass_2() -> void:
-	_log_info("Metro Mod Loader v" + MODLOADER_VERSION + " — Pass 2")
-	_log_info("  %d archive(s) mounted at file-scope" % _pass2_mount_count)
+	_log_info("Pass 2 — %d archive(s) mounted at file-scope" % _file_scope_mounts)
 	_clear_restart_counter()
 	_compile_regex()
 	_load_developer_mode_setting()
-	_ui_mod_entries = _collect_mod_metadata()
+	_ui_mod_entries = collect_mod_metadata()
 	_load_ui_config()
-	# Early mod autoloads are already in the scene tree (Godot loaded them
-	# from [autoload_prepend] in override.cfg). Mount remaining archives and
-	# instantiate late autoloads that aren't already present.
-	_load_all_mods("Pass 2")
+
+	load_all_mods("Pass 2")
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
-			_log_info("  Autoload '" + entry["name"] + "' already in tree (early) — skipped")
+			_log_info("  Autoload '%s' already in tree — skipped" % entry["name"])
 			continue
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
+
 	if _developer_mode:
 		_log_override_timing_warnings()
 		_print_conflict_summary()
 		_write_conflict_report()
 	_delete_heartbeat()
-	# Clean up pass state FIRST — prevents stale file-scope mounts if next line crashes.
-	if FileAccess.file_exists(PASS_STATE_PATH):
-		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
-	# Restore clean override.cfg so next normal launch starts fresh.
-	_restore_clean_override_cfg()
-	# Reload so mounted resource overrides and take_over_path() apply to the scene.
-	if _pass2_mount_count > 0 or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
-		var reload_err := get_tree().reload_current_scene()
-		if reload_err != OK:
-			_log_critical("reload_current_scene() failed with error " + str(reload_err))
+	if _file_scope_mounts > 0 or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+		var err := get_tree().reload_current_scene()
+		if err != OK:
+			_log_critical("reload_current_scene() failed with error " + str(err))
 			return
 		if _developer_mode:
 			await get_tree().process_frame
 			_audit_override_instances()
-
 
 func _compile_regex() -> void:
 	_re_take_over = RegEx.new()
@@ -239,10 +288,9 @@ func _compile_regex() -> void:
 	_re_filename_priority = RegEx.new()
 	_re_filename_priority.compile('^(-?\\d+)-(.*)')
 
+# Mod metadata collection (no mounting)
 
-# ─── Mod metadata collection (no mounting) ────────────────────────────────────
-
-func _collect_mod_metadata() -> Array[Dictionary]:
+func collect_mod_metadata() -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
 	_mods_dir = OS.get_executable_path().get_base_dir().path_join(MOD_DIR)
 	_log_info("Scanning mods dir: " + _mods_dir)
@@ -287,27 +335,22 @@ func _collect_mod_metadata() -> Array[Dictionary]:
 			_log_info("  " + e["file_name"] + " (" + e["mod_name"] + ")" + tag)
 	return entries
 
-
 func _build_archive_entry(mods_dir: String, file_name: String, ext: String) -> Dictionary:
 	var full_path := mods_dir.path_join(file_name)
 	if ext == "pck":
 		_last_mod_txt_status = "pck"
-	var cfg: ConfigFile = _read_mod_config(full_path) if ext != "pck" else null
+	var cfg: ConfigFile = read_mod_config(full_path) if ext != "pck" else null
 	var entry := _entry_from_config(cfg, file_name, full_path, ext)
 	entry["warnings"] = _build_entry_warnings(entry)
 	return entry
 
-
 func _build_folder_entry(mods_dir: String, dir_name: String) -> Dictionary:
 	var folder_path := mods_dir.path_join(dir_name)
-	var cfg: ConfigFile = _read_mod_config_folder(folder_path)
+	var cfg: ConfigFile = read_mod_config_folder(folder_path)
 	var entry := _entry_from_config(cfg, dir_name, folder_path, "folder")
 	entry["warnings"] = _build_entry_warnings(entry)
 	return entry
 
-
-# Future: mod.txt may support [mod] load_after = "other_mod_id" for soft dependencies.
-# This would feed into a topological sort pass before the priority/name sort.
 func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, ext: String) -> Dictionary:
 	var mod_name := file_name
 	var mod_id   := file_name
@@ -347,7 +390,6 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		entry["enabled"] = false
 	return entry
 
-
 func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 	var warnings: Array[String] = []
 	var ext: String = entry["ext"]
@@ -365,8 +407,7 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 		warnings.append("Invalid mod — packaged incorrectly. Try re-downloading.")
 	return warnings
 
-
-# ─── Config persistence ───────────────────────────────────────────────────────
+# Config persistence
 
 func _load_developer_mode_setting() -> void:
 	var cfg := ConfigFile.new()
@@ -375,7 +416,6 @@ func _load_developer_mode_setting() -> void:
 	_developer_mode = bool(cfg.get_value("settings", "developer_mode", false))
 	if _developer_mode:
 		_log_info("Developer mode: ON")
-
 
 func _load_ui_config() -> void:
 	var cfg := ConfigFile.new()
@@ -389,7 +429,6 @@ func _load_ui_config() -> void:
 		if cfg.has_section_key("priority", fn):
 			entry["priority"] = int(str(cfg.get_value("priority", fn)))
 
-
 func _save_ui_config() -> void:
 	var cfg := ConfigFile.new()
 	for entry in _ui_mod_entries:
@@ -399,10 +438,9 @@ func _save_ui_config() -> void:
 	cfg.set_value("settings", "developer_mode", _developer_mode)
 	cfg.save(UI_CONFIG_PATH)
 
+# UI
 
-# ─── UI ───────────────────────────────────────────────────────────────────────
-
-func _show_mod_ui() -> void:
+func show_mod_ui() -> void:
 	var win := Window.new()
 	win.title = "Road to Vostok — Mod Loader"
 	win.size = Vector2i(960, 640)
@@ -441,7 +479,7 @@ func _show_mod_ui() -> void:
 	margin.add_theme_constant_override("margin_top", 8)
 	margin.add_theme_constant_override("margin_bottom", 10)
 	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	margin.theme = _make_dark_theme()
+	margin.theme = make_dark_theme()
 	win.add_child(margin)
 
 	var root := VBoxContainer.new()
@@ -492,19 +530,18 @@ func _show_mod_ui() -> void:
 	# Closing the window with X should behave the same as clicking Launch.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
 
-	var mods_tab := _build_mods_tab(tabs)
+	var mods_tab := build_mods_tab(tabs)
 	mods_tab.name = "Mods"
 	tabs.add_child(mods_tab)
 
-	var updates_tab := _build_updates_tab()
+	var updates_tab := build_updates_tab()
 	updates_tab.name = "Updates"
 	tabs.add_child(updates_tab)
 
 	await launch_btn.pressed
 	win.queue_free()
 
-
-func _make_dark_theme() -> Theme:
+func make_dark_theme() -> Theme:
 	var t := Theme.new()
 
 	const C_PANEL := Color(0.04, 0.04, 0.04)
@@ -596,8 +633,7 @@ func _make_dark_theme() -> Theme:
 
 	return t
 
-
-func _build_mods_tab(tabs: TabContainer) -> Control:
+func build_mods_tab(tabs: TabContainer) -> Control:
 	var outer := VBoxContainer.new()
 	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
@@ -626,13 +662,13 @@ func _build_mods_tab(tabs: TabContainer) -> Control:
 
 	dev_check.toggled.connect(func(on: bool):
 		_developer_mode = on
-		_ui_mod_entries = _collect_mod_metadata()
+		_ui_mod_entries = collect_mod_metadata()
 		_load_ui_config()
 		var old := tabs.get_node("Mods")
 		var idx := old.get_index()
 		tabs.remove_child(old)
 		old.queue_free()
-		var new_tab := _build_mods_tab(tabs)
+		var new_tab := build_mods_tab(tabs)
 		new_tab.name = "Mods"
 		tabs.add_child(new_tab)
 		tabs.move_child(new_tab, idx)
@@ -806,9 +842,7 @@ func _build_mods_tab(tabs: TabContainer) -> Control:
 	refresh_order.call()
 	return outer
 
-
-
-func _build_updates_tab() -> Control:
+func build_updates_tab() -> Control:
 	var margin := MarginContainer.new()
 	margin.add_theme_constant_override("margin_left", 8)
 	margin.add_theme_constant_override("margin_right", 8)
@@ -987,23 +1021,21 @@ func _build_updates_tab() -> Control:
 			btn.disabled = true
 			btn.mouse_filter = Control.MOUSE_FILTER_IGNORE
 			btn.text = "Download"
-		await _check_updates_for_ui(status_info, add_log, check_btn)
+		await check_updates_for_ui(status_info, add_log, check_btn)
 		check_btn.disabled = false
 		check_btn.text = "Check for Updates"
 	)
 
 	return margin
 
-
-
-func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn: Button) -> void:
+func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn: Button) -> void:
 	var ids: Array[int] = []
 	for fn in status_info:
 		ids.append(status_info[fn]["mw_id"])
 	if ids.is_empty():
 		return
 
-	var latest := await _fetch_latest_modworkshop_versions(ids)
+	var latest := await fetch_latest_modworkshop_versions(ids)
 
 	if not is_instance_valid(check_btn):
 		return
@@ -1018,7 +1050,7 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 			lbl.modulate = Color(1.0, 1.0, 1.0)
 			continue
 
-		var cmp := _compare_versions(info["version"], str(latest_v))
+		var cmp := compare_versions(info["version"], str(latest_v))
 		if cmp >= 0:
 			# Local is same version or newer than what's on the server.
 			lbl.text = "up to date"
@@ -1042,7 +1074,7 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 				dl_btn.text = "Downloading..."
 				lbl.text = "downloading..."
 				check_btn.disabled = true
-				var ok := await _download_and_replace_mod(full_path, mw_id)
+				var ok := await download_and_replace_mod(full_path, mw_id)
 				if not is_instance_valid(check_btn):
 					return
 				check_btn.disabled = false
@@ -1065,10 +1097,9 @@ func _check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn
 					add_log.call(mod_name + " — download failed.")
 			)
 
+# Main load loop
 
-# ─── Main load loop ───────────────────────────────────────────────────────────
-
-func _load_all_mods(pass_label: String = "") -> void:
+func load_all_mods(pass_label: String = "") -> void:
 	_pending_autoloads.clear()
 	_loaded_mod_ids.clear()
 	_registered_autoload_names.clear()
@@ -1080,7 +1111,6 @@ func _load_all_mods(pass_label: String = "") -> void:
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
-	# Build the candidate list from UI-configured entries (already filtered and trusted).
 	var candidates: Array[Dictionary] = []
 	for entry in _ui_mod_entries:
 		if not entry["enabled"]:
@@ -1113,7 +1143,6 @@ func _load_all_mods(pass_label: String = "") -> void:
 	for load_index in candidates.size():
 		_process_mod_candidate(candidates[load_index], load_index)
 
-
 func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var file_name: String = c["file_name"]
 	var full_path: String = c["full_path"]
@@ -1134,7 +1163,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	var mount_path := full_path
 	if ext == "folder":
-		mount_path = _zip_folder_to_temp(full_path)
+		mount_path = zip_folder_to_temp(full_path)
 		if mount_path == "":
 			_log_critical("Failed to zip folder: " + file_name)
 			return
@@ -1148,19 +1177,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	if ext != "pck":
 		var scan_path := mount_path if ext == "folder" else full_path
-		_scan_and_register_archive_claims(scan_path, mod_name, file_name, load_index)
-		# Verify mount actually worked — check if at least one file is accessible.
-		# Debug-only: FileAccess/ResourceLoader checks are unreliable for mounted
-		# archives on some systems, so this is diagnostic info, not an error.
-		if _developer_mode and _archive_file_sets.has(file_name):
-			var verified := false
-			for res_path: String in _archive_file_sets[file_name]:
-				if FileAccess.file_exists(res_path) or ResourceLoader.exists(res_path):
-					verified = true
-					break
-			if not verified and _archive_file_sets[file_name].size() > 0:
-				_log_debug("  Mount verification: no files accessible via FileAccess/ResourceLoader (may be normal)")
-				_log_debug("  Will attempt load() directly when needed")
+		scan_and_register_archive_claims(scan_path, mod_name, file_name, load_index)
 
 	if ext == "pck" or cfg == null:
 		if cfg == null and ext != "pck":
@@ -1181,7 +1198,6 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var keys: PackedStringArray = cfg.get_section_keys("autoload")
 	for key in keys:
 		var autoload_name := str(key)
-		# Strip Godot autoload prefix (*), detect early-autoload prefix (!).
 		var raw_path := str(cfg.get_value("autoload", key)).lstrip("*").strip_edges()
 		var is_early := raw_path.begins_with("!")
 		if is_early:
@@ -1218,26 +1234,22 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		_log_info("  Autoload queued: " + autoload_name + " -> " + res_path + early_tag)
 		_register_claim(res_path, mod_name, file_name, load_index)
 
-
-# ─── Logging ──────────────────────────────────────────────────────────────────
+# Logging
 
 func _log_info(msg: String) -> void:
 	var line := "[ModLoader][Info] " + msg
 	print(line)
 	_report_lines.append(line)
 
-
 func _log_warning(msg: String) -> void:
 	var line := "[ModLoader][Warning] " + msg
 	push_warning(line)
 	_report_lines.append(line)
 
-
 func _log_critical(msg: String) -> void:
 	var line := "[ModLoader][Critical] " + msg
 	push_error(line)
 	_report_lines.append(line)
-
 
 func _log_debug(msg: String) -> void:
 	if not _developer_mode:
@@ -1246,8 +1258,7 @@ func _log_debug(msg: String) -> void:
 	print(line)
 	_report_lines.append(line)
 
-
-# ─── Override registry ────────────────────────────────────────────────────────
+# Override registry
 
 func _register_claim(res_path: String, mod_name: String, archive: String,
 		load_index: int) -> void:
@@ -1267,15 +1278,12 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 	var b_name := (b["mod_name"] as String).to_lower()
 	if a_name != b_name:
 		return a_name < b_name
-	# file_name is the archive's disk filename — guaranteed unique by the filesystem.
-	# This final tiebreaker makes the ordering a strict total order so that Godot's
-	# unstable introsort can never shuffle "equal" elements.
+	# Filename tiebreaker for stable sort.
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
+# Archive scanner
 
-# ─── Archive scanner ──────────────────────────────────────────────────────────
-
-func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
+func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		archive_file: String, load_index: int) -> void:
 	var zr := ZIPReader.new()
 	if zr.open(archive_path) != OK:
@@ -1317,7 +1325,9 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		if f.get_extension().to_lower() == "gd":
 			gd_analysis["total_gd_files"] = gd_analysis["total_gd_files"] + 1
 			if _developer_mode:
-				_scan_gd_source(zr.read_file(f).get_string_from_utf8(), gd_analysis)
+				var gd_bytes := zr.read_file(f)
+				if gd_bytes.size() > 0:
+					_scan_gd_source(gd_bytes.get_string_from_utf8(), gd_analysis)
 
 		var res_path := _normalize_to_res_path(f)
 		if res_path == "":
@@ -1351,7 +1361,6 @@ func _scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		_log_info("  " + str(gd_analysis["total_gd_files"]) + " .gd file(s), "
 				+ str(override_count) + " override target(s)" + dynamic_tag)
 
-
 func _normalize_to_res_path(zip_path: String) -> String:
 	var path := zip_path.replace("\\", "/")
 	if path.begins_with("res://"):   return path
@@ -1361,8 +1370,7 @@ func _normalize_to_res_path(zip_path: String) -> String:
 		return "res://" + path
 	return ""
 
-
-# ─── GDScript source analysis ─────────────────────────────────────────────────
+# GDScript source analysis
 
 func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 	for m in _re_take_over.search_all(text):
@@ -1402,15 +1410,13 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 	if not analysis["calls_base"]:
 		analysis["calls_base"] = "base(" in text
 
-	# Collect preload() paths for stale-cache detection.
+	# preload() paths — used for stale-cache detection.
 	for m_pl in _re_preload.search_all(text):
 		var pl_path := m_pl.get_string(1)
 		if pl_path not in (analysis["preload_paths"] as Array):
 			(analysis["preload_paths"] as Array).append(pl_path)
 
-	# Collect ALL method declarations. If this file extends a vanilla script,
-	# track which methods it overrides — this is the key data for method-level
-	# collision detection between mods.
+	# Method declarations — needed for mod collision detection.
 	var func_matches := _re_func.search_all(text)
 
 	# Determine the extends target for this file (if any).
@@ -1429,9 +1435,7 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 			if func_name not in method_list:
 				method_list.append(func_name)
 
-		# Check lifecycle methods for super(). Missing it breaks the override chain.
-		# Only flag scripts that extend a game script (res:// path). Standalone
-		# autoloads (extends Node, etc.) don't participate in override chains.
+		# Warn if lifecycle methods lack super() in scripts that extend game scripts.
 		if ext_target == "":
 			continue
 		if func_name not in LIFECYCLE_METHODS:
@@ -1444,13 +1448,9 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 			if func_name not in (analysis["lifecycle_no_super"] as Array):
 				(analysis["lifecycle_no_super"] as Array).append(func_name)
 
+# Override diagnostics (developer mode)
 
-
-# ─── Override diagnostics (developer mode) ───────────────────────────────────
-
-# Logs a timing note for each mod that uses overrideScript(). Runs after
-# autoloads have been instantiated — by this point the override is registered
-# but the scene hasn't reloaded yet, so existing nodes still have the old script.
+# Log which mods use overrideScript() — overrides apply after scene reload.
 func _log_override_timing_warnings() -> void:
 	for mod_name: String in _mod_script_analysis:
 		var analysis: Dictionary = _mod_script_analysis[mod_name]
@@ -1463,10 +1463,7 @@ func _log_override_timing_warnings() -> void:
 		_log_debug(mod_name + " uses overrideScript() on: " + target_list
 				+ " — applies after scene reload")
 
-
-# Walks the scene tree after reload and checks whether any live node's script
-# matches a known override target. Logs a warning for targets with zero matching
-# instances — the most common "mod does nothing" silent-failure case.
+# After reload, do any live nodes actually match the override targets?
 func _audit_override_instances() -> void:
 	var override_targets: Dictionary = {}  # res_path -> mod_name
 	for mod_name: String in _mod_script_analysis:
@@ -1492,9 +1489,7 @@ func _audit_override_instances() -> void:
 			_log_debug("Override registered but 0 nodes use " + target_path.get_file()
 					+ " in current scene — likely spawned at runtime [" + mod_name + "]")
 
-
 func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
-	# Iterative traversal to avoid stack overflow on deeply nested scene trees.
 	var stack: Array[Node] = [root_node]
 	while not stack.is_empty():
 		var node: Node = stack.pop_back()
@@ -1505,11 +1500,8 @@ func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
 				out[path] = (out.get(path, 0) as int) + 1
 		stack.append_array(node.get_children())
 
+# Two-pass helpers
 
-# ─── Two-pass helpers ─────────────────────────────────────────────────────────
-
-# Classify pending autoloads into prepend (early, ! prefix) and append (late).
-# ModLoader is always LAST in prepend — reverse insertion means last listed loads first.
 func _build_autoload_sections() -> Dictionary:
 	var prepend: Array[Dictionary] = []
 	var append: Array[Dictionary] = []
@@ -1520,8 +1512,6 @@ func _build_autoload_sections() -> Dictionary:
 			append.append({ "name": entry["name"], "path": entry["path"] })
 	return { "prepend": prepend, "append": append }
 
-
-# Collect full OS paths for all enabled mod archives (for pass state file).
 func _collect_enabled_archive_paths() -> PackedStringArray:
 	var paths := PackedStringArray()
 	var candidates: Array[Dictionary] = []
@@ -1536,13 +1526,8 @@ func _collect_enabled_archive_paths() -> PackedStringArray:
 		paths.append(c["full_path"])
 	return paths
 
-
-# Write override.cfg with FileAccess (not ConfigFile — ConfigFile erases null keys).
-# ModLoader is LAST in [autoload_prepend] (reverse insertion = last listed loads first).
-# Late (non-early) autoloads are NOT written here — Godot would try to load them
-# natively before archives are mounted, causing "file not found" errors. The modloader
-# handles late autoloads via add_child() in Pass 2 instead.
-# Atomic write: write .tmp then rename.
+# Uses FileAccess instead of ConfigFile (which erases null keys).
+# ModLoader listed last in [autoload_prepend] = loaded first (reverse insertion).
 func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var path := exe_dir.path_join("override.cfg")
@@ -1552,10 +1537,8 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 		lines.append("[autoload_prepend]")
 		for entry in prepend_autoloads:
 			lines.append('%s="*%s"' % [entry["name"], entry["path"]])
-		# ModLoader LAST = loads FIRST (reverse insertion).
 		lines.append('ModLoader="*' + MODLOADER_RES_PATH + '"')
 		lines.append("")
-	# Only ModLoader in [autoload] — late mod autoloads are handled by Pass 2 via add_child().
 	lines.append("[autoload]")
 	if prepend_autoloads.is_empty():
 		lines.append('ModLoader="*' + MODLOADER_RES_PATH + '"')
@@ -1565,102 +1548,116 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 		return FileAccess.get_open_error()
 	f.store_string("\n".join(lines) + "\n")
 	f.close()
+	# Windows DirAccess.rename() won't overwrite — remove target first.
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
 	var dir := DirAccess.open(exe_dir)
 	if dir == null:
 		DirAccess.remove_absolute(tmp)
 		return ERR_CANT_OPEN
-	var rename_err := dir.rename(tmp.get_file(), path.get_file())
-	if rename_err != OK:
+	var err := dir.rename(tmp.get_file(), path.get_file())
+	if err != OK:
 		DirAccess.remove_absolute(tmp)
-	return rename_err
+	return err
 
-
-# Persist archive paths and restart metadata for file-scope mounting in Pass 2.
-func _write_pass_state(archive_paths: PackedStringArray) -> void:
+func _write_pass_state(archive_paths: PackedStringArray, state_hash: String = "") -> Error:
 	var cfg := ConfigFile.new()
-	cfg.load(PASS_STATE_PATH)  # OK if doesn't exist
+	cfg.load(PASS_STATE_PATH)
 	var count: int = cfg.get_value("state", "restart_count", 0)
 	cfg.set_value("state", "restart_count", count + 1)
-	cfg.set_value("state", "mods_hash", _compute_mods_hash())
+	cfg.set_value("state", "mods_hash", state_hash)
 	cfg.set_value("state", "archive_paths", archive_paths)
 	cfg.set_value("state", "modloader_version", MODLOADER_VERSION)
 	cfg.set_value("state", "timestamp", Time.get_unix_time_from_system())
-	var save_err := cfg.save(PASS_STATE_PATH)
-	if save_err != OK:
-		_log_critical("Failed to save pass state (error %d) — two-pass restart will fail" % save_err)
+	var err := cfg.save(PASS_STATE_PATH)
+	if err != OK:
+		_log_critical("Failed to save pass state (error %d)" % err)
+	return err
 
-
-func _compute_mods_hash() -> String:
-	var dir := DirAccess.open(_mods_dir)
-	if dir == null:
+func _compute_state_hash(archive_paths: PackedStringArray, prepend_autoloads: Array[Dictionary]) -> String:
+	if archive_paths.is_empty() and prepend_autoloads.is_empty():
 		return ""
-	var entries := PackedStringArray()
-	dir.list_dir_begin()
-	var fname := dir.get_next()
-	while fname != "":
-		if not fname.begins_with("."):
-			entries.append(fname)
-		fname = dir.get_next()
-	dir.list_dir_end()
-	entries.sort()
-	return str(entries).md5_text()
+	var parts := PackedStringArray()
+	var sorted_paths := Array(archive_paths)
+	sorted_paths.sort()
+	for p in sorted_paths:
+		# Include mtime so replacing a file with the same name triggers a restart.
+		parts.append("a:%s@%d" % [p, FileAccess.get_modified_time(p)])
+	for entry in prepend_autoloads:
+		parts.append("p:%s=%s" % [entry["name"], entry["path"]])
+	for entry in _ui_mod_entries:
+		if entry["enabled"] and entry.get("cfg") != null:
+			var ver: String = (entry["cfg"] as ConfigFile).get_value("mod", "version", "")
+			if not ver.is_empty():
+				parts.append("v:%s=%s" % [entry["mod_id"], ver])
+	return "\n".join(parts).md5_text()
 
-
-# Write heartbeat to detect crashes. Deleted on successful completion.
 func _write_heartbeat() -> void:
 	var f := FileAccess.open(HEARTBEAT_PATH, FileAccess.WRITE)
 	if f:
 		f.store_string("started:%d" % Time.get_unix_time_from_system())
 		f.close()
 
-
 func _delete_heartbeat() -> void:
 	if FileAccess.file_exists(HEARTBEAT_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(HEARTBEAT_PATH))
 
-
-# If heartbeat exists from a previous launch, the game crashed. Increment counter.
-# After MAX_RESTART_COUNT crashes, wipe override.cfg to clean state.
 func _check_crash_recovery() -> void:
 	if not FileAccess.file_exists(HEARTBEAT_PATH):
 		return
-	_log_warning("Heartbeat file found — previous launch may have crashed")
+	_log_warning("Heartbeat detected — previous launch may have crashed")
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) == OK:
 		var count: int = cfg.get_value("state", "restart_count", 0)
 		if count >= MAX_RESTART_COUNT:
-			_log_critical("Restart loop detected (%d crashes) — restoring clean override.cfg" % count)
+			_log_critical("Restart loop (%d crashes) — resetting to clean state" % count)
 			_restore_clean_override_cfg()
 			DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 			_delete_heartbeat()
 			return
 	_delete_heartbeat()
 
-
-# User can create an empty "modloader_safe_mode" file in the game dir to force recovery.
 func _check_safe_mode() -> void:
 	var exe_dir := OS.get_executable_path().get_base_dir()
-	var safe_mode_path := exe_dir.path_join(SAFE_MODE_FILE)
-	if not FileAccess.file_exists(safe_mode_path):
+	var safe_path := exe_dir.path_join(SAFE_MODE_FILE)
+	if not FileAccess.file_exists(safe_path):
 		return
-	_log_warning("Safe mode file detected — restoring clean override.cfg")
+	_log_warning("Safe mode file detected — resetting to clean state")
 	_restore_clean_override_cfg()
 	if FileAccess.file_exists(PASS_STATE_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 	_delete_heartbeat()
-	DirAccess.remove_absolute(safe_mode_path)
+	DirAccess.remove_absolute(safe_path)
 
+func _clean_stale_cache() -> void:
+	# Remove cached zips whose source .vmz no longer exists in the mods folder.
+	var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
+	if not DirAccess.dir_exists_absolute(cache_dir):
+		return
+	var dir := DirAccess.open(cache_dir)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	while true:
+		var fname := dir.get_next()
+		if fname == "":
+			break
+		if fname.get_extension().to_lower() != "zip":
+			continue
+		var vmz_name := fname.get_basename() + ".vmz"
+		if not FileAccess.file_exists(_mods_dir.path_join(vmz_name)):
+			DirAccess.remove_absolute(cache_dir.path_join(fname))
+			_log_debug("Removed stale cache: " + fname)
+	dir.list_dir_end()
 
-# Write minimal override.cfg that only registers ModLoader.
 func _restore_clean_override_cfg() -> void:
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var f := FileAccess.open(exe_dir.path_join("override.cfg"), FileAccess.WRITE)
 	if f == null:
-		_log_critical("Cannot restore override.cfg — game dir may be read-only: " + exe_dir)
+		_log_critical("Cannot write override.cfg — game dir may be read-only: " + exe_dir)
 		return
 	f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n")
 	f.close()
-
 
 func _clear_restart_counter() -> void:
 	var cfg := ConfigFile.new()
@@ -1668,9 +1665,7 @@ func _clear_restart_counter() -> void:
 		cfg.set_value("state", "restart_count", 0)
 		cfg.save(PASS_STATE_PATH)
 
-
-
-# ─── Conflict summary ─────────────────────────────────────────────────────────
+# Conflict summary
 
 func _print_conflict_summary() -> void:
 	_log_info("")
@@ -1704,7 +1699,6 @@ func _print_conflict_summary() -> void:
 	_log_info("============================================")
 	_log_info("")
 
-
 func _write_conflict_report() -> void:
 	var f := FileAccess.open(CONFLICT_REPORT_PATH, FileAccess.WRITE)
 	if f == null:
@@ -1715,29 +1709,17 @@ func _write_conflict_report() -> void:
 	f.close()
 	_log_info("Conflict report written to: " + CONFLICT_REPORT_PATH)
 
-
-# ─── Autoload instantiation ───────────────────────────────────────────────────
+# Autoload instantiation
 
 func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: String) -> void:
-	# Neither FileAccess.file_exists() nor ResourceLoader.exists() is reliable for
-	# files in mounted archives across all systems. Try load() directly and use the
-	# existence checks only for diagnostics when load() fails.
 	var resource: Resource = load(res_path)
 	if resource == null:
-		var fa := FileAccess.file_exists(res_path)
-		var rl := ResourceLoader.exists(res_path)
-		_log_critical("Autoload failed: " + autoload_name + " -> " + res_path + " [" + mod_name + "]")
-		_log_critical("  FileAccess.file_exists=" + str(fa) + "  ResourceLoader.exists=" + str(rl))
-		if not fa and not rl:
-			_log_critical("  File not accessible after mounting. Possible causes:")
-			_log_critical("    - Windows backslash paths in zip (re-pack with 7-Zip)")
-			_log_critical("    - Archive failed to mount (check for earlier errors)")
-			_log_critical("    - Path in mod.txt doesn't match actual file path in archive")
-		else:
-			_log_critical("  File exists but failed to parse. Check the Godot log above.")
+		_log_critical("Autoload failed: %s -> %s [%s]" % [autoload_name, res_path, mod_name])
+		if _developer_mode:
+			_log_debug("  FileAccess=%s  ResourceLoader=%s"
+					% [str(FileAccess.file_exists(res_path)), str(ResourceLoader.exists(res_path))])
 		return
 
-	# Add to root so mods can find autoloads at /root/<name>, matching real autoload behavior.
 	if get_tree().root.has_node(autoload_name):
 		_log_warning("Autoload name '" + autoload_name + "' conflicts with existing node at /root/"
 				+ autoload_name + " — Godot will rename it. [" + mod_name + "]")
@@ -1776,37 +1758,25 @@ func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: St
 	_log_warning("Autoload is not a PackedScene or GDScript: " + autoload_name
 			+ " -> " + res_path + " [" + mod_name + "]")
 
-
-# ─── Mount helper ─────────────────────────────────────────────────────────────
+# Mount helper
 
 func _try_mount_pack(path: String) -> bool:
 	if ProjectSettings.load_resource_pack(path):
 		return true
 	if path.get_extension().to_lower() != "vmz":
 		return false
-	# VMZ files are renamed zips — copy to a real .zip path so Godot can open them.
-	var temp_zip := ProjectSettings.globalize_path(TMP_DIR).path_join(
-			path.get_file().get_basename() + ".zip")
-	var data := FileAccess.get_file_as_bytes(path)
-	if data.size() == 0:
-		return false
-	var out := FileAccess.open(temp_zip, FileAccess.WRITE)
-	if out == null:
-		return false
-	out.store_buffer(data)
-	out.close()
-	return ProjectSettings.load_resource_pack(temp_zip)
+	var zip_path := _static_vmz_to_zip(path)
+	return not zip_path.is_empty() and ProjectSettings.load_resource_pack(zip_path)
 
+# mod.txt parser
 
-# ─── mod.txt parser ───────────────────────────────────────────────────────────
-
-func _read_mod_config(path: String) -> ConfigFile:
+func read_mod_config(path: String) -> ConfigFile:
 	_last_mod_txt_status = "none"
 	var zr := ZIPReader.new()
 	if zr.open(path) != OK:
 		return null
 	if not zr.file_exists("mod.txt"):
-		# Scan for nested mod.txt (e.g. "SubFolder/mod.txt").
+		# Nested mod.txt (e.g. "SubFolder/mod.txt") means bad packaging.
 		for f: String in zr.get_files():
 			if f.get_file() == "mod.txt":
 				_last_mod_txt_status = "nested:" + f
@@ -1814,8 +1784,12 @@ func _read_mod_config(path: String) -> ConfigFile:
 				return null
 		zr.close()
 		return null
-	var text := zr.read_file("mod.txt").get_string_from_utf8()
+	var raw := zr.read_file("mod.txt")
 	zr.close()
+	if raw.size() == 0:
+		_last_mod_txt_status = "parse_error"
+		return null
+	var text := raw.get_string_from_utf8()
 	var cfg := _parse_mod_txt(text)
 	if cfg == null:
 		_last_mod_txt_status = "parse_error"
@@ -1823,8 +1797,7 @@ func _read_mod_config(path: String) -> ConfigFile:
 	_last_mod_txt_status = "ok"
 	return cfg
 
-
-func _read_mod_config_folder(folder_path: String) -> ConfigFile:
+func read_mod_config_folder(folder_path: String) -> ConfigFile:
 	_last_mod_txt_status = "none"
 	var mod_txt_path := folder_path.path_join("mod.txt")
 	if not FileAccess.file_exists(mod_txt_path):
@@ -1841,7 +1814,6 @@ func _read_mod_config_folder(folder_path: String) -> ConfigFile:
 	_last_mod_txt_status = "ok"
 	return cfg
 
-
 func _parse_mod_txt(text: String) -> ConfigFile:
 	if text.begins_with("\uFEFF"):
 		text = text.substr(1)
@@ -1850,10 +1822,9 @@ func _parse_mod_txt(text: String) -> ConfigFile:
 		return null
 	return cfg
 
+# Folder → temp zip (developer mode)
 
-# ─── Folder → temp zip (developer mode) ──────────────────────────────────────
-
-func _zip_folder_to_temp(folder_path: String) -> String:
+func zip_folder_to_temp(folder_path: String) -> String:
 	var folder_name := folder_path.get_file()
 	var tmp_zip_path := ProjectSettings.globalize_path(TMP_DIR).path_join(
 			folder_name + "_dev.zip")
@@ -1866,7 +1837,6 @@ func _zip_folder_to_temp(folder_path: String) -> String:
 	_zip_folder_recursive(zp, folder_path, "")
 	zp.close()
 	return tmp_zip_path
-
 
 func _zip_folder_recursive(zp: ZIPPacker, disk_path: String, archive_prefix: String) -> void:
 	var dir := DirAccess.open(disk_path)
@@ -1890,24 +1860,26 @@ func _zip_folder_recursive(zp: ZIPPacker, disk_path: String, archive_prefix: Str
 			zp.close_file()
 	dir.list_dir_end()
 
+# Update fetch helpers
 
-# ─── Update fetch helpers ─────────────────────────────────────────────────────
-
-# Compares two dotted version strings. Returns -1 if a < b, 0 if equal, 1 if a > b.
-# "0.0.2" vs "0.0.1" → 1 (local is newer, no update needed).
-func _compare_versions(a: String, b: String) -> int:
+# Returns -1/0/1 for version comparison (a < b, equal, a > b).
+# Returns -1/0/1 for version comparison (a < b, equal, a > b).
+func compare_versions(a: String, b: String) -> int:
+	if a.is_empty() or b.is_empty():
+		return 0 if a == b else (-1 if a.is_empty() else 1)
 	var pa := a.lstrip("vV").split(".")
 	var pb := b.lstrip("vV").split(".")
 	var n := max(pa.size(), pb.size())
 	for i in n:
-		var va := int(pa[i]) if i < pa.size() else 0
-		var vb := int(pb[i]) if i < pb.size() else 0
+		var sa := pa[i] if i < pa.size() else "0"
+		var sb := pb[i] if i < pb.size() else "0"
+		var va := int(sa) if sa.is_valid_int() else 0
+		var vb := int(sb) if sb.is_valid_int() else 0
 		if va < vb: return -1
 		if va > vb: return 1
 	return 0
 
-
-func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
+func fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 	var latest_versions := {}
 	for chunk_ids in _chunk_int_array(ids, MODWORKSHOP_BATCH_SIZE):
 		var req := HTTPRequest.new()
@@ -1919,7 +1891,7 @@ func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 		if err != OK:
 			req.queue_free()
 			continue
-		# request_completed → [result, http_code, headers, body]
+
 		var res: Array = await req.request_completed
 		req.queue_free()
 		if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
@@ -1929,8 +1901,7 @@ func _fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 			latest_versions.merge(parsed, true)
 	return latest_versions
 
-
-func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
+func download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 	var req := HTTPRequest.new()
 	req.timeout = API_DOWNLOAD_TIMEOUT
 	req.download_body_size_limit = 256 * 1024 * 1024
@@ -1960,7 +1931,7 @@ func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool
 	out.store_buffer(response_body)
 	out.close()
 
-	if _read_mod_config(temp_path) == null:
+	if read_mod_config(temp_path) == null:
 		DirAccess.remove_absolute(temp_path)
 		return false
 
@@ -1983,7 +1954,6 @@ func _download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool
 	if FileAccess.file_exists(backup_path):
 		DirAccess.remove_absolute(backup_path)
 	return true
-
 
 func _chunk_int_array(arr: Array[int], chunk_size: int) -> Array:
 	var result: Array = []

--- a/modloader.gd
+++ b/modloader.gd
@@ -1537,6 +1537,10 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 				method_list.append(func_name)
 
 		# Check lifecycle methods for super(). Missing it breaks the override chain.
+		# Only flag scripts that extend a game script (res:// path). Standalone
+		# autoloads (extends Node, etc.) don't participate in override chains.
+		if ext_target == "":
+			continue
 		if func_name not in LIFECYCLE_METHODS:
 			continue
 		var body_start := func_matches[i].get_end()

--- a/modloader.gd
+++ b/modloader.gd
@@ -53,6 +53,7 @@ var _re_extends_classname: RegEx
 var _re_class_name: RegEx
 var _re_func: RegEx
 var _re_preload: RegEx
+var _re_filename_priority: RegEx
 
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
@@ -105,6 +106,9 @@ func _compile_regex() -> void:
 	_re_func.compile('(?m)^(?:static\\s+)?func\\s+(\\w+)\\s*\\(')
 	_re_preload = RegEx.new()
 	_re_preload.compile('preload\\s*\\(\\s*"(res://[^"]+)"\\s*\\)')
+	# VostokMods compat: "100-ModName.vmz" encodes priority in the filename.
+	_re_filename_priority = RegEx.new()
+	_re_filename_priority.compile('^(-?\\d+)-(.*)')
 
 
 # ─── Mod metadata collection (no mounting) ────────────────────────────────────
@@ -173,11 +177,30 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 	var mod_name := file_name
 	var mod_id   := file_name
 	var priority := 0
+
+	# VostokMods compat: parse "100-ModName.vmz" filename priority prefix.
+	# The prefix is stripped from mod_name/mod_id defaults and used as fallback priority.
+	var base_name := file_name.get_basename()  # strip extension
+	var filename_priority := 0
+	var has_filename_priority := false
+	if _re_filename_priority:
+		var m := _re_filename_priority.search(base_name)
+		if m:
+			filename_priority = int(m.get_string(1))
+			base_name = m.get_string(2)
+			has_filename_priority = true
+			mod_name = base_name
+			mod_id   = base_name
+
 	if cfg:
-		mod_name = str(cfg.get_value("mod", "name", file_name))
-		mod_id   = str(cfg.get_value("mod", "id",   file_name))
+		mod_name = str(cfg.get_value("mod", "name", mod_name))
+		mod_id   = str(cfg.get_value("mod", "id",   mod_id))
 		if cfg.has_section_key("mod", "priority"):
 			priority = int(str(cfg.get_value("mod", "priority")))
+		elif has_filename_priority:
+			priority = filename_priority
+	elif has_filename_priority:
+		priority = filename_priority
 	return {
 		"file_name": file_name, "full_path": full_path, "ext": ext,
 		"mod_name": mod_name, "mod_id": mod_id,
@@ -1265,7 +1288,8 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var keys: PackedStringArray = cfg.get_section_keys("autoload")
 	for key in keys:
 		var autoload_name := str(key)
-		var res_path := str(cfg.get_value("autoload", key)).lstrip("*").strip_edges()
+		# Strip Godot autoload prefix (*) and VostokMods early-autoload prefix (!).
+		var res_path := str(cfg.get_value("autoload", key)).lstrip("*!").strip_edges()
 
 		if res_path == "":
 			_log_warning("  Empty autoload path for '" + autoload_name + "' — skipped")

--- a/modloader.gd
+++ b/modloader.gd
@@ -87,13 +87,14 @@ static func _mount_previous_session() -> int:
 		any_missing = true
 
 	if any_missing:
-		# Archive gone, no cache. Wipe override.cfg so the next boot is clean.
-		# This boot might log errors for the missing autoloads but won't crash
-		# (Godot 4.6 treats missing [autoload_prepend] scripts as non-fatal).
+		# Archive gone, no cache. Wipe override.cfg autoload sections so the next
+		# boot is clean, but preserve any non-autoload settings ([display], etc.).
 		var exe_dir := OS.get_executable_path().get_base_dir()
-		var f := FileAccess.open(exe_dir.path_join("override.cfg"), FileAccess.WRITE)
+		var cfg_path := exe_dir.path_join("override.cfg")
+		var preserved := _read_preserved_cfg_sections(cfg_path)
+		var f := FileAccess.open(cfg_path, FileAccess.WRITE)
 		if f:
-			f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n")
+			f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n" + preserved)
 			f.close()
 		var state_path := ProjectSettings.globalize_path(PASS_STATE_PATH)
 		if FileAccess.file_exists(state_path):
@@ -1530,12 +1531,40 @@ func _collect_enabled_archive_paths() -> PackedStringArray:
 		paths.append(c["full_path"])
 	return paths
 
+# Reads override.cfg and returns lines for sections OTHER than [autoload] and
+# [autoload_prepend]. Used to preserve user/game settings when rewriting.
+static func _read_preserved_cfg_sections(cfg_path: String) -> String:
+	if not FileAccess.file_exists(cfg_path):
+		return ""
+	var f := FileAccess.open(cfg_path, FileAccess.READ)
+	if f == null:
+		return ""
+	var text := f.get_as_text()
+	f.close()
+	var result := PackedStringArray()
+	var in_autoload_section := false
+	for line in text.split("\n"):
+		var stripped := line.strip_edges()
+		if stripped.begins_with("["):
+			var section := stripped.to_lower()
+			in_autoload_section = section == "[autoload]" or section == "[autoload_prepend]"
+			if not in_autoload_section:
+				result.append(line)
+			continue
+		if not in_autoload_section and stripped != "":
+			result.append(line)
+	var preserved := "\n".join(result).strip_edges()
+	if preserved.is_empty():
+		return ""
+	return "\n" + preserved + "\n"
+
 # Uses FileAccess instead of ConfigFile (which erases null keys).
 # ModLoader listed last in [autoload_prepend] = loaded first (reverse insertion).
 func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var path := exe_dir.path_join("override.cfg")
 	var tmp := path + ".tmp"
+	var preserved := _read_preserved_cfg_sections(path)
 	var lines := PackedStringArray()
 	if prepend_autoloads.size() > 0:
 		lines.append("[autoload_prepend]")
@@ -1550,7 +1579,7 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 	var f := FileAccess.open(tmp, FileAccess.WRITE)
 	if f == null:
 		return FileAccess.get_open_error()
-	f.store_string("\n".join(lines) + "\n")
+	f.store_string("\n".join(lines) + "\n" + preserved)
 	f.close()
 	# Windows DirAccess.rename() won't overwrite — remove target first.
 	if FileAccess.file_exists(path):
@@ -1656,11 +1685,13 @@ func _clean_stale_cache() -> void:
 
 func _restore_clean_override_cfg() -> void:
 	var exe_dir := OS.get_executable_path().get_base_dir()
-	var f := FileAccess.open(exe_dir.path_join("override.cfg"), FileAccess.WRITE)
+	var path := exe_dir.path_join("override.cfg")
+	var preserved := _read_preserved_cfg_sections(path)
+	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
 		_log_critical("Cannot write override.cfg — game dir may be read-only: " + exe_dir)
 		return
-	f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n")
+	f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n" + preserved)
 	f.close()
 
 func _clear_restart_counter() -> void:

--- a/override.cfg
+++ b/override.cfg
@@ -1,2 +1,2 @@
 [autoload]
-ModLoader="user://modloader.gd"  # Path to your bootstrap script
+ModLoader="*res://modloader.gd"


### PR DESCRIPTION
Full rewrite of the mod loader for Early Access.

## What changed

**Two-pass architecture for early autoloads.** Mods can now load *before* game autoloads by using a `!` prefix in mod.txt. The mod loader writes a temporary `override.cfg` with `[autoload_prepend]`, restarts the game, and the mod's autoloads run before Loader/Database/Simulation initialize. Includes crash recovery (heartbeat + restart counter), safe mode file, and atomic override.cfg writes.

**Load order is now deterministic.** Previously with 17+ mods, Godot's introsort could shuffle mods that shared the same priority. Sort now uses a strict total order: priority → mod name → archive filename.

**VostokMods compatibility.** Filename-encoded priority (e.g. `100-ModName.vmz`) is parsed and used as fallback when mod.txt doesn't set priority. Early-autoload prefix (`!`) is stripped so VostokMods-packaged mods work without changes.

**Developer mode.** All heavy analysis is behind a toggle in the Settings tab. Off by default — regular users get a clean, fast launch. Devs/modders can turn it on for:
- Compatibility tab with dry-scan conflict analysis
- Pre-flight compile check on override scripts
- Post-reload override audit
- Conflict report written to modloader_conflicts.txt
- Verbose debug logging
- Loose folder loading for mod development

**10+ conflict checks** (up from 5): take_over_path collisions, broken override chains (missing super()), file overlap between mod pairs, Database.gd replacement impact, class_name double override detection, broken extends paths, base() usage (Godot 3 pattern), method-level collisions, stale preload paths, bad zip detection (Windows backslash paths).

**UI overhaul.** Compatibility tab is split-pane with clickable issue cards. Updates tab has per-mod download buttons with rollback. Settings tab for developer mode.

**Robustness fixes:**
- Skip restart when mod list hasn't changed between launches
- Mount all archives early (before UI) for reliable metadata extraction
- Guard against window-close crash during download, await coroutines
- Preserve non-autoload sections when rewriting override.cfg
- Autoload loading uses load() directly instead of unreliable FileAccess checks
- can_instantiate() validation before running mod scripts
- Re-entrancy guard prevents double-init after reload
- HTTP timeouts on update checks and downloads
- Iterative scene tree traversal (no stack overflow on deep trees)
- BOM handling in mod.txt parsing
- Backup + rollback on mod downloads

**README updated** with two-pass docs, developer mode, conflict message explanations, mod author guidance, archive format table, and MIT license.

## Files changed

- `modloader.gd` — full rewrite (~2000 lines)
- `README.md` — rewritten for v2.0
- `override.cfg` — uses `res://` path (game dir)