### PR TITLE
Fix non-deterministic load order with 17+ mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher U
 
 ## Requirements
 
-- Road to Vostok(PC, Steam)
+- Road to Vostok (PC, Steam)
 - Mods packaged as `.zip`, `.vmz`, or `.pck` files
 
 ---

--- a/modloader.gd
+++ b/modloader.gd
@@ -167,6 +167,8 @@ func _build_folder_entry(mods_dir: String, dir_name: String) -> Dictionary:
 	return _entry_from_config(cfg, dir_name, folder_path, "folder")
 
 
+# Future: mod.txt may support [mod] load_after = "other_mod_id" for soft dependencies.
+# This would feed into a topological sort pass before the priority/name sort.
 func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, ext: String) -> Dictionary:
 	var mod_name := file_name
 	var mod_id   := file_name
@@ -506,7 +508,7 @@ func _build_mods_tab() -> Control:
 		for child in order_list.get_children():
 			child.queue_free()
 		var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
-		sorted.sort_custom(func(a, b): return a["priority"] < b["priority"])
+		sorted.sort_custom(_compare_load_order)
 		if sorted.is_empty():
 			var lbl := Label.new()
 			lbl.text = "(none enabled)"
@@ -800,7 +802,7 @@ func _run_dry_compat_analysis(populate_cb: Callable) -> void:
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
 	var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
-	sorted.sort_custom(func(a, b): return a["priority"] < b["priority"])
+	sorted.sort_custom(_compare_load_order)
 
 	if sorted.is_empty():
 		populate_cb.call([])
@@ -1145,17 +1147,27 @@ func _load_all_mods() -> void:
 		if not entry["enabled"]:
 			continue
 		candidates.append(entry.duplicate())
-	candidates.sort_custom(func(a, b): return a["priority"] < b["priority"])
+	candidates.sort_custom(_compare_load_order)
 
 	if candidates.is_empty():
 		_log_info("No mods enabled.")
 		return
 
+	# Warn about duplicate mod names — likely a packaging mistake or fork.
+	# The sort is still deterministic (file_name tiebreaker), but users should know.
+	for i in range(1, candidates.size()):
+		if (candidates[i]["mod_name"] as String).to_lower() \
+				== (candidates[i - 1]["mod_name"] as String).to_lower():
+			_log_warning("Duplicate mod name '" + candidates[i]["mod_name"]
+					+ "' — archives '" + candidates[i - 1]["file_name"]
+					+ "' and '" + candidates[i]["file_name"]
+					+ "'. Load order tie broken by archive filename.")
+
 	_log_info("=== Load Order ===")
 	for i in candidates.size():
 		var c: Dictionary = candidates[i]
-		var tag := " [priority=" + str(c["priority"]) + "]" if c["priority"] != 0 else ""
-		_log_info("  [" + str(i + 1) + "] " + c["mod_name"] + " | " + c["file_name"] + tag)
+		_log_info("  [" + str(i + 1) + "] " + c["mod_name"] + " | " + c["file_name"]
+				+ " [priority=" + str(c["priority"]) + "]")
 	_log_info("==================")
 
 	for load_index in candidates.size():
@@ -1323,6 +1335,18 @@ func _register_claim(res_path: String, mod_name: String, archive: String,
 		"mod_name": mod_name, "archive": archive, "load_index": load_index,
 		"claim_type": claim_type, "source_path": source_path,
 	})
+
+func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
+	if a["priority"] != b["priority"]:
+		return a["priority"] < b["priority"]
+	var a_name := (a["mod_name"] as String).to_lower()
+	var b_name := (b["mod_name"] as String).to_lower()
+	if a_name != b_name:
+		return a_name < b_name
+	# file_name is the archive's disk filename — guaranteed unique by the filesystem.
+	# This final tiebreaker makes the ordering a strict total order so that Godot's
+	# unstable introsort can never shuffle "equal" elements.
+	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
 func _is_dangerous_path(res_path: String) -> bool:
 	return _vanilla_paths.has(res_path)

--- a/modloader.gd
+++ b/modloader.gd
@@ -53,6 +53,7 @@ var _re_extends_classname: RegEx
 var _re_class_name: RegEx
 var _re_func: RegEx
 var _re_preload: RegEx
+var _re_filename_priority: RegEx
 
 
 # ─── Entry point ──────────────────────────────────────────────────────────────
@@ -105,6 +106,9 @@ func _compile_regex() -> void:
 	_re_func.compile('(?m)^(?:static\\s+)?func\\s+(\\w+)\\s*\\(')
 	_re_preload = RegEx.new()
 	_re_preload.compile('preload\\s*\\(\\s*"(res://[^"]+)"\\s*\\)')
+	# VostokMods compat: "100-ModName.vmz" encodes priority in the filename.
+	_re_filename_priority = RegEx.new()
+	_re_filename_priority.compile('^(-?\\d+)-(.*)')
 
 
 # ─── Mod metadata collection (no mounting) ────────────────────────────────────
@@ -173,11 +177,30 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 	var mod_name := file_name
 	var mod_id   := file_name
 	var priority := 0
+
+	# VostokMods compat: parse "100-ModName.vmz" filename priority prefix.
+	# The prefix is stripped from mod_name/mod_id defaults and used as fallback priority.
+	var base_name := file_name.get_basename()  # strip extension
+	var filename_priority := 0
+	var has_filename_priority := false
+	if _re_filename_priority:
+		var m := _re_filename_priority.search(base_name)
+		if m:
+			filename_priority = int(m.get_string(1))
+			base_name = m.get_string(2)
+			has_filename_priority = true
+			mod_name = base_name
+			mod_id   = base_name
+
 	if cfg:
-		mod_name = str(cfg.get_value("mod", "name", file_name))
-		mod_id   = str(cfg.get_value("mod", "id",   file_name))
+		mod_name = str(cfg.get_value("mod", "name", mod_name))
+		mod_id   = str(cfg.get_value("mod", "id",   mod_id))
 		if cfg.has_section_key("mod", "priority"):
 			priority = int(str(cfg.get_value("mod", "priority")))
+		elif has_filename_priority:
+			priority = filename_priority
+	elif has_filename_priority:
+		priority = filename_priority
 	return {
 		"file_name": file_name, "full_path": full_path, "ext": ext,
 		"mod_name": mod_name, "mod_id": mod_id,
@@ -1265,7 +1288,8 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var keys: PackedStringArray = cfg.get_section_keys("autoload")
 	for key in keys:
 		var autoload_name := str(key)
-		var res_path := str(cfg.get_value("autoload", key)).lstrip("*").strip_edges()
+		# Strip Godot autoload prefix (*) and VostokMods early-autoload prefix (!).
+		var res_path := str(cfg.get_value("autoload", key)).lstrip("*!").strip_edges()
 
 		if res_path == "":
 			_log_warning("  Empty autoload path for '" + autoload_name + "' — skipped")


### PR DESCRIPTION
## Summary

Fixes mod load order becoming unpredictable when 17+ mods are enabled, and adds cross-compatibility with [VostokMods](https://github.com/Ryhon0/VostokMods) mod loader.

**Reported by user smel:** XP & Skills System and Cash System broke when enabling a 17th mod, all at default priority 0.

## Root Cause: Godot Introsort Threshold

Godot's `Array.sort_custom()` switches from insertion sort to introsort quicksort partitioning at exactly 17 elements (`INTROSORT_THRESHOLD = 16` in [`core/templates/sort_array.h`](https://github.com/godotengine/godot/blob/master/core/templates/sort_array.h)). Confirmed by [godotengine/godot#49618](https://github.com/godotengine/godot/issues/49618) and [godotengine/godot-proposals#5552](https://github.com/godotengine/godot-proposals/issues/5552).

| Mod count | Sort algorithm | Equal-element behavior |
|-----------|---------------|----------------------|
| 1-16 | Insertion sort | Preserves original order (appears stable) |
| **17+** | **Introsort (quicksort + heapsort)** | **Shuffles equal elements unpredictably** |

The old comparator only checked `priority` — with all mods at 0, every element was "equal" and the sort shuffled them arbitrarily when crossing the 17-element threshold.

## Changes

### Commit 1: Deterministic load order

**`_compare_load_order()`** — new shared comparator (replaces 3 inline lambdas) producing a strict total order:

1. **Priority** (ascending) — from `mod.txt [mod] priority` or UI SpinBox
2. **Mod name** (case-insensitive ascending) — from `mod.txt [mod] name` or archive filename
3. **Archive filename** (case-insensitive ascending) — guaranteed unique by filesystem

The `file_name` final tiebreaker ensures no two entries can compare as "equal", making the sort deterministic regardless of array size or algorithm stability.

**Additional:**
- Duplicate mod name detection with warning logged
- Load order log always shows priority value (even when 0) to aid debugging
- Reserved `[mod] load_after` field name for future soft-dependency support

### Commit 2: VostokMods cross-compatibility

Compared against [Ryhon0/VostokMods](https://github.com/Ryhon0/VostokMods) to ensure mods packaged for either loader work correctly:

**Filename priority prefix** — VostokMods encodes priority as `100-ModName.vmz`. Now parsed as fallback priority when `mod.txt` doesn't specify one; prefix stripped from default mod name/id. `mod.txt [mod] priority` still takes precedence.

**Early autoload prefix** — VostokMods uses `!` prefix in autoload paths (`!res://path.gd`) for early autoloads. Now stripped alongside Godot's `*` prefix so paths resolve correctly.

### Full VostokMods compatibility matrix

| Feature | VostokMods | This loader | Status |
|---------|-----------|-------------|--------|
| `.vmz` archives | Yes | Yes | Compatible |
| `.zip` archives | Via symlink | Direct | Compatible |
| `mod.txt` format | Required | Optional | Compatible (superset) |
| Filename priority (`100-Name.vmz`) | Yes | **Now yes** | Fixed in this PR |
| `!` early autoload prefix | Yes | **Now stripped** | Fixed in this PR |
| `[mod] priority` in mod.txt | Yes | Yes | Compatible |
| `[autoload]` section | Yes | Yes | Compatible |
| `override.cfg` merging | Yes | No | Future work |
| `class_list` registration | Yes | No | Future work |
| `copyFiles/` extraction | Yes | No | Future work |

## Edge Cases

| Scenario | Handled by |
|----------|-----------|
| All mods at priority 0 (smel's setup) | `mod_name` alphabetical tiebreaker |
| `100-ModName.vmz` without mod.txt | Filename prefix parsed as priority, name stripped |
| `100-ModName.vmz` WITH mod.txt priority | mod.txt priority takes precedence over filename |
| Duplicate `mod_name` across archives | `file_name` tiebreaker + warning logged |
| PCK files without `mod.txt` | `mod_name` defaults to `file_name` — still unique |
| 16 or fewer mods (below threshold) | Tiebreaker is redundant but correct — no regression |
| Mixed priorities | Priority sorts first; tiebreaker only within same-priority groups |
| `!res://path.gd` autoload path | `!` stripped, path resolves correctly |
| Negative filename priority (`-5-ModName.vmz`) | Regex handles negative numbers |

## Test plan

- [ ] Launch with 17+ mods all at priority 0 — verify load order matches alphabetical-by-name in the log
- [ ] Launch multiple times — verify load order is identical across runs
- [ ] Test with mixed priorities — verify priority ordering takes precedence
- [ ] Test with two mods sharing the same `[mod] name` — verify warning is logged and `file_name` breaks the tie
- [ ] Test with `100-ModName.vmz` filename — verify priority 100 is parsed and name is cleaned
- [ ] Test with `100-ModName.vmz` that also has `[mod] priority = 50` — verify mod.txt wins (priority 50)
- [ ] Test with a VostokMods mod using `!` autoload prefix — verify it loads correctly
- [ ] Verify the UI load order preview matches the actual mount order