### PR TITLE
Hook all class_name methods without mod.txt declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,47 @@
-# Road to Vostok — Community Mod Loader
+# Road to Vostok - Community Mod Loader
 
-A community-built mod loader for **Road to Vostok** (Godot 4). Adds a launcher UI before the game starts, letting you enable/disable mods, set load order, and check for updates.
+Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods, load order, and updates.
 
----
+## Requirements
+
+- Road to Vostok (PC, Steam)
+- Mods packaged as `.vmz` files
 
 ## Installation
 
-Both files go in the **game installation folder** (next to `RTV.exe`):
+1. Copy `override.cfg` and `modloader.gd` into the game folder:
+   ```
+   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
+   ```
 
-```
-C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
-```
+2. Create a `mods` folder if it doesn't exist:
+   ```
+   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods\
+   ```
 
-1. Copy `override.cfg` and `modloader.gd` into the game folder.
+3. Drop `.vmz` mod files into `mods/`.
 
-2. Create a `mods` folder inside the game folder if it doesn't exist.
-
-3. Place your `.vmz` mod files inside the `mods` folder.
-
-4. Launch the game normally. The mod loader UI will appear before the main menu.
-
-**That's it.** No AppData setup needed — everything lives in one folder.
-
----
+4. Launch the game. The mod loader UI appears before the main menu.
 
 ## Installing Mods
 
-Drop `.vmz` mod files into the `mods` folder. The mod loader finds them automatically on next launch.
+Drop `.vmz` files into the `mods` folder. They show up automatically on next launch.
 
-If a mod was distributed as a `.zip` file, rename it to `.vmz` before placing it in the mods folder.
+`.pck` files also work but have no mod.txt metadata, autoloads, or update checking.
 
----
+## Launcher UI
 
-## Using the Launcher
+The mod loader opens with two tabs:
 
-When you start the game, the mod loader window opens with two tabs:
+**Mods** - Lists detected mods with checkboxes and a priority spinbox. Higher priority loads later and wins file conflicts. The load order panel on the right updates in real time.
 
-### Mods
-Enable or disable mods with checkboxes. The **priority number** controls load order — higher number loads later and wins when two mods change the same file. The **Load Order** panel on the right shows the final order in real time.
+**Updates** - If mods include ModWorkshop info in `mod.txt`, you can check for and download updates here.
 
-### Updates
-Click **Check for Updates** to see if any of your mods have newer versions available on ModWorkshop.
+Click **Launch Game** or close the window to start.
 
-### Settings
-Toggle **Developer Mode** to enable the Compatibility tab and verbose conflict logging. Off by default — only needed for mod authors or troubleshooting.
+## mod.txt
 
-Click **Launch Game** when you're ready to play.
-
----
-
-## Troubleshooting
-
-If the game crashes or gets stuck after enabling mods:
-
-- **Wait it out.** After 2 failed launches, the mod loader automatically resets to a clean state.
-- **Manual reset:** Create an empty file named `modloader_safe_mode` (no file extension) in the game folder. On next launch, the mod loader resets and deletes the file.
-- **Full reset:** Delete `override.cfg` from the game folder and replace it with a fresh copy from the mod loader release.
-
----
-
-## Uninstalling
-
-Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder and its contents can be removed separately.
-
-Settings are stored in `%APPDATA%\Road to Vostok\mod_config.cfg` and can be deleted safely.
-
----
-
-# For Mod Authors
-
-Everything below is for mod developers.
-
----
-
-## mod.txt Reference
-
-Mod archives must contain a `mod.txt` file at their root:
+Mods can include a `mod.txt` at the root of their archive. All string values need to be quoted.
 
 ```ini
 [mod]
@@ -85,7 +51,7 @@ version="1.0.0"
 priority=0
 
 [autoload]
-MyModMain="res://MyMod/Main.gd"
+MyModMain="res://MyModMain/Main.gd"
 
 [updates]
 modworkshop=12345
@@ -93,118 +59,208 @@ modworkshop=12345
 
 | Field | Description |
 |---|---|
-| `name` | Display name shown in the UI (must be quoted) |
-| `id` | Unique identifier — duplicates are skipped |
-| `version` | Semver string used for update comparison |
-| `priority` | Load order number. Higher = loads later = wins. Default 0 |
-| `[autoload]` | `Name="res://path/to/script.gd"` — instantiated as a Node after all mods mount |
-| `[autoload]` `!` prefix | `Name="!res://path.gd"` — loads **before** game autoloads (see Early Autoloads) |
-| `[updates] modworkshop` | ModWorkshop mod ID for update checking |
+| `name` | Display name in the UI |
+| `id` | Unique ID. Duplicates are skipped. |
+| `version` | Version string for update comparison |
+| `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
+| `[autoload]` | `Name="res://path.gd"` - instantiated as a Node after mods mount |
+| `[hooks]` | Declares methods to hook. See [Hooks](#hooks). |
+| `[updates] modworkshop` | ModWorkshop ID for update checking |
 
-String values must be quoted. Mods without `mod.txt` will mount but show a warning.
+Mods without `mod.txt` still mount as resource packs. Their files override vanilla resources, but no autoloads run.
 
-### Supported archive formats
+## Hooks
 
-| Format | Notes |
-|--------|-------|
-| `.vmz` | Road to Vostok's native mod format (renamed zip) |
-| `.zip` | Must be renamed to `.vmz` before use |
-| `.pck` | Godot PCK — mount only, no mod.txt or autoloads |
+Hooks let you intercept methods on vanilla `class_name` scripts without replacing the whole file. Multiple mods can hook the same method.
 
-### Load priority
+### How it works
 
-Higher number = loads later = wins any file conflict. Default is `0`. Equal priority sorts alphabetically.
+1. Declare which methods you want to hook in `mod.txt`.
+2. At launch, the mod loader reads the game's binary-tokenized scripts, reconstructs the source, and rewrites the target methods with dispatch wrappers.
+3. Your autoload calls `ModLoader.add_hook()` to register callbacks.
 
-Priority controls both which archive's files win *and* which mod's `take_over_path()` executes last — it's the main tool for resolving conflicts between mods that touch the same scripts.
+Rewritten scripts are applied via `take_over_path()`. Vanilla source is cached between launches. The cache auto-invalidates when the game executable changes.
 
----
+### Declaring hooks
 
-## Early Autoloads (Two-Pass Loading)
+Add a `[hooks]` section to `mod.txt`. Keys are `res://` script paths, values are comma-separated method names:
 
-Most mods load **after** the game's core systems (Loader, Database, Simulation) are already initialized. If your mod needs to run **before** those systems — for example, to modify the shelter list before `Loader._ready()` validates saves — prefix its autoload path with `!`:
+```ini
+[hooks]
+"res://Scripts/Controller.gd"="Movement, Gravity"
+"res://Scripts/Door.gd"="_ready, Interact"
+```
+
+Rules:
+- The script needs a `class_name` declaration.
+- Only methods the script defines can be hooked. Inherited methods that aren't overridden (like an un-overridden `_ready`) can't be hooked.
+- Typos in method names produce a warning in the log.
+- You need an `[autoload]` to call `add_hook()` at runtime.
+
+### add_hook()
+
+Call this from your autoload's `_ready()`:
+
+```gdscript
+ModLoader.add_hook(
+    script_path: String,   # must match the key in [hooks]
+    method_name: String,   # must match a declared method
+    callback: Callable,    # your function
+    before: bool = true    # true = before hook, false = after hook
+)
+```
+
+### Before hooks
+
+Fires before the vanilla method. Receives the instance and an args array:
+
+```gdscript
+func my_hook(instance: Object, args: Array) -> Variant:
+    # instance - the object (null for static methods)
+    # args - [arg0, arg1, ...] matching the method's parameters
+    #
+    # Mutate args in-place to change what vanilla receives:
+    #   args[0] = new_value
+    #
+    # Return true to skip the vanilla method entirely.
+    pass
+```
+
+### After hooks
+
+Fires after the vanilla method. Gets the instance, args, and a result wrapper:
+
+```gdscript
+func my_hook(instance: Object, args: Array, result: Array) -> void:
+    # result - [return_value] or [] for void methods
+    # Mutate result[0] to change the return value.
+    pass
+```
+
+### Example: faster doors
+
+Makes doors open 10x faster by changing `openSpeed` after vanilla `_ready` runs.
+
+**mod.txt:**
+```ini
+[mod]
+name="Fast Doors"
+id="fast_doors"
+version="1.0.0"
+
+[hooks]
+"res://Scripts/Door.gd"="_ready"
+
+[autoload]
+FastDoors="res://FastDoors/Main.gd"
+```
+
+**FastDoors/Main.gd:**
+```gdscript
+extends Node
+
+func _ready() -> void:
+    ModLoader.add_hook(
+        "res://Scripts/Door.gd",
+        "_ready",
+        _on_door_ready,
+        false  # after hook
+    )
+
+func _on_door_ready(instance: Object, args: Array, result: Array) -> void:
+    if instance and "openSpeed" in instance:
+        instance.openSpeed = 40.0  # default is 4.0
+```
+
+### Example: low gravity
+
+Halves gravity by mutating the delta argument on every physics frame.
+
+**mod.txt:**
+```ini
+[mod]
+name="Low Gravity"
+id="low_gravity"
+version="1.0.0"
+
+[hooks]
+"res://Scripts/Controller.gd"="Gravity"
+
+[autoload]
+LowGravity="res://LowGravity/Main.gd"
+```
+
+**LowGravity/Main.gd:**
+```gdscript
+extends Node
+
+func _ready() -> void:
+    ModLoader.add_hook(
+        "res://Scripts/Controller.gd",
+        "Gravity",
+        _low_gravity,
+        true  # before hook
+    )
+
+func _low_gravity(instance: Object, args: Array) -> void:
+    if args.size() > 0:
+        args[0] = args[0] * 0.5
+```
+
+### Skipping vanilla
+
+Return `true` from a before hook to prevent the original method from running:
+
+```gdscript
+func _skip_loot(instance: Object, args: Array) -> bool:
+    return true  # vanilla GenerateLoot won't run
+```
+
+### Multiple mods on the same method
+
+- Before hooks run in load order (by `priority`). If one returns `true`, later before hooks, the vanilla method, and after hooks are all skipped.
+- When nothing skips, all after hooks run in order.
+- Registering the same Callable twice is a no-op.
+
+### Hooks vs file replacement
+
+| | Hooks | File replacement |
+|---|---|---|
+| Multiple mods per script | Yes | Last loaded wins |
+| Survives game updates | Yes, cache rebuilds | May break |
+| Scope | Per-method | Whole file |
+
+### Limitations
+
+- Only methods the script defines can be hooked. If a script doesn't override `_ready()`, you can't hook it.
+- Hooking methods called every frame (from `_physics_process`) adds minor overhead from the dispatch wrapper.
+- Source is reconstructed from Godot's binary token format. Original comments are not preserved.
+
+### Troubleshooting
+
+- **"add_hook() for undeclared script"** - `script_path` doesn't match any key in your `[hooks]` section.
+- **"add_hook() for undeclared method"** - method name wasn't declared in `mod.txt`. The wrapper wasn't generated.
+- **"Method not found in script"** - the method doesn't exist in the vanilla script. Check spelling.
+- **"hooked but also replaced by..."** - another mod replaces the same script file. Hooks wrap the modded version.
+
+Errors go to `%APPDATA%\Road to Vostok\modloader_conflicts.txt`.
+
+## Early Autoloads
+
+Prefix an autoload with `!` to load it before the game's own autoloads:
 
 ```ini
 [autoload]
-ShelterFix="!res://ShelterMod/Fix.gd"
+EarlySetup="!res://MyMod/EarlySetup.gd"
 ```
 
-When the mod loader detects `!` prefix autoloads, it:
+This triggers a two-pass launch. The mod loader writes the autoload to `override.cfg`, restarts the game, and your node is in the scene tree before the game's autoloads run.
 
-1. Shows the config UI as usual
-2. Writes a temporary `override.cfg` that tells the engine to load these mods first
-3. Restarts the game automatically (~5 seconds)
-4. On the second launch, mods load before game autoloads — no UI is shown
+Regular autoloads (without `!`) load after all mods mount.
 
-Mods without `!` are unaffected and never trigger a restart. Only use `!` when your mod genuinely needs to run before game autoloads — most mods don't.
+## Uninstalling
 
----
+Delete `override.cfg` and `modloader.gd` from the game folder.
 
-## Conflict Report
-
-With Developer Mode enabled, a full conflict log is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch.
-
-| Message | Meaning |
-|---------|---------|
-| **CONFLICT** | Two mods ship the same file. Last-loaded wins. Adjust priorities. |
-| **SCRIPT CONFLICT** | Two mods both `take_over_path()` the same script. Hard incompatibility. |
-| **CHAIN OK / CHAIN BROKEN** | Override chain via `super()` — OK means mods stack cleanly, BROKEN means one skips `super()`. |
-| **DATABASE OVERRIDE** | A mod replaced `Database.gd`. Normal for overhauls, may block other mods' scene overrides. |
-| **OVERHAUL** | 5+ core script overrides. Likely incompatible with other overhaul mods. |
-| **NO SUPER** | Lifecycle method override without `super()`. Breaks other mods in the chain. |
-| **BAD ZIP** | Backslash file paths in the archive. Re-pack with 7-Zip. |
-
----
-
-## Best Practices
-
-- **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes).
-- **Include a `mod.txt`** at the archive root. Without it, autoloads won't run.
-- **Use `super()` in lifecycle methods.** Skipping it breaks other mods that override the same class.
-- **Prefer `extends + super()` over `take_over_path()`** for commonly-overridden scripts. It composes across mods; flat `take_over_path()` doesn't.
-- **If you replace Database.gd**, every `preload()` path must exist or the game breaks.
-- **`UpdateTooltip()` is inventory-only.** World-item tooltips come from `HUD._physics_process` reading `gameData.tooltip`.
-- **Test with other mods installed** and check the conflict report.
-
----
-
-## VostokMods Compatibility
-
-Mods packaged for [VostokMods](https://github.com/Ryhon0/VostokMods) generally work with this loader.
-
-| Feature | Status |
-|---------|--------|
-| `.vmz` archives | Supported |
-| `mod.txt` format | Supported |
-| `[mod] priority` | Supported |
-| Filename priority prefix (`100-ModName.vmz`) | Supported |
-| `!` early autoload prefix | Supported |
-
-### Features that require VostokMods
-
-VostokMods runs as a separate launcher before Godot starts. This loader runs inside the game, so it cannot:
-
-- **Merge `override.cfg`** — engine settings are read at startup before GDScript runs
-- **Register `class_name`** — global class cache is read-only at runtime (use path references instead)
-- **Extract native plugins** — GDExtension `.dll`/`.so` files must be on disk at startup
-
----
-
-## Recovery (Technical Details)
-
-- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. If it persists, the mod loader increments a crash counter. After 2 crashes, it wipes `override.cfg` and all two-pass state.
-- **Safe mode:** An empty `modloader_safe_mode` file in the game folder triggers a full reset on next launch.
-- **State files:** `user://mod_pass_state.cfg` stores archive paths for the two-pass restart. Deleted after successful Pass 2.
-
----
-
-## License
-
-MIT License
-
-Copyright (c) 2025
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Settings: `%APPDATA%\Road to Vostok\mod_config.cfg`
+Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`

--- a/README.md
+++ b/README.md
@@ -289,24 +289,6 @@ With Developer Mode enabled, a full conflict log is written to `%APPDATA%\Road t
 - **`UpdateTooltip()` is inventory-only.** World-item tooltips come from `HUD._physics_process` reading `gameData.tooltip`.
 - **Test with other mods installed** and check the conflict report.
 
-## VostokMods Compatibility
-
-Mods packaged for [VostokMods](https://github.com/Ryhon0/VostokMods) generally work with this loader.
-
-| Feature | Status |
-|---------|--------|
-| `.vmz` archives | Supported |
-| `mod.txt` format | Supported |
-| `[mod] priority` | Supported |
-| Filename priority prefix (`100-ModName.vmz`) | Supported |
-| `!` early autoload prefix | Supported |
-
-VostokMods runs as a separate launcher before Godot starts. This loader runs inside the game, so it cannot:
-
-- **Merge `override.cfg`** - engine settings are read at startup before GDScript runs
-- **Register `class_name`** - global class cache is read-only at runtime (use path references instead)
-- **Extract native plugins** - GDExtension `.dll`/`.so` files must be on disk at startup
-
 ## Uninstalling
 
 Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder and its contents can be removed separately.

--- a/README.md
+++ b/README.md
@@ -255,3 +255,25 @@ Delete `override.cfg` and `modloader.gd` from the game folder.
 
 Settings: `%APPDATA%\Road to Vostok\mod_config.cfg`
 Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
+
+---
+
+## Recovery (Technical Details)
+
+- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. If it persists, the mod loader increments a crash counter. After 2 crashes, it wipes `override.cfg` and all two-pass state.
+- **Safe mode:** An empty `modloader_safe_mode` file in the game folder triggers a full reset on next launch.
+- **State files:** `user://mod_pass_state.cfg` stores archive paths for the two-pass restart. Deleted after successful Pass 2.
+
+---
+
+## License
+
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ modworkshop=12345
 | `version` | Version string for update comparison |
 | `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
 | `[autoload]` | `Name="res://path.gd"` - instantiated as a Node after mods mount |
-| `[hooks]` | Declares methods to hook. See [Hooks](#hooks). |
+| `[hooks]` | Optional. Logged as hints, not required for hooks to work. See [Hooks](#hooks). |
 | `[updates] modworkshop` | ModWorkshop ID for update checking |
 
 Mods without `mod.txt` still mount as resource packs. Their files override vanilla resources, but no autoloads run.
@@ -75,27 +75,11 @@ Hooks let you intercept methods on vanilla `class_name` scripts without replacin
 
 ### How it works
 
-1. Declare which methods you want to hook in `mod.txt`.
-2. At launch, the mod loader reads the game's binary-tokenized scripts, reconstructs the source, and rewrites the target methods with dispatch wrappers.
-3. Your autoload calls `ModLoader.add_hook()` to register callbacks.
+At startup the mod loader detokenizes every `class_name` script in the game, wraps each method with a dispatch imposter, and applies the result via `take_over_path()`. Mods just call `add_hook()` from their autoload. No `[hooks]` section in mod.txt needed.
 
-Rewritten scripts are applied via `take_over_path()`. Vanilla source is cached between launches. The cache auto-invalidates when the game executable changes.
+Unhooked methods have a fast-path that skips the dispatch entirely (single dictionary lookup, no array allocation). Only methods with active hooks pay the full dispatch cost.
 
-### Declaring hooks
-
-Add a `[hooks]` section to `mod.txt`. Keys are `res://` script paths, values are comma-separated method names:
-
-```ini
-[hooks]
-"res://Scripts/Controller.gd"="Movement, Gravity"
-"res://Scripts/Door.gd"="_ready, Interact"
-```
-
-Rules:
-- The script needs a `class_name` declaration.
-- Only methods the script defines can be hooked. Inherited methods that aren't overridden (like an un-overridden `_ready`) can't be hooked.
-- Typos in method names produce a warning in the log.
-- You need an `[autoload]` to call `add_hook()` at runtime.
+Vanilla source is cached between launches. The cache rebuilds automatically when the game updates or the modloader version changes.
 
 ### add_hook()
 
@@ -103,12 +87,14 @@ Call this from your autoload's `_ready()`:
 
 ```gdscript
 ModLoader.add_hook(
-    script_path: String,   # must match the key in [hooks]
-    method_name: String,   # must match a declared method
+    script_path: String,   # res:// path to the script
+    method_name: String,   # name of the method to hook
     callback: Callable,    # your function
     before: bool = true    # true = before hook, false = after hook
 )
 ```
+
+The script must have a `class_name` and the method must be defined in that script (not just inherited).
 
 ### Before hooks
 
@@ -148,9 +134,6 @@ name="Fast Doors"
 id="fast_doors"
 version="1.0.0"
 
-[hooks]
-"res://Scripts/Door.gd"="_ready"
-
 [autoload]
 FastDoors="res://FastDoors/Main.gd"
 ```
@@ -183,9 +166,6 @@ name="Low Gravity"
 id="low_gravity"
 version="1.0.0"
 
-[hooks]
-"res://Scripts/Controller.gd"="Gravity"
-
 [autoload]
 LowGravity="res://LowGravity/Main.gd"
 ```
@@ -216,6 +196,8 @@ func _skip_loot(instance: Object, args: Array) -> bool:
     return true  # vanilla GenerateLoot won't run
 ```
 
+Be careful with skip hooks on methods that manage game state (like `Jump` or `Movement`). Skipping a method that other code depends on can cause side effects.
+
 ### Multiple mods on the same method
 
 - Before hooks run in load order (by `priority`). If one returns `true`, later before hooks, the vanilla method, and after hooks are all skipped.
@@ -230,18 +212,27 @@ func _skip_loot(instance: Object, args: Array) -> bool:
 | Survives game updates | Yes, cache rebuilds | May break |
 | Scope | Per-method | Whole file |
 
+### Backwards compatibility
+
+The `[hooks]` section in mod.txt is still recognized but no longer required. If present, entries are logged as hints. Mods using the old format continue to work without changes.
+
 ### Limitations
 
-- Only methods the script defines can be hooked. If a script doesn't override `_ready()`, you can't hook it.
-- Hooking methods called every frame (from `_physics_process`) adds minor overhead from the dispatch wrapper.
-- Source is reconstructed from Godot's binary token format. Original comments are not preserved.
+- **Typed arrays**: Scripts whose `class_name` is used as a typed array element type (`Array[SlotData]`, `Array[ItemData]`, etc) can't be wrapped. `take_over_path()` breaks Godot's internal type identity check for typed arrays ([godotengine/godot#97433](https://github.com/godotengine/godot/issues/97433)). The modloader detects these automatically and skips them. Currently 9 class names are excluded, mostly data/save classes. If a future game update adds typed array references to a gameplay script, hooks on that script would stop firing.
+- **Own methods only**. If a script doesn't override `_ready()`, you can't hook it. Only methods the script defines (not inherited) are wrapped.
+- **Per-frame overhead**. Unhooked methods cost one dictionary lookup per call. Methods with active hooks do the full dispatch (array allocation, callable iteration). On 314 wrapped methods with zero hooks active, there's no measurable performance impact.
+- **Source reconstruction**. Scripts are reconstructed from Godot's binary token format. Original comments and formatting are not preserved. The detokenizer handles Godot 4.0-4.6 token formats.
 
 ### Troubleshooting
 
-- **"add_hook() for undeclared script"** - `script_path` doesn't match any key in your `[hooks]` section.
-- **"add_hook() for undeclared method"** - method name wasn't declared in `mod.txt`. The wrapper wasn't generated.
-- **"Method not found in script"** - the method doesn't exist in the vanilla script. Check spelling.
-- **"hooked but also replaced by..."** - another mod replaces the same script file. Hooks wrap the modded version.
+- **"add_hook() for unwrapped script"** - the script path isn't a wrapped `class_name` script. Check that the path is correct and the script has a `class_name` declaration.
+- **"Cannot assign contents of Array[Object] to Array[Object]"** - a script whose `class_name` is used in typed arrays was wrapped. This shouldn't happen with the auto-detection, but if it does, check which class name is causing it and report an issue.
+- **"hooked but also replaced by..."** - another mod replaces the same script file. Hooks will wrap the modded version, not vanilla.
+- **Hook doesn't fire** - make sure you're calling `add_hook()` from `_ready()` in an autoload, not from a script in the scene tree. The hook needs to be registered before the method gets called.
+- **"Compiler bug: unresolved assign"** - Godot engine bug that can occur during compilation of certain scripts (e.g. KnifeRig.gd). Non-fatal, the script still works.
+
+Hook cache: `%APPDATA%\Road to Vostok\modloader_hooks\`
+To force a full rebuild, delete the `modloader_hooks` folder and `mod_pass_state.cfg`.
 
 Errors go to `%APPDATA%\Road to Vostok\modloader_conflicts.txt`.
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,69 @@ EarlySetup="!res://MyMod/EarlySetup.gd"
 
 This triggers a two-pass launch. The mod loader writes the autoload to `override.cfg`, restarts the game, and your node is in the scene tree before the game's autoloads run.
 
-Regular autoloads (without `!`) load after all mods mount.
+Regular autoloads (without `!`) load after all mods mount. Only use `!` when your mod genuinely needs to run before game autoloads.
+
+## Supported Archive Formats
+
+| Format | Notes |
+|--------|-------|
+| `.vmz` | Road to Vostok's native mod format (renamed zip) |
+| `.zip` | Must be renamed to `.vmz` before use |
+| `.pck` | Godot PCK - mount only, no mod.txt or autoloads |
+
+## Troubleshooting
+
+If the game crashes or gets stuck after enabling mods:
+
+- **Wait it out.** After 2 failed launches, the mod loader automatically resets to a clean state.
+- **Manual reset:** Create an empty file named `modloader_safe_mode` (no file extension) in the game folder. On next launch, the mod loader resets and deletes the file.
+- **Full reset:** Delete `override.cfg` from the game folder and replace it with a fresh copy from the mod loader release.
+
+## Conflict Report
+
+With Developer Mode enabled, a full conflict log is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch.
+
+| Message | Meaning |
+|---------|---------|
+| **CONFLICT** | Two mods ship the same file. Last-loaded wins. Adjust priorities. |
+| **SCRIPT CONFLICT** | Two mods both `take_over_path()` the same script. Hard incompatibility. |
+| **CHAIN OK / CHAIN BROKEN** | Override chain via `super()`. OK means mods stack cleanly, BROKEN means one skips `super()`. |
+| **DATABASE OVERRIDE** | A mod replaced `Database.gd`. Normal for overhauls, may block other mods' scene overrides. |
+| **OVERHAUL** | 5+ core script overrides. Likely incompatible with other overhaul mods. |
+| **NO SUPER** | Lifecycle method override without `super()`. Breaks other mods in the chain. |
+| **BAD ZIP** | Backslash file paths in the archive. Re-pack with 7-Zip. |
+
+## Best Practices
+
+- **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes).
+- **Include a `mod.txt`** at the archive root. Without it, autoloads won't run.
+- **Use `super()` in lifecycle methods.** Skipping it breaks other mods that override the same class.
+- **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't.
+- **If you replace Database.gd**, every `preload()` path must exist or the game breaks.
+- **`UpdateTooltip()` is inventory-only.** World-item tooltips come from `HUD._physics_process` reading `gameData.tooltip`.
+- **Test with other mods installed** and check the conflict report.
+
+## VostokMods Compatibility
+
+Mods packaged for [VostokMods](https://github.com/Ryhon0/VostokMods) generally work with this loader.
+
+| Feature | Status |
+|---------|--------|
+| `.vmz` archives | Supported |
+| `mod.txt` format | Supported |
+| `[mod] priority` | Supported |
+| Filename priority prefix (`100-ModName.vmz`) | Supported |
+| `!` early autoload prefix | Supported |
+
+VostokMods runs as a separate launcher before Godot starts. This loader runs inside the game, so it cannot:
+
+- **Merge `override.cfg`** - engine settings are read at startup before GDScript runs
+- **Register `class_name`** - global class cache is read-only at runtime (use path references instead)
+- **Extract native plugins** - GDExtension `.dll`/`.so` files must be on disk at startup
 
 ## Uninstalling
 
-Delete `override.cfg` and `modloader.gd` from the game folder.
+Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder and its contents can be removed separately.
 
 Settings: `%APPDATA%\Road to Vostok\mod_config.cfg`
 Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods,
 ## Requirements
 
 - Road to Vostok (PC, Steam)
-- Mods packaged as `.vmz` files
+- Mods packaged as `.vmz` or `.pck` files
 
 ## Installation
 
@@ -27,7 +27,12 @@ Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods,
 
 Drop `.vmz` files into the `mods` folder. They show up automatically on next launch.
 
-`.pck` files also work but have no mod.txt metadata, autoloads, or update checking.
+`.pck` files also work but have no mod.txt metadata, autoloads, or update checking. If a mod was distributed as a `.zip`, rename it to `.vmz`.
+
+| Format | Notes |
+|--------|-------|
+| `.vmz` | Road to Vostok's native mod format (renamed zip) |
+| `.pck` | Godot PCK - mount only, no mod.txt or autoloads |
 
 ## Launcher UI
 
@@ -63,8 +68,8 @@ modworkshop=12345
 | `id` | Unique ID. Duplicates are skipped. |
 | `version` | Version string for update comparison |
 | `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
-| `[autoload]` | `Name="res://path.gd"` - instantiated as a Node after mods mount |
-| `[hooks]` | Optional. Logged as hints, not required for hooks to work. See [Hooks](#hooks). |
+| `[autoload]` | `Name="res://path.gd"` - instantiated as a Node after mods mount. Prefix with `!` for [early autoloads](#early-autoloads). |
+| `[hooks]` | Optional. See [Hooks](#hooks). |
 | `[updates] modworkshop` | ModWorkshop ID for update checking |
 
 Mods without `mod.txt` still mount as resource packs. Their files override vanilla resources, but no autoloads run.
@@ -223,18 +228,16 @@ The `[hooks]` section in mod.txt is still recognized but no longer required. If 
 - **Per-frame overhead**. Unhooked methods cost one dictionary lookup per call. Methods with active hooks do the full dispatch (array allocation, callable iteration). On 314 wrapped methods with zero hooks active, there's no measurable performance impact.
 - **Source reconstruction**. Scripts are reconstructed from Godot's binary token format. Original comments and formatting are not preserved. The detokenizer handles Godot 4.0-4.6 token formats.
 
-### Troubleshooting
+### Hook troubleshooting
 
-- **"add_hook() for unwrapped script"** - the script path isn't a wrapped `class_name` script. Check that the path is correct and the script has a `class_name` declaration.
-- **"Cannot assign contents of Array[Object] to Array[Object]"** - a script whose `class_name` is used in typed arrays was wrapped. This shouldn't happen with the auto-detection, but if it does, check which class name is causing it and report an issue.
-- **"hooked but also replaced by..."** - another mod replaces the same script file. Hooks will wrap the modded version, not vanilla.
-- **Hook doesn't fire** - make sure you're calling `add_hook()` from `_ready()` in an autoload, not from a script in the scene tree. The hook needs to be registered before the method gets called.
-- **"Compiler bug: unresolved assign"** - Godot engine bug that can occur during compilation of certain scripts (e.g. KnifeRig.gd). Non-fatal, the script still works.
+- **"add_hook() for unwrapped script"** - the script path isn't a wrapped `class_name` script. Check the path and that the script has a `class_name` declaration.
+- **"Cannot assign contents of Array[Object] to Array[Object]"** - a script whose `class_name` is used in typed arrays was wrapped. Shouldn't happen with auto-detection. Report an issue if it does.
+- **"hooked but also replaced by..."** - another mod replaces the same script file. Hooks wrap the modded version, not vanilla.
+- **Hook doesn't fire** - make sure you're calling `add_hook()` from `_ready()` in an autoload, not from a scene script. The hook needs to be registered before the method gets called.
+- **"Compiler bug: unresolved assign"** - Godot engine bug during compilation of certain scripts (e.g. KnifeRig.gd). Non-fatal, the script still works.
 
 Hook cache: `%APPDATA%\Road to Vostok\modloader_hooks\`
 To force a full rebuild, delete the `modloader_hooks` folder and `mod_pass_state.cfg`.
-
-Errors go to `%APPDATA%\Road to Vostok\modloader_conflicts.txt`.
 
 ## Early Autoloads
 
@@ -248,14 +251,6 @@ EarlySetup="!res://MyMod/EarlySetup.gd"
 This triggers a two-pass launch. The mod loader writes the autoload to `override.cfg`, restarts the game, and your node is in the scene tree before the game's autoloads run.
 
 Regular autoloads (without `!`) load after all mods mount. Only use `!` when your mod genuinely needs to run before game autoloads.
-
-## Supported Archive Formats
-
-| Format | Notes |
-|--------|-------|
-| `.vmz` | Road to Vostok's native mod format (renamed zip) |
-| `.zip` | Must be renamed to `.vmz` before use |
-| `.pck` | Godot PCK - mount only, no mod.txt or autoloads |
 
 ## Troubleshooting
 

--- a/modloader.gd
+++ b/modloader.gd
@@ -1,4 +1,4 @@
-## Metro Mod Loader — community mod loader for Road to Vostok (Godot 4.6+).
+## Metro Mod Loader -- community mod loader for Road to Vostok (Godot 4.6+).
 ## Loads .vmz/.pck archives from <game>/mods/ via a pre-game config window.
 ## Two-pass architecture: mounts archives at file-scope, optionally restarts to
 ## prepend mod autoloads before the game's own autoloads via [autoload_prepend].
@@ -72,30 +72,30 @@ static func _mount_previous_session() -> int:
 
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) != OK:
-		log_lines.append("[FileScope] No pass state file — skipping")
+		log_lines.append("[FileScope] No pass state file -- skipping")
 		_write_filescope_log(log_lines)
 		return 0
 	# Wipe stale state from a different modloader version (format may have changed).
 	var saved_ver: String = cfg.get_value("state", "modloader_version", "")
 	if saved_ver != MODLOADER_VERSION:
-		log_lines.append("[FileScope] Version mismatch: saved=%s current=%s — wiping" % [saved_ver, MODLOADER_VERSION])
+		log_lines.append("[FileScope] Version mismatch: saved=%s current=%s -- wiping" % [saved_ver, MODLOADER_VERSION])
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		_write_filescope_log(log_lines)
 		return 0
-	# Detect game updates — exe mtime change means vanilla scripts may have changed.
+	# Detect game updates -- exe mtime change means vanilla scripts may have changed.
 	var saved_exe_mtime: int = cfg.get_value("state", "exe_mtime", 0)
 	if saved_exe_mtime != 0:
 		var current_exe_mtime := FileAccess.get_modified_time(OS.get_executable_path())
 		if current_exe_mtime != saved_exe_mtime:
-			log_lines.append("[FileScope] Game exe mtime changed — wiping hook cache")
-			# Game updated — wipe hook cache so Pass 1 regenerates from fresh vanilla.
+			log_lines.append("[FileScope] Game exe mtime changed -- wiping hook cache")
+			# Game updated -- wipe hook cache so Pass 1 regenerates from fresh vanilla.
 			_static_wipe_hook_cache()
 			DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 			_write_filescope_log(log_lines)
 			return 0
 	var paths: PackedStringArray = cfg.get_value("state", "archive_paths", PackedStringArray())
 	if paths.is_empty():
-		log_lines.append("[FileScope] Pass state has no archive paths — skipping")
+		log_lines.append("[FileScope] Pass state has no archive paths -- skipping")
 		_write_filescope_log(log_lines)
 		return 0
 
@@ -110,7 +110,7 @@ static func _mount_previous_session() -> int:
 		if FileAccess.file_exists(abs_path):
 			log_lines.append("[FileScope]   EXISTS: " + abs_path)
 			continue
-		# VMZ source gone — check if the zip cache survived.
+		# VMZ source gone -- check if the zip cache survived.
 		if abs_path.get_extension().to_lower() == "vmz":
 			var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
 			var cached := cache_dir.path_join(abs_path.get_file().get_basename() + ".zip")
@@ -122,7 +122,7 @@ static func _mount_previous_session() -> int:
 		any_missing = true
 
 	if any_missing:
-		log_lines.append("[FileScope] Archive(s) missing — resetting to clean state")
+		log_lines.append("[FileScope] Archive(s) missing -- resetting to clean state")
 		# Archive gone, no cache. Wipe override.cfg autoload sections so the next
 		# boot is clean, but preserve any non-autoload settings ([display], etc.).
 		var exe_dir := OS.get_executable_path().get_base_dir()
@@ -139,7 +139,7 @@ static func _mount_previous_session() -> int:
 		return 0
 
 	if any_stale:
-		# Source gone but cache works — invalidate hash so Pass 1 rewrites state.
+		# Source gone but cache works -- invalidate hash so Pass 1 rewrites state.
 		cfg.set_value("state", "mods_hash", "")
 		cfg.save(PASS_STATE_PATH)
 
@@ -170,7 +170,7 @@ static func _mount_previous_session() -> int:
 		else:
 			log_lines.append("[FileScope]   HOOK PACK MOUNT FAILED: " + hook_pack)
 
-	log_lines.append("[FileScope] Done — %d archive(s) mounted" % count)
+	log_lines.append("[FileScope] Done -- %d archive(s) mounted" % count)
 	_write_filescope_log(log_lines)
 	return count
 
@@ -198,7 +198,7 @@ static func _static_wipe_hook_cache() -> void:
 	while file_name != "":
 		var full := cache_dir.path_join(file_name)
 		if dir.current_is_dir():
-			# Shallow — vanilla cache is only Scripts/*.gd (one level deep)
+			# Shallow -- vanilla cache is only Scripts/*.gd (one level deep)
 			var sub := DirAccess.open(full)
 			if sub:
 				sub.list_dir_begin()
@@ -251,7 +251,7 @@ func _ready() -> void:
 	else:
 		await _run_pass_1()
 
-# Pass 1: Normal launch — show UI, configure, optionally restart
+# Pass 1: Normal launch -- show UI, configure, optionally restart
 
 func _run_pass_1() -> void:
 	_log_info("Metro Mod Loader v" + MODLOADER_VERSION)
@@ -278,7 +278,7 @@ func _run_pass_1() -> void:
 		old_hash = state_cfg.get_value("state", "mods_hash", "")
 
 	if new_hash == old_hash and not new_hash.is_empty():
-		_log_info("Mod state unchanged — skipping restart")
+		_log_info("Mod state unchanged -- skipping restart")
 		await _finish_with_existing_mounts()
 		return
 
@@ -290,16 +290,16 @@ func _run_pass_1() -> void:
 		else:
 			archive_paths.append(hook_pack_path)
 	elif not _loaded_mod_ids.is_empty():
-		_log_critical("[Hooks] Hook pack generation failed — hooks will not work")
+		_log_critical("[Hooks] Hook pack generation failed -- hooks will not work")
 
 	if archive_paths.size() > 0:
-		_log_info("Preparing two-pass restart — %d archive(s)" % archive_paths.size())
+		_log_info("Preparing two-pass restart -- %d archive(s)" % archive_paths.size())
 		if sections.prepend.size() > 0:
 			_log_info("  %d early autoload(s) in [autoload_prepend]" % sections.prepend.size())
 		_write_heartbeat()
 		var err := _write_override_cfg(sections.prepend)
 		if err != OK:
-			_log_critical("Failed to write override.cfg (error %d) — single-pass fallback" % err)
+			_log_critical("Failed to write override.cfg (error %d) -- single-pass fallback" % err)
 			await _finish_single_pass()
 			return
 		if _write_pass_state(archive_paths, new_hash) != OK:
@@ -323,7 +323,7 @@ func _finish_with_existing_mounts() -> void:
 	_apply_hook_pack_scripts()
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
-			_log_info("  Autoload '%s' already in tree — skipped" % entry["name"])
+			_log_info("  Autoload '%s' already in tree -- skipped" % entry["name"])
 			continue
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 	if _developer_mode:
@@ -357,10 +357,10 @@ func _finish_single_pass() -> void:
 			await get_tree().process_frame
 			_audit_override_instances()
 
-# Pass 2: Post-restart — archives already mounted at file-scope
+# Pass 2: Post-restart -- archives already mounted at file-scope
 
 func _run_pass_2() -> void:
-	_log_info("Pass 2 — %d archive(s) mounted at file-scope" % _file_scope_mounts)
+	_log_info("Pass 2 -- %d archive(s) mounted at file-scope" % _file_scope_mounts)
 	_apply_hook_pack_scripts()
 	_clear_restart_counter()
 	_compile_regex()
@@ -372,7 +372,7 @@ func _run_pass_2() -> void:
 	load_all_mods("Pass 2")
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
-			_log_info("  Autoload '%s' already in tree — skipped" % entry["name"])
+			_log_info("  Autoload '%s' already in tree -- skipped" % entry["name"])
 			continue
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 
@@ -519,11 +519,11 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 		return warnings
 	var status: String = entry.get("mod_txt_status", "none")
 	if status == "none":
-		warnings.append("Invalid mod — may not work correctly. Try re-downloading.")
+		warnings.append("Invalid mod -- may not work correctly. Try re-downloading.")
 	elif status == "parse_error":
-		warnings.append("Invalid mod — may not work correctly. Try re-downloading.")
+		warnings.append("Invalid mod -- may not work correctly. Try re-downloading.")
 	elif status.begins_with("nested:"):
-		warnings.append("Invalid mod — packaged incorrectly. Try re-downloading.")
+		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
 	return warnings
 
 # Config persistence
@@ -561,7 +561,7 @@ func _save_ui_config() -> void:
 
 func show_mod_ui() -> void:
 	var win := Window.new()
-	win.title = "Road to Vostok — Mod Loader"
+	win.title = "Road to Vostok -- Mod Loader"
 	win.size = Vector2i(960, 640)
 	win.min_size = Vector2i(640, 420)
 	win.wrap_controls = false
@@ -693,7 +693,7 @@ func make_dark_theme() -> Theme:
 	t.set_color("font_pressed_color",  "Button", C_TEXT)
 	t.set_color("font_disabled_color", "Button", C_DIM)
 
-	# ── CheckBox (font only — box glyph needs texture to restyle) ─────────────
+	# ── CheckBox (font only -- box glyph needs texture to restyle) ─────────────
 	t.set_color("font_color",       "CheckBox", C_TEXT)
 	t.set_color("font_hover_color", "CheckBox", Color(1.0, 1.0, 1.0))
 
@@ -1056,13 +1056,13 @@ func build_updates_tab() -> Control:
 			name_col.add_child(mod_lbl)
 
 		var ver_lbl := Label.new()
-		ver_lbl.text = "v" + version if version != "" else "—"
+		ver_lbl.text = "v" + version if version != "" else "--"
 		ver_lbl.custom_minimum_size.x = 90
 		row.add_child(ver_lbl)
 
 		var status_lbl := Label.new()
 		status_lbl.custom_minimum_size.x = 160
-		status_lbl.text = "no update info" if mw_id == 0 or version == "" else "—"
+		status_lbl.text = "no update info" if mw_id == 0 or version == "" else "--"
 		row.add_child(status_lbl)
 
 		# Always add dl_btn to preserve column width. Use modulate.a to
@@ -1200,7 +1200,7 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 					return
 				check_btn.disabled = false
 				if ok:
-					lbl.text = "updated — restart to apply"
+					lbl.text = "updated -- restart to apply"
 					lbl.modulate = Color(0.80, 0.80, 0.80)
 					dl_btn.modulate.a = 0.0
 					dl_btn.disabled = true
@@ -1209,13 +1209,13 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 					# Update cached version so next Check won't re-flag this mod.
 					info["version"] = new_ver
 					(info["ver_lbl"] as Label).text = "v" + new_ver
-					add_log.call(mod_name + " — updated to v" + new_ver + ". Restart game to apply.")
+					add_log.call(mod_name + " -- updated to v" + new_ver + ". Restart game to apply.")
 				else:
 					lbl.text = "download failed"
 					lbl.modulate = Color(1.0, 0.4, 0.4)
 					dl_btn.disabled = false
 					dl_btn.text = "Retry"
-					add_log.call(mod_name + " — download failed.")
+					add_log.call(mod_name + " -- download failed.")
 			)
 
 # Main load loop
@@ -1245,13 +1245,13 @@ func load_all_mods(pass_label: String = "") -> void:
 		_log_info("No mods enabled.")
 		return
 
-	# Warn about duplicate mod names — likely a packaging mistake or fork.
+	# Warn about duplicate mod names -- likely a packaging mistake or fork.
 	# The sort is still deterministic (file_name tiebreaker), but users should know.
 	for i in range(1, candidates.size()):
 		if (candidates[i]["mod_name"] as String).to_lower() \
 				== (candidates[i - 1]["mod_name"] as String).to_lower():
 			_log_warning("Duplicate mod name '" + candidates[i]["mod_name"]
-					+ "' — archives '" + candidates[i - 1]["file_name"]
+					+ "' -- archives '" + candidates[i - 1]["file_name"]
 					+ "' and '" + candidates[i]["file_name"]
 					+ "'. Load order tie broken by archive filename.")
 
@@ -1277,11 +1277,11 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	_log_info("--- [" + str(load_index + 1) + "] " + mod_name + " (" + file_name + ")")
 
 	if ext == "zip":
-		_log_warning("Skipping .zip file: " + file_name + " — rename to .vmz to use")
+		_log_warning("Skipping .zip file: " + file_name + " -- rename to .vmz to use")
 		return
 
 	if ext != "pck" and _loaded_mod_ids.has(mod_id):
-		_log_warning("Duplicate mod id '" + mod_id + "' — skipped: " + file_name)
+		_log_warning("Duplicate mod id '" + mod_id + "' -- skipped: " + file_name)
 		return
 
 	var mount_path := full_path
@@ -1306,16 +1306,16 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		if cfg == null and ext != "pck":
 			var status: String = c.get("mod_txt_status", "none")
 			if status.begins_with("nested:"):
-				_log_warning("  Invalid mod — packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
+				_log_warning("  Invalid mod -- packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
 			elif status == "parse_error":
-				_log_warning("  Invalid mod — mod.txt failed to parse")
+				_log_warning("  Invalid mod -- mod.txt failed to parse")
 			else:
-				_log_warning("  No mod.txt — autoloads skipped")
+				_log_warning("  No mod.txt -- autoloads skipped")
 		return
 
 	_loaded_mod_ids[mod_id] = true
 
-	# [hooks] is optional — all class_name methods are pre-wrapped.
+	# [hooks] is optional -- all class_name methods are pre-wrapped.
 	if cfg != null and cfg.has_section("hooks"):
 		for key in cfg.get_section_keys("hooks"):
 			var script_path := str(key)
@@ -1339,11 +1339,11 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		var res_path := raw_path
 
 		if res_path == "":
-			_log_warning("  Empty autoload path for '" + autoload_name + "' — skipped")
+			_log_warning("  Empty autoload path for '" + autoload_name + "' -- skipped")
 			continue
 
 		if _registered_autoload_names.has(autoload_name):
-			_log_warning("Duplicate autoload name '" + autoload_name + "' — skipped")
+			_log_warning("Duplicate autoload name '" + autoload_name + "' -- skipped")
 			continue
 		_registered_autoload_names[autoload_name] = true
 
@@ -1416,7 +1416,7 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
 # Apply hook pack scripts via take_over_path.  class_name is stripped to avoid
-# "hides a global script class" — scripts with typed array refs are excluded
+# "hides a global script class" -- scripts with typed array refs are excluded
 # upstream in _generate_hook_pack() to prevent Array[Object] identity errors.
 func _apply_hook_pack_scripts() -> void:
 	var hook_pack := ProjectSettings.globalize_path(HOOK_PACK_PATH)
@@ -1456,12 +1456,12 @@ func _apply_hook_pack_scripts() -> void:
 	if applied > 0:
 		_log_info("[Hooks] Applied %d hooked script(s) via take_over_path" % applied)
 
-# Hook API — mods call add_hook() to intercept methods on class_name scripts.
+# Hook API -- mods call add_hook() to intercept methods on class_name scripts.
 # before=true: fires before vanilla (return true to skip). before=false: fires after.
 func add_hook(script_path: String, method_name: String, callback: Callable, before: bool = true) -> void:
 	var key := script_path + "::" + method_name
 	if not _hook_script_paths.is_empty() and not _hook_script_paths.has(script_path):
-		_log_warning("[Hooks] add_hook() for unwrapped script %s — not a class_name script?" % script_path)
+		_log_warning("[Hooks] add_hook() for unwrapped script %s -- not a class_name script?" % script_path)
 	if not _hook_registry.has(key):
 		_hook_registry[key] = { "before": [], "after": [] }
 	var list_key := "before" if before else "after"
@@ -1514,7 +1514,7 @@ func _build_class_name_lookup() -> void:
 				_class_name_to_path[cn] = path
 		_log_info("Loaded %d class_name mappings from game cache" % _class_name_to_path.size())
 	else:
-		_log_warning("Could not load global_script_class_cache.cfg — using hardcoded fallback")
+		_log_warning("Could not load global_script_class_cache.cfg -- using hardcoded fallback")
 		_class_name_to_path = _get_hardcoded_class_map()
 
 func _get_hardcoded_class_map() -> Dictionary:
@@ -1590,7 +1590,7 @@ const _GDSC_TOKEN_BITS := 8
 const _GDSC_TOKEN_MASK := (1 << (_GDSC_TOKEN_BITS - 1)) - 1  # 0x7F
 const _GDSC_TOKEN_BYTE_MASK := 0x80
 
-# Token type indices — Godot 4.5-4.6 / TOKENIZER_VERSION 101.
+# Token type indices -- Godot 4.5-4.6 / TOKENIZER_VERSION 101.
 # 0=EMPTY 1=ANNOTATION 2=IDENTIFIER 3=LITERAL
 # 4-9: < <= > >= == !=   10-15: and or not && || !
 # 16-21: & | ~ ^ << >>   22-27: + - * ** / %
@@ -1658,7 +1658,7 @@ const _SPACE_AFTER := {
 }
 
 func _detokenize_script(script_path: String) -> String:
-	# Try multiple methods to read raw bytes — FileAccess on res:// can fail for
+	# Try multiple methods to read raw bytes -- FileAccess on res:// can fail for
 	# PCK-embedded files depending on the container format (RSCC, encryption, etc.).
 	var raw := PackedByteArray()
 
@@ -1692,7 +1692,7 @@ func _detokenize_script(script_path: String) -> String:
 		return ""
 	var magic := raw.slice(0, 4).get_string_from_ascii()
 	if magic != _GDSC_MAGIC:
-		# Not a GDSC file — might be plain text that load() failed on for another reason.
+		# Not a GDSC file -- might be plain text that load() failed on for another reason.
 		var text := raw.get_string_from_utf8()
 		if not text.is_empty() and (text.begins_with("extends") or text.begins_with("class_name") or text.begins_with("@")):
 			return text
@@ -1804,7 +1804,7 @@ func _detokenize_script(script_path: String) -> String:
 		return ""
 
 	# ── Validate: try to parse the reconstructed source ──
-	# Strip class_name for validation — GDScript.new().reload() rejects duplicate
+	# Strip class_name for validation -- GDScript.new().reload() rejects duplicate
 	# class_name declarations that conflict with already-registered global classes.
 	var validate_source := result
 	var cn_regex := RegEx.new()
@@ -1819,7 +1819,7 @@ func _detokenize_script(script_path: String) -> String:
 		for j in mini(40, dbg_lines.size()):
 			_log_debug("[Detokenize]   %3d | %s" % [j + 1, dbg_lines[j]])
 	else:
-		_log_info("[Detokenize] Reconstructed: %s (%d tokens, %d lines) — parse OK" \
+		_log_info("[Detokenize] Reconstructed: %s (%d tokens, %d lines) -- parse OK" \
 				% [script_path, tokens.size(), result.count("\n") + 1])
 	return result
 
@@ -1858,7 +1858,7 @@ func _gdsc_reconstruct(tokens: Array, identifiers: Array[String], constants: Arr
 			prev_tk = tk
 			continue
 
-		if tk == 89 or tk == 90:  # INDENT / DEDENT — skip, we use col_map instead
+		if tk == 89 or tk == 90:  # INDENT / DEDENT -- skip, we use col_map instead
 			prev_tk = tk
 			continue
 
@@ -1892,7 +1892,7 @@ func _gdsc_reconstruct(tokens: Array, identifiers: Array[String], constants: Arr
 			if _SPACE_BEFORE.has(tk):
 				add_space_before = true
 			elif tk == 2 or tk == 3 or tk == 1 or (tk >= 40 and tk <= 72):
-				# IDENTIFIER, LITERAL, ANNOTATION, or any keyword — space before
+				# IDENTIFIER, LITERAL, ANNOTATION, or any keyword -- space before
 				# unless prev was an opener, dot, $, ~, !, indent, newline.
 				# Note: annotation (1) excluded only for identifiers (part of the
 				# annotation name), NOT for keywords like var/func after @export.
@@ -1994,7 +1994,7 @@ func _read_vanilla_source(script_path: String) -> String:
 					_save_vanilla_source(script_path, live.source_code)
 					return live.source_code
 				return cached
-			return cached  # live is hooked or binary-tokenized — trust cache
+			return cached  # live is hooked or binary-tokenized -- trust cache
 
 	var script := load(script_path) as GDScript
 	if script == null:
@@ -2002,13 +2002,13 @@ func _read_vanilla_source(script_path: String) -> String:
 
 	var source := script.source_code
 	if source.is_empty():
-		# Script is binary-tokenized (GDSC format) — detokenize from raw bytes.
+		# Script is binary-tokenized (GDSC format) -- detokenize from raw bytes.
 		source = _detokenize_script(script_path)
 		if source.is_empty():
 			return ""
 
 	if "func _vanilla_" in source:  # hook pack mounted but cache missing
-		_log_critical("[Hooks] Cannot read vanilla source for %s — delete %s and restart"
+		_log_critical("[Hooks] Cannot read vanilla source for %s -- delete %s and restart"
 				% [script_path, ProjectSettings.globalize_path(HOOK_PACK_PATH)])
 		return ""
 	_save_vanilla_source(script_path, source)
@@ -2076,7 +2076,7 @@ func _preprocess_script(script_path: String) -> String:
 			if stripped_line.begins_with("#"):
 				continue  # skip comment lines
 			if "super(" not in line_str:
-				continue  # fast path — no super() call on this line
+				continue  # fast path -- no super() call on this line
 			var comment_pos := line_str.find("#")
 			var super_pos := line_str.find("super(")
 			if comment_pos >= 0 and super_pos > comment_pos:
@@ -2103,7 +2103,7 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 	var method_name: String = method_dict["name"]
 
 	var start_line := -1
-	# get_member_line() crashes on binary-tokenized scripts — only call it if
+	# get_member_line() crashes on binary-tokenized scripts -- only call it if
 	# the script has source code available.
 	if script.has_source_code():
 		start_line = script.get_member_line(method_name) - 1
@@ -2150,7 +2150,7 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 	for i in range(body_start, body_end):
 		body_text += lines[i] + "\n"
 
-	# Detect async — check for `await` in body, but skip comments and strings.
+	# Detect async -- check for `await` in body, but skip comments and strings.
 	var is_async := _body_contains_keyword(body_text, "await")
 
 	# Determine return type.
@@ -2159,7 +2159,7 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 	var ret = method_dict["return"]
 	if method_name == "_init" or method_name in LIFECYCLE_METHODS:
 		return_type = "void"
-	elif ret["type"] == 0:  # Variant::NIL — could be void or untyped
+	elif ret["type"] == 0:  # Variant::NIL -- could be void or untyped
 		if "-> void" in sig_line:
 			return_type = "void"
 		else:
@@ -2172,7 +2172,7 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 					continue
 				var bind := _get_indent_level(bline)
 				if bind > method_indent + 1:
-					continue  # deeper indent — could be lambda body
+					continue  # deeper indent -- could be lambda body
 				if bstripped.begins_with("return ") and bstripped != "return":
 					has_value_return = true
 					break
@@ -2215,7 +2215,7 @@ func _body_contains_keyword(body_text: String, keyword: String) -> bool:
 			continue
 		if keyword not in stripped:
 			continue
-		# Skip if in a string literal — crude check: count quotes before keyword.
+		# Skip if in a string literal -- crude check: count quotes before keyword.
 		var kpos := stripped.find(keyword)
 		var dquotes := 0
 		var squotes := 0
@@ -2277,7 +2277,7 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 	else:
 		lines.append("\t\treturn " + fast_call)
 
-	# Full dispatch — before hooks, arg mutation, vanilla call, after hooks.
+	# Full dispatch -- before hooks, arg mutation, vanilla call, after hooks.
 	var args_str := "[" + ", ".join(info["param_names"]) + "]"
 	lines.append("\tvar __hook_args := " + args_str)
 
@@ -2312,7 +2312,7 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 
 func _find_typed_array_class_refs() -> Dictionary:
 	# Find class_names used as typed array elements (e.g. Array[SlotData]).
-	# These can't be wrapped — take_over_path breaks the pointer identity check
+	# These can't be wrapped -- take_over_path breaks the pointer identity check
 	# in container_type_validate.h (godotengine/godot#97433).
 	# Only scans class_name scripts; refs from other scripts aren't detected.
 	var refs: Dictionary = {}  # class_name -> true
@@ -2335,13 +2335,13 @@ func _generate_hook_pack() -> String:
 	if _class_name_to_path.is_empty():
 		return ""
 	if _loaded_mod_ids.is_empty():
-		return ""  # No mods loaded — no one to call add_hook()
+		return ""  # No mods loaded -- no one to call add_hook()
 
 	var unsafe_class_names := _find_typed_array_class_refs()
 
-	var _path_to_class_name: Dictionary = {}
+	var path_to_cn: Dictionary = {}
 	for k: String in _class_name_to_path:
-		_path_to_class_name[_class_name_to_path[k]] = k
+		path_to_cn[_class_name_to_path[k]] = k
 
 	_hook_script_paths.clear()
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(HOOK_PACK_DIR))
@@ -2360,15 +2360,15 @@ func _generate_hook_pack() -> String:
 	var total_methods := 0
 	for script_path: String in _class_name_to_path.values():
 		# Skip scripts whose class_name is referenced in typed arrays.
-		var cn: String = _path_to_class_name.get(script_path, "")
+		var cn: String = path_to_cn.get(script_path, "")
 		if cn in unsafe_class_names:
-			_log_info("[Hooks] Skipped %s — class_name '%s' used in typed arrays" % [script_path, cn])
+			_log_info("[Hooks] Skipped %s -- class_name '%s' used in typed arrays" % [script_path, cn])
 			continue
 		# Warn if a mod also ships a direct replacement for this script.
 		if _override_registry.has(script_path):
 			var claims: Array = _override_registry[script_path]
 			for claim in claims:
-				_log_warning("[Hooks] %s is hooked but also replaced by '%s' — hooks will wrap the modded version, not vanilla"
+				_log_warning("[Hooks] %s is hooked but also replaced by '%s' -- hooks will wrap the modded version, not vanilla"
 						% [script_path, claim["mod_name"]])
 
 		var transformed := _preprocess_script(script_path)
@@ -2381,7 +2381,7 @@ func _generate_hook_pack() -> String:
 		validate.source_code = validate_src
 		var verr := validate.reload(true)
 		if verr != OK:
-			_log_critical("[Hooks] Transformed %s has parse errors (error %d) — skipping" % [script_path, verr])
+			_log_critical("[Hooks] Transformed %s has parse errors (error %d) -- skipping" % [script_path, verr])
 			var vlines := transformed.split("\n")
 			for vj in mini(50, vlines.size()):
 				_log_debug("[Hooks]   %3d | %s" % [vj + 1, vlines[vj]])
@@ -2449,7 +2449,7 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		"extends_class_names":     [],
 		"override_methods":        {},   # extends_path -> Array[method_name]
 		"preload_paths":           [],
-		"calls_base":              false, # uses base() instead of super() — Godot 3 or removed method
+		"calls_base":              false, # uses base() instead of super() -- Godot 3 or removed method
 		"total_gd_files":          0,
 	}
 
@@ -2521,14 +2521,14 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 		if path not in (analysis["extends_paths"] as Array):
 			(analysis["extends_paths"] as Array).append(path)
 
-	# Detect extends via class_name (e.g. "extends Weapon") — breaks override chains.
+	# Detect extends via class_name (e.g. "extends Weapon") -- breaks override chains.
 	var m_ext_cn := _re_extends_classname.search(text)
 	if m_ext_cn:
 		var cn := m_ext_cn.get_string(1)
 		if cn not in (analysis["extends_class_names"] as Array):
 			(analysis["extends_class_names"] as Array).append(cn)
 
-	# Detect class_name declarations — Godot bug #83542: can only be overridden once.
+	# Detect class_name declarations -- Godot bug #83542: can only be overridden once.
 	for m_cn in _re_class_name.search_all(text):
 		var cn := m_cn.get_string(1)
 		if cn not in (analysis["class_names"] as Array):
@@ -2539,21 +2539,21 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 				or "take_over_path(parentScript" in text
 
 	# UpdateTooltip() is inventory-UI only. World-item tooltips are written directly
-	# by HUD._physics_process from gameData.tooltip — this override has no effect there.
+	# by HUD._physics_process from gameData.tooltip -- this override has no effect there.
 	if not analysis["calls_update_tooltip"]:
 		analysis["calls_update_tooltip"] = "UpdateTooltip" in text
 
-	# Detect base() calls — Godot 3 pattern or removed parent method.
+	# Detect base() calls -- Godot 3 pattern or removed parent method.
 	if not analysis["calls_base"]:
 		analysis["calls_base"] = "base(" in text
 
-	# preload() paths — used for stale-cache detection.
+	# preload() paths -- used for stale-cache detection.
 	for m_pl in _re_preload.search_all(text):
 		var pl_path := m_pl.get_string(1)
 		if pl_path not in (analysis["preload_paths"] as Array):
 			(analysis["preload_paths"] as Array).append(pl_path)
 
-	# Method declarations — needed for mod collision detection.
+	# Method declarations -- needed for mod collision detection.
 	var func_matches := _re_func.search_all(text)
 
 	# Determine the extends target for this file (if any).
@@ -2597,12 +2597,12 @@ func _check_class_name_safety(text: String, file_path: String, mod_name: String)
 		var to_path := m_to.get_string(1)
 		for cn: String in _class_name_to_path:
 			if _class_name_to_path[cn] == to_path:
-				_log_critical("  DANGER: %s calls take_over_path on class_name script %s (%s) — this will crash" % [file_path, to_path, cn])
+				_log_critical("  DANGER: %s calls take_over_path on class_name script %s (%s) -- this will crash" % [file_path, to_path, cn])
 				break
 
 # Override diagnostics (developer mode)
 
-# Log which mods use overrideScript() — overrides apply after scene reload.
+# Log which mods use overrideScript() -- overrides apply after scene reload.
 func _log_override_timing_warnings() -> void:
 	for mod_name: String in _mod_script_analysis:
 		var analysis: Dictionary = _mod_script_analysis[mod_name]
@@ -2613,7 +2613,7 @@ func _log_override_timing_warnings() -> void:
 			continue
 		var target_list := ", ".join(targets.map(func(p): return (p as String).get_file()))
 		_log_debug(mod_name + " uses overrideScript() on: " + target_list
-				+ " — applies after scene reload")
+				+ " -- applies after scene reload")
 
 # After reload, do any live nodes actually match the override targets?
 func _audit_override_instances() -> void:
@@ -2636,10 +2636,10 @@ func _audit_override_instances() -> void:
 		var mod_name: String = override_targets[target_path]
 		if live_script_paths.has(target_path):
 			_log_debug("Override applied: " + target_path.get_file()
-					+ " — " + str(live_script_paths[target_path]) + " node(s) [" + mod_name + "]")
+					+ " -- " + str(live_script_paths[target_path]) + " node(s) [" + mod_name + "]")
 		else:
 			_log_debug("Override registered but 0 nodes use " + target_path.get_file()
-					+ " in current scene — likely spawned at runtime [" + mod_name + "]")
+					+ " in current scene -- likely spawned at runtime [" + mod_name + "]")
 
 func _collect_live_scripts(root_node: Node, out: Dictionary) -> void:
 	var stack: Array[Node] = [root_node]
@@ -2677,7 +2677,7 @@ func _clean_early_autoload_dir() -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:
 		return
-	# Simple recursive wipe — this directory is entirely modloader-managed.
+	# Simple recursive wipe -- this directory is entirely modloader-managed.
 	dir.list_dir_begin()
 	while true:
 		var entry := dir.get_next()
@@ -2701,13 +2701,13 @@ func _clean_early_autoload_dir() -> void:
 # Extract an early autoload .gd script to disk if it only exists inside a
 # mounted archive.  Godot opens [autoload_prepend] scripts before file-scope
 # code runs, so archive-only scripts must be on disk for the restart.
-# Scene autoloads (.tscn) are handled by file-scope mounting — returned as-is.
+# Scene autoloads (.tscn) are handled by file-scope mounting -- returned as-is.
 func _ensure_early_autoload_on_disk(res_path: String, mod_name: String) -> String:
 	var global := ProjectSettings.globalize_path(res_path)
 	if FileAccess.file_exists(global):
 		return res_path
 
-	# Only .gd scripts need extraction — scenes resolve via file-scope mount.
+	# Only .gd scripts need extraction -- scenes resolve via file-scope mount.
 	var script := load(res_path) as GDScript
 	if script == null or not script.has_source_code():
 		return res_path
@@ -2741,14 +2741,14 @@ func _collect_enabled_archive_paths() -> PackedStringArray:
 			continue
 		if c["ext"] == "folder":
 			# Folder mods are zipped to a temp cache during load_all_mods().
-			# Store the temp zip path — the folder itself can't be mounted.
+			# Store the temp zip path -- the folder itself can't be mounted.
 			var folder_name: String = c["full_path"].get_file()
 			var tmp_zip := ProjectSettings.globalize_path(TMP_DIR).path_join(
 					folder_name + "_dev.zip")
 			if FileAccess.file_exists(tmp_zip):
 				paths.append(tmp_zip)
 			else:
-				_log_warning("Folder mod '%s' has no cached zip — skipping from pass state"
+				_log_warning("Folder mod '%s' has no cached zip -- skipping from pass state"
 						% c["mod_name"])
 			continue
 		paths.append(c["full_path"])
@@ -2804,7 +2804,7 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 		return FileAccess.get_open_error()
 	f.store_string("\n".join(lines) + "\n" + preserved)
 	f.close()
-	# Windows DirAccess.rename() won't overwrite — remove target first.
+	# Windows DirAccess.rename() won't overwrite -- remove target first.
 	if FileAccess.file_exists(path):
 		DirAccess.remove_absolute(path)
 	var dir := DirAccess.open(exe_dir)
@@ -2863,12 +2863,12 @@ func _delete_heartbeat() -> void:
 func _check_crash_recovery() -> void:
 	if not FileAccess.file_exists(HEARTBEAT_PATH):
 		return
-	_log_warning("Heartbeat detected — previous launch may have crashed")
+	_log_warning("Heartbeat detected -- previous launch may have crashed")
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) == OK:
 		var count: int = cfg.get_value("state", "restart_count", 0)
 		if count >= MAX_RESTART_COUNT:
-			_log_critical("Restart loop (%d crashes) — resetting to clean state" % count)
+			_log_critical("Restart loop (%d crashes) -- resetting to clean state" % count)
 			_restore_clean_override_cfg()
 			DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 			_delete_heartbeat()
@@ -2880,7 +2880,7 @@ func _check_safe_mode() -> void:
 	var safe_path := exe_dir.path_join(SAFE_MODE_FILE)
 	if not FileAccess.file_exists(safe_path):
 		return
-	_log_warning("Safe mode file detected — resetting to clean state")
+	_log_warning("Safe mode file detected -- resetting to clean state")
 	_restore_clean_override_cfg()
 	if FileAccess.file_exists(PASS_STATE_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
@@ -2904,12 +2904,12 @@ func _clean_stale_cache() -> void:
 			continue
 		var base := fname.get_basename()
 		if base.ends_with("_dev"):
-			# Folder mod cache — check if the source folder still exists.
+			# Folder mod cache -- check if the source folder still exists.
 			var folder_name := base.substr(0, base.length() - 4)
 			if DirAccess.dir_exists_absolute(_mods_dir.path_join(folder_name)):
 				continue
 		else:
-			# VMZ cache — check if the source .vmz still exists.
+			# VMZ cache -- check if the source .vmz still exists.
 			var vmz_name := base + ".vmz"
 			if FileAccess.file_exists(_mods_dir.path_join(vmz_name)):
 				continue
@@ -2923,7 +2923,7 @@ func _restore_clean_override_cfg() -> void:
 	var preserved := _read_preserved_cfg_sections(path)
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
-		_log_critical("Cannot write override.cfg — game dir may be read-only: " + exe_dir)
+		_log_critical("Cannot write override.cfg -- game dir may be read-only: " + exe_dir)
 		return
 	f.store_string("[autoload]\nModLoader=\"*" + MODLOADER_RES_PATH + "\"\n" + preserved)
 	f.close()
@@ -2952,7 +2952,7 @@ func _print_conflict_summary() -> void:
 	_log_info("Conflicting resource paths: " + str(conflicted_paths.size()))
 
 	if conflicted_paths.is_empty():
-		_log_info("No resource path conflicts — all mods appear compatible.")
+		_log_info("No resource path conflicts -- all mods appear compatible.")
 	else:
 		_log_info("")
 		_log_info("--- Conflicted Paths (last loader wins) ---")
@@ -3000,7 +3000,7 @@ func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: St
 
 	if get_tree().root.has_node(autoload_name):
 		_log_warning("Autoload name '" + autoload_name + "' conflicts with existing node at /root/"
-				+ autoload_name + " — Godot will rename it. [" + mod_name + "]")
+				+ autoload_name + " -- Godot will rename it. [" + mod_name + "]")
 
 	if resource is PackedScene:
 		var instance: Node = (resource as PackedScene).instantiate()
@@ -3029,7 +3029,7 @@ func _instantiate_autoload(mod_name: String, autoload_name: String, res_path: St
 			get_tree().root.add_child(inst as Node)
 			_log_info("Autoload instantiated (script): " + autoload_name + " [" + mod_name + "]")
 			return
-		_log_warning("Autoload is not a Node — not added to tree: " + autoload_name
+		_log_warning("Autoload is not a Node -- not added to tree: " + autoload_name
 				+ " [" + mod_name + "]")
 		return
 
@@ -3149,7 +3149,7 @@ func zip_folder_to_temp(folder_path: String) -> String:
 	if zp.open(tmp_zip_path) != OK:
 		_log_critical("Failed to create temp zip: " + tmp_zip_path)
 		return ""
-	# Zip contents without a top-level wrapper — the folder's internal structure
+	# Zip contents without a top-level wrapper -- the folder's internal structure
 	# already mirrors the res:// paths the mod expects.
 	_zip_folder_recursive(zp, folder_path, "")
 	zp.close()

--- a/modloader.gd
+++ b/modloader.gd
@@ -322,6 +322,7 @@ func _run_pass_1() -> void:
 	await _finish_single_pass()
 
 func _finish_with_existing_mounts() -> void:
+	_apply_hook_pack_scripts()
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
 			_log_info("  Autoload '%s' already in tree — skipped" % entry["name"])
@@ -362,6 +363,7 @@ func _finish_single_pass() -> void:
 
 func _run_pass_2() -> void:
 	_log_info("Pass 2 — %d archive(s) mounted at file-scope" % _file_scope_mounts)
+	_apply_hook_pack_scripts()
 	_clear_restart_counter()
 	_compile_regex()
 	_build_class_name_lookup()
@@ -1420,6 +1422,53 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 	# Filename tiebreaker for stable sort.
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
+# Apply hook pack scripts on Pass 2.  load_resource_pack() with text .gd files
+# does NOT override binary-tokenized .gd from the game PCK.  So we read the
+# hooked source from the vanilla cache + imposter functions, create a new GDScript,
+# and use take_over_path() to replace the cached binary version — same technique
+# the Godot Mod Loader uses for script extensions.
+func _apply_hook_pack_scripts() -> void:
+	var hook_pack := ProjectSettings.globalize_path(HOOK_PACK_PATH)
+	if not FileAccess.file_exists(hook_pack):
+		return
+
+	# Read the transformed scripts from the hook pack ZIP.
+	var zr := ZIPReader.new()
+	if zr.open(hook_pack) != OK:
+		_log_warning("[Hooks] Could not open hook pack for take_over_path application")
+		return
+
+	var applied := 0
+	for file_path in zr.get_files():
+		if not file_path.ends_with(".gd"):
+			continue
+		var res_path := "res://" + file_path
+		var source := zr.read_file(file_path).get_string_from_utf8()
+		if source.is_empty():
+			continue
+
+		# Strip class_name to avoid "hides a global script class" crash.
+		# The class is already registered from the game's PCK — we just need
+		# the script to compile and take over the path.
+		var cn_regex := RegEx.new()
+		cn_regex.compile("(?m)^class_name\\s+.*$")
+		var stripped_source := cn_regex.sub(source, "")
+
+		var new_script := GDScript.new()
+		new_script.source_code = stripped_source
+		var err := new_script.reload()
+		if err != OK:
+			_log_critical("[Hooks] take_over_path: failed to compile %s (error %d)" % [res_path, err])
+			continue
+
+		new_script.take_over_path(res_path)
+		applied += 1
+		_log_info("[Hooks] take_over_path: applied %s" % res_path)
+
+	zr.close()
+	if applied > 0:
+		_log_info("[Hooks] Applied %d hooked script(s) via take_over_path" % applied)
+
 # Script hooks — lets multiple mods modify methods on vanilla class_name scripts.
 # Mods declare hooks in mod.txt [hooks]; the preprocessor rewrites vanilla methods
 # with dispatch wrappers. Mods register callables via add_hook() at runtime.
@@ -1548,6 +1597,407 @@ func _get_hardcoded_class_map() -> Dictionary:
 		"WorldSave": "res://Scripts/WorldSave.gd",
 	}
 
+# ─── GDSC Binary Token Detokenizer ───────────────────────────────────────────
+# Reconstructs GDScript source from Godot's binary-tokenized .gdc format (GDSC).
+# Used when the game exports with binary tokenization and load().source_code is
+# empty.  Only called on-demand for scripts listed in mod [hooks] sections.
+# Supports TOKENIZER_VERSION 100 (Godot 4.0-4.4) and 101 (Godot 4.5-4.6).
+
+const _GDSC_MAGIC := "GDSC"
+const _GDSC_TOKEN_BITS := 8
+const _GDSC_TOKEN_MASK := (1 << (_GDSC_TOKEN_BITS - 1)) - 1  # 0x7F
+const _GDSC_TOKEN_BYTE_MASK := 0x80
+
+# Token type indices — Godot 4.5-4.6 / TOKENIZER_VERSION 101.
+# 0=EMPTY 1=ANNOTATION 2=IDENTIFIER 3=LITERAL
+# 4-9: < <= > >= == !=   10-15: and or not && || !
+# 16-21: & | ~ ^ << >>   22-27: + - * ** / %
+# 28-39: = += -= *= **= /= %= <<= >>= &= |= ^=
+# 40-50: if elif else for while break continue pass return match when
+# 51-72: as assert await breakpoint class class_name const enum extends func
+#        in is namespace preload self signal static super trait var void yield
+# 73-78: [ ] { } ( )   79-87: , ; . .. ... : $ -> _
+# 88-90: NEWLINE INDENT DEDENT   91-94: PI TAU INF NAN   99: EOF
+#
+# Raw int keys are used in dictionaries below because Godot does not allow
+# enum references in const dictionary initializers.
+const _TOKEN_TEXT := {
+	4: "<", 5: "<=", 6: ">", 7: ">=", 8: "==", 9: "!=",
+	10: "and", 11: "or", 12: "not", 13: "&&", 14: "||", 15: "!",
+	16: "&", 17: "|", 18: "~", 19: "^", 20: "<<", 21: ">>",
+	22: "+", 23: "-", 24: "*", 25: "**", 26: "/", 27: "%",
+	28: "=", 29: "+=", 30: "-=", 31: "*=", 32: "**=", 33: "/=",
+	34: "%=", 35: "<<=", 36: ">>=", 37: "&=", 38: "|=", 39: "^=",
+	40: "if", 41: "elif", 42: "else", 43: "for", 44: "while",
+	45: "break", 46: "continue", 47: "pass", 48: "return", 49: "match", 50: "when",
+	51: "as", 52: "assert", 53: "await", 54: "breakpoint", 55: "class",
+	56: "class_name", 57: "const", 58: "enum", 59: "extends", 60: "func",
+	61: "in", 62: "is", 63: "namespace", 64: "preload", 65: "self",
+	66: "signal", 67: "static", 68: "super", 69: "trait", 70: "var",
+	71: "void", 72: "yield",
+	73: "[", 74: "]", 75: "{", 76: "}", 77: "(", 78: ")",
+	79: ",", 80: ";", 81: ".", 82: "..", 83: "...",
+	84: ":", 85: "$", 86: "->", 87: "_",
+	91: "PI", 92: "TAU", 93: "INF", 94: "NAN",
+	96: "`", 97: "?",
+}
+
+# Tokens that want a space BEFORE them (binary operators, keywords after exprs).
+const _SPACE_BEFORE := {
+	4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1,      # < <= > >= == !=
+	10: 1, 11: 1, 12: 1, 13: 1, 14: 1,         # and or not && ||
+	16: 1, 17: 1, 19: 1, 20: 1, 21: 1,          # & | ^ << >>
+	22: 1, 23: 1, 24: 1, 25: 1, 26: 1, 27: 1,  # + - * ** / %
+	28: 1, 29: 1, 30: 1, 31: 1, 32: 1, 33: 1,  # = += -= *= **= /=
+	34: 1, 35: 1, 36: 1, 37: 1, 38: 1, 39: 1,  # %= <<= >>= &= |= ^=
+	40: 1, 42: 1, 51: 1, 61: 1, 62: 1,          # if else as in is
+	86: 1,                                        # ->
+}
+
+# Tokens that want a space AFTER them.
+const _SPACE_AFTER := {
+	79: 1, 80: 1, 86: 1,                          # , ; ->
+	4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1,          # < <= > >= == !=
+	10: 1, 11: 1, 12: 1, 13: 1, 14: 1, 15: 1,    # and or not && || !
+	16: 1, 17: 1, 19: 1, 20: 1, 21: 1,            # & | ^ << >>
+	22: 1, 23: 1, 24: 1, 25: 1, 26: 1, 27: 1,    # + - * ** / %
+	28: 1, 29: 1, 30: 1, 31: 1, 32: 1, 33: 1,    # = += -= *= **= /=
+	34: 1, 35: 1, 36: 1, 37: 1, 38: 1, 39: 1,    # %= <<= >>= &= |= ^=
+	84: 1,                                          # :
+	1: 1,                                           # @ annotations
+	# All keywords (40-72) need space after:
+	40: 1, 41: 1, 42: 1, 43: 1, 44: 1,            # if elif else for while
+	45: 1, 46: 1, 47: 1, 48: 1, 49: 1, 50: 1,    # break continue pass return match when
+	51: 1, 52: 1, 53: 1, 54: 1, 55: 1,            # as assert await breakpoint class
+	56: 1, 57: 1, 58: 1, 59: 1, 60: 1,            # class_name const enum extends func
+	61: 1, 62: 1, 63: 1, 64: 1, 65: 1,            # in is namespace preload self
+	66: 1, 67: 1, 68: 1, 69: 1, 70: 1,            # signal static super trait var
+	71: 1, 72: 1,                                   # void yield
+}
+
+func _detokenize_script(script_path: String) -> String:
+	# Try multiple methods to read raw bytes — FileAccess on res:// can fail for
+	# PCK-embedded files depending on the container format (RSCC, encryption, etc.).
+	var raw := PackedByteArray()
+
+	# Method 1: FileAccess.open() on res:// path directly.
+	var f := FileAccess.open(script_path, FileAccess.READ)
+	if f:
+		raw = f.get_buffer(f.get_length())
+		f.close()
+
+	# Method 2: Try the globalized path.
+	if raw.is_empty():
+		var glob_path := ProjectSettings.globalize_path(script_path)
+		f = FileAccess.open(glob_path, FileAccess.READ)
+		if f:
+			raw = f.get_buffer(f.get_length())
+			f.close()
+
+	# Method 3: Try loading as a generic Resource and check if it has raw data.
+	# (GDScript objects loaded from tokenized files don't expose raw bytes, but
+	# we can try get_file_as_bytes with .gdc extension in case Godot mapped it.)
+	if raw.is_empty():
+		var gdc_path := script_path.replace(".gd", ".gdc")
+		raw = FileAccess.get_file_as_bytes(gdc_path)
+
+	if raw.is_empty():
+		_log_warning("[Detokenize] Cannot read bytes from: %s (tried res://, globalized, .gdc)" % script_path)
+		return ""
+
+	# ── Header (12 bytes) ──
+	if raw.size() < 12:
+		return ""
+	var magic := raw.slice(0, 4).get_string_from_ascii()
+	if magic != _GDSC_MAGIC:
+		# Not a GDSC file — might be plain text that load() failed on for another reason.
+		var text := raw.get_string_from_utf8()
+		if not text.is_empty() and (text.begins_with("extends") or text.begins_with("class_name") or text.begins_with("@")):
+			return text
+		_log_warning("[Detokenize] Not a GDSC file: " + script_path)
+		return ""
+
+	var version := raw.decode_u32(4)
+	if version != 100 and version != 101:
+		_log_critical("[Detokenize] Unsupported GDSC version %d in %s (expected 100 or 101)" % [version, script_path])
+		return ""
+
+	var decompressed_size := raw.decode_u32(8)
+	var buf: PackedByteArray
+	if decompressed_size == 0:
+		buf = raw.slice(12)
+	else:
+		var compressed := raw.slice(12)
+		buf = compressed.decompress(decompressed_size, FileAccess.COMPRESSION_ZSTD)
+		if buf.is_empty():
+			_log_critical("[Detokenize] ZSTD decompression failed for: " + script_path)
+			return ""
+
+	# ── Metadata ──
+	var meta_size := 20 if version == 100 else 16  # v100 has 4-byte padding
+	if buf.size() < meta_size:
+		return ""
+	var ident_count: int = buf.decode_u32(0)
+	var const_count: int = buf.decode_u32(4)
+	var line_count: int  = buf.decode_u32(8)
+	var token_count: int
+	if version == 100:
+		token_count = buf.decode_u32(16)
+	else:
+		token_count = buf.decode_u32(12)
+
+	var offset := meta_size
+
+	# ── Identifiers (XOR 0xb6 encoded UTF-32) ──
+	var identifiers: Array[String] = []
+	for _i in ident_count:
+		if offset + 4 > buf.size():
+			break
+		var str_len: int = buf.decode_u32(offset)
+		offset += 4
+		var s := ""
+		for _j in str_len:
+			if offset + 4 > buf.size():
+				break
+			var b0: int = buf[offset] ^ 0xb6
+			var b1: int = buf[offset + 1] ^ 0xb6
+			var b2: int = buf[offset + 2] ^ 0xb6
+			var b3: int = buf[offset + 3] ^ 0xb6
+			var code_point: int = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+			if code_point > 0:
+				s += String.chr(code_point)
+			offset += 4
+		identifiers.append(s)
+
+	# ── Constants (Variant-encoded, sequential) ──
+	var constants: Array = []
+	for _i in const_count:
+		if offset + 4 > buf.size():
+			break
+		# Decode next Variant from the stream.  We round-trip through
+		# var_to_bytes() to determine consumed size since bytes_to_var()
+		# doesn't report how many bytes it read.
+		var remaining := buf.slice(offset)
+		var val = bytes_to_var(remaining)
+		constants.append(val)
+		# Advance offset by the encoded size.
+		var encoded := var_to_bytes(val)
+		offset += encoded.size()
+
+	# ── Line/column maps ──
+	var line_map := {}  # token_index -> line
+	var col_map := {}   # token_index -> column
+	for _i in line_count:
+		if offset + 8 > buf.size():
+			break
+		var tok_idx: int = buf.decode_u32(offset)
+		var line_val: int = buf.decode_u32(offset + 4)
+		line_map[tok_idx] = line_val
+		offset += 8
+	for _i in line_count:
+		if offset + 8 > buf.size():
+			break
+		var tok_idx: int = buf.decode_u32(offset)
+		var col_val: int = buf.decode_u32(offset + 4)
+		col_map[tok_idx] = col_val
+		offset += 8
+
+	# ── Token stream ──
+	var tokens: Array = []  # Array of [type: int, data_index: int]
+	for _i in token_count:
+		if offset >= buf.size():
+			break
+		var token_len := 8 if (buf[offset] & _GDSC_TOKEN_BYTE_MASK) else 5
+		if offset + token_len > buf.size():
+			break
+		var raw_type: int = buf.decode_u32(offset)
+		var tk_type: int = raw_type & _GDSC_TOKEN_MASK
+		var data_idx: int = raw_type >> _GDSC_TOKEN_BITS
+		tokens.append([tk_type, data_idx])
+		offset += token_len
+
+	# ── Reconstruct source ──
+	var result := _gdsc_reconstruct(tokens, identifiers, constants, line_map, col_map)
+	if result.is_empty():
+		return ""
+
+	# ── Validate: try to parse the reconstructed source ──
+	# Strip class_name for validation — GDScript.new().reload() rejects duplicate
+	# class_name declarations that conflict with already-registered global classes.
+	var validate_source := result
+	var cn_regex := RegEx.new()
+	cn_regex.compile("(?m)^class_name\\s+.*$")
+	validate_source = cn_regex.sub(validate_source, "# class_name stripped for validation")
+	var test_script := GDScript.new()
+	test_script.source_code = validate_source
+	var err := test_script.reload(true)  # true = keep_state
+	if err != OK:
+		_log_critical("[Detokenize] Reconstructed source for %s has parse errors (error %d)" % [script_path, err])
+		var dbg_lines := result.split("\n")
+		for j in mini(40, dbg_lines.size()):
+			_log_debug("[Detokenize]   %3d | %s" % [j + 1, dbg_lines[j]])
+	else:
+		_log_info("[Detokenize] Reconstructed: %s (%d tokens, %d lines) — parse OK" \
+				% [script_path, tokens.size(), result.count("\n") + 1])
+	return result
+
+func _gdsc_reconstruct(tokens: Array, identifiers: Array[String], constants: Array,
+		line_map: Dictionary, col_map: Dictionary) -> String:
+	var lines := PackedStringArray()
+	var current_line := ""
+	var current_line_num := 1
+	var need_space := false
+	var prev_tk := -1
+	var line_started := false  # has any visible token been emitted on this line?
+
+	for i in tokens.size():
+		var tk: int = tokens[i][0]
+		var idx: int = tokens[i][1]
+
+		# Handle line changes via line_map.
+		if line_map.has(i):
+			var new_line: int = line_map[i]
+			while current_line_num < new_line:
+				lines.append(current_line)
+				current_line = ""
+				current_line_num += 1
+				need_space = false
+				line_started = false
+
+		if tk == 99:  # EOF
+			break
+
+		if tk == 88:  # NEWLINE
+			lines.append(current_line)
+			current_line = ""
+			current_line_num += 1
+			need_space = false
+			line_started = false
+			prev_tk = tk
+			continue
+
+		if tk == 89 or tk == 90:  # INDENT / DEDENT — skip, we use col_map instead
+			prev_tk = tk
+			continue
+
+		# Build the text for this token.
+		var text := ""
+		if tk == 2:  # IDENTIFIER
+			text = identifiers[idx] if idx < identifiers.size() else "<ident?>"
+		elif tk == 1:  # ANNOTATION
+			var aname: String = identifiers[idx] if idx < identifiers.size() else "?"
+			text = aname if aname.begins_with("@") else ("@" + aname)
+		elif tk == 3:  # LITERAL
+			text = _gdsc_variant_to_source(constants[idx] if idx < constants.size() else null)
+		elif _TOKEN_TEXT.has(tk):
+			text = _TOKEN_TEXT[tk]
+		else:
+			text = "<tk%d>" % tk
+
+		# Apply indentation from column data for the first visible token on a line.
+		if not line_started:
+			line_started = true
+			if col_map.has(i):
+				var col: int = col_map[i]
+				# Convert column to tabs (Godot uses tab_size=4 for indentation).
+				var tabs: int = col / 4
+				for _t in tabs:
+					current_line += "\t"
+
+		# Spacing logic.
+		var add_space_before := false
+		if need_space and not current_line.is_empty() and not current_line.ends_with("\t"):
+			if _SPACE_BEFORE.has(tk):
+				add_space_before = true
+			elif tk == 2 or tk == 3 or tk == 1 or (tk >= 40 and tk <= 72):
+				# IDENTIFIER, LITERAL, ANNOTATION, or any keyword — space before
+				# unless prev was an opener, dot, $, ~, !, indent, newline.
+				# Note: annotation (1) excluded only for identifiers (part of the
+				# annotation name), NOT for keywords like var/func after @export.
+				var skip_anno := (prev_tk == 1 and (tk == 2 or tk == 1))  # ident/anno after anno
+				if not skip_anno \
+						and prev_tk != 77 and prev_tk != 73 \
+						and prev_tk != 81 and prev_tk != 85 \
+						and prev_tk != 18 \
+						and prev_tk != 15 and prev_tk != 89 \
+						and prev_tk != 88 and prev_tk != -1:
+					add_space_before = true
+			elif tk == 77:  # PAREN_OPEN
+				# Space before ( after control-flow keywords, but NOT after
+				# function-like keywords (func, preload, super, assert, await).
+				if prev_tk >= 40 and prev_tk <= 50:  # if..when (control flow)
+					add_space_before = true
+			elif tk == 12 or tk == 15:  # NOT, BANG
+				add_space_before = true
+
+		if add_space_before and not current_line.ends_with(" ") and not current_line.ends_with("\t"):
+			current_line += " "
+
+		current_line += text
+
+		# Set need_space for next token.  _SPACE_AFTER covers operators,
+		# keywords, and punctuation.  Also need space after identifiers (2),
+		# literals (3), close-parens (78), close-bracket (74), close-brace (76),
+		# constants (91-94 PI/TAU/INF/NAN), and underscore (87).
+		need_space = _SPACE_AFTER.has(tk) or tk == 2 or tk == 3 \
+				or tk == 78 or tk == 74 or tk == 76 \
+				or tk == 91 or tk == 92 or tk == 93 \
+				or tk == 94 or tk == 87
+
+		prev_tk = tk
+
+	# Flush last line.
+	if not current_line.is_empty():
+		lines.append(current_line)
+
+	# GDScript files should end with newline.
+	var result := "\n".join(lines)
+	if not result.ends_with("\n"):
+		result += "\n"
+	return result
+
+func _gdsc_variant_to_source(value: Variant) -> String:
+	if value == null:
+		return "null"
+	match typeof(value):
+		TYPE_BOOL:
+			return "true" if value else "false"
+		TYPE_INT:
+			return str(value)
+		TYPE_FLOAT:
+			var s := str(value)
+			if "." not in s and "e" not in s and "inf" not in s.to_lower() and "nan" not in s.to_lower():
+				s += ".0"
+			return s
+		TYPE_STRING:
+			return '"%s"' % str(value).c_escape()
+		TYPE_STRING_NAME:
+			return '&"%s"' % str(value).c_escape()
+		TYPE_NODE_PATH:
+			return '^"%s"' % str(value).c_escape()
+		TYPE_VECTOR2:
+			return "Vector2(%s, %s)" % [_gdsc_variant_to_source(value.x), _gdsc_variant_to_source(value.y)]
+		TYPE_VECTOR2I:
+			return "Vector2i(%s, %s)" % [value.x, value.y]
+		TYPE_VECTOR3:
+			return "Vector3(%s, %s, %s)" % [_gdsc_variant_to_source(value.x), _gdsc_variant_to_source(value.y), _gdsc_variant_to_source(value.z)]
+		TYPE_VECTOR3I:
+			return "Vector3i(%s, %s, %s)" % [value.x, value.y, value.z]
+		TYPE_COLOR:
+			return "Color(%s, %s, %s, %s)" % [_gdsc_variant_to_source(value.r), _gdsc_variant_to_source(value.g), _gdsc_variant_to_source(value.b), _gdsc_variant_to_source(value.a)]
+		TYPE_ARRAY:
+			var parts := PackedStringArray()
+			for item in value:
+				parts.append(_gdsc_variant_to_source(item))
+			return "[%s]" % ", ".join(parts)
+		TYPE_DICTIONARY:
+			var parts := PackedStringArray()
+			for k in value:
+				parts.append("%s: %s" % [_gdsc_variant_to_source(k), _gdsc_variant_to_source(value[k])])
+			return "{%s}" % ", ".join(parts)
+		_:
+			return str(value)
+
 func _read_vanilla_source(script_path: String) -> String:
 	# Hook pack may be file-scope-mounted, so load() could return the hooked
 	# version.  The vanilla cache stores the original source.
@@ -1564,9 +2014,16 @@ func _read_vanilla_source(script_path: String) -> String:
 			return cached  # live is hooked — trust cache
 
 	var script := load(script_path) as GDScript
-	if script == null or script.source_code.is_empty():
+	if script == null:
 		return ""
+
 	var source := script.source_code
+	if source.is_empty():
+		# Script is binary-tokenized (GDSC format) — detokenize from raw bytes.
+		source = _detokenize_script(script_path)
+		if source.is_empty():
+			return ""
+
 	if "func _vanilla_" in source:  # hook pack mounted but cache missing
 		_log_critical("[Hooks] Cannot read vanilla source for %s — delete %s and restart"
 				% [script_path, ProjectSettings.globalize_path(HOOK_PACK_PATH)])
@@ -1575,6 +2032,8 @@ func _read_vanilla_source(script_path: String) -> String:
 	return source
 
 func _save_vanilla_source(script_path: String, source: String) -> void:
+	if source.is_empty():
+		return  # never write 0-byte cache files
 	var cache_file := VANILLA_CACHE_DIR.path_join(script_path.trim_prefix("res://"))
 	DirAccess.make_dir_recursive_absolute(
 		ProjectSettings.globalize_path(cache_file.get_base_dir()))
@@ -1646,6 +2105,17 @@ func _preprocess_script(script_path: String, hooked_methods: Array[String]) -> S
 			var super_pos := line_str.find("super(")
 			if comment_pos >= 0 and super_pos > comment_pos:
 				continue  # super( is inside a comment
+			# Check if super( is inside a string literal.
+			var in_string := false
+			var dquotes := 0
+			var squotes := 0
+			for ci in super_pos:
+				if line_str[ci] == '"':
+					dquotes += 1
+				elif line_str[ci] == "'":
+					squotes += 1
+			if dquotes % 2 != 0 or squotes % 2 != 0:
+				continue  # super( is inside a string literal
 			lines[i] = line_str.replace("super(", "super." + method_name + "(")
 		imposters.append(_generate_imposter(script_path, method_name, info))
 
@@ -1657,7 +2127,11 @@ func _preprocess_script(script_path: String, hooked_methods: Array[String]) -> S
 func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionary) -> Variant:
 	var method_name: String = method_dict["name"]
 
-	var start_line: int = script.get_member_line(method_name) - 1
+	var start_line := -1
+	# get_member_line() crashes on binary-tokenized scripts — only call it if
+	# the script has source code available.
+	if script.has_source_code():
+		start_line = script.get_member_line(method_name) - 1
 	if start_line < 0 or start_line >= lines.size():
 		start_line = -1  # fallback: scan source text
 		for i in lines.size():
@@ -1697,19 +2171,41 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 		param_names.append(arg["name"])
 
 	var body_text := ""
+	var method_indent := _get_indent_level(sig_line)
 	for i in range(body_start, body_end):
 		body_text += lines[i] + "\n"
-	var is_async := "await " in body_text
 
+	# Detect async — check for `await` in body, but skip comments and strings.
+	var is_async := _body_contains_keyword(body_text, "await")
+
+	# Determine return type.
 	var return_type := ""
+	var return_type_id: int = 0  # Variant::Type for typed returns
 	var ret = method_dict["return"]
 	if method_name == "_init" or method_name in LIFECYCLE_METHODS:
 		return_type = "void"
 	elif ret["type"] == 0:  # Variant::NIL — could be void or untyped
 		if "-> void" in sig_line:
 			return_type = "void"
+		else:
+			# No return type annotation.  Check if body has `return <value>` at
+			# the method's own indent level (not inside lambdas/inner funcs).
+			var has_value_return := false
+			for bline in body_text.split("\n"):
+				var bstripped := bline.strip_edges()
+				if bstripped.is_empty() or bstripped.begins_with("#"):
+					continue
+				var bind := _get_indent_level(bline)
+				if bind > method_indent + 1:
+					continue  # deeper indent — could be lambda body
+				if bstripped.begins_with("return ") and bstripped != "return":
+					has_value_return = true
+					break
+			if not has_value_return:
+				return_type = "void"
 	else:
 		return_type = "typed"
+		return_type_id = ret["type"]
 
 	var is_static: bool = (int(method_dict["flags"]) & 32) != 0  # METHOD_FLAG_STATIC
 
@@ -1722,6 +2218,7 @@ func _extract_method_info(script: GDScript, lines: Array, method_dict: Dictionar
 		"is_static": is_static,
 		"is_async": is_async,
 		"return_type": return_type,
+		"return_type_id": return_type_id,
 	}
 
 func _get_indent_level(line: String) -> int:
@@ -1729,9 +2226,63 @@ func _get_indent_level(line: String) -> int:
 	for c in line:
 		if c == '\t':
 			count += 1
+		elif c == ' ':
+			count += 1  # spaces from detokenized source (4 spaces = 1 tab)
 		else:
 			break
-	return count
+	return count / 4 if count > 0 and '\t' not in line.left(count) else count
+
+# Check if body text contains a keyword outside of comments and string literals.
+func _body_contains_keyword(body_text: String, keyword: String) -> bool:
+	for bline in body_text.split("\n"):
+		var stripped := bline.strip_edges()
+		if stripped.is_empty() or stripped.begins_with("#"):
+			continue
+		if keyword not in stripped:
+			continue
+		# Skip if in a string literal — crude check: count quotes before keyword.
+		var kpos := stripped.find(keyword)
+		var dquotes := 0
+		var squotes := 0
+		for ci in kpos:
+			if stripped[ci] == '"':
+				dquotes += 1
+			elif stripped[ci] == "'":
+				squotes += 1
+		if dquotes % 2 != 0 or squotes % 2 != 0:
+			continue  # keyword is inside a string literal
+		# Skip comment-trailing keyword.
+		var hash_pos := -1
+		for ci in stripped.length():
+			if stripped[ci] == '#':
+				hash_pos = ci
+				break
+			elif stripped[ci] == '"' or stripped[ci] == "'":
+				break  # string before any #, stop looking
+		if hash_pos >= 0 and kpos > hash_pos:
+			continue  # keyword is after # comment
+		return true
+	return false
+
+# Return a GDScript expression for the default value of a Variant type.
+func _get_type_default(type_id: int) -> String:
+	match type_id:
+		TYPE_BOOL: return "false"
+		TYPE_INT: return "0"
+		TYPE_FLOAT: return "0.0"
+		TYPE_STRING: return '""'
+		TYPE_STRING_NAME: return '&""'
+		TYPE_VECTOR2: return "Vector2()"
+		TYPE_VECTOR2I: return "Vector2i()"
+		TYPE_VECTOR3: return "Vector3()"
+		TYPE_VECTOR3I: return "Vector3i()"
+		TYPE_COLOR: return "Color()"
+		TYPE_ARRAY: return "[]"
+		TYPE_DICTIONARY: return "{}"
+		TYPE_PACKED_BYTE_ARRAY: return "PackedByteArray()"
+		TYPE_PACKED_STRING_ARRAY: return "PackedStringArray()"
+		TYPE_NODE_PATH: return 'NodePath("")'
+		_: return "null"
 
 func _generate_imposter(script_path: String, method_name: String, info: Dictionary) -> String:
 	var lines := PackedStringArray()
@@ -1744,7 +2295,12 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 	lines.append('\tvar __skip := ModLoader._call_before_hooks("%s", "%s", %s, __hook_args)' \
 			% [script_path, method_name, self_ref])
 
-	lines.append("\tif __skip: return")
+	# Return appropriate default when skip is true.
+	if info["return_type"] == "typed":
+		var default_val := _get_type_default(info["return_type_id"])
+		lines.append("\tif __skip: return %s" % default_val)
+	else:
+		lines.append("\tif __skip: return")
 
 	for i in info["param_names"].size():
 		lines.append("\t%s = __hook_args[%d]" % [info["param_names"][i], i])
@@ -1774,8 +2330,9 @@ func _generate_hook_pack() -> String:
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(HOOK_PACK_DIR))
 
 	var pack_path := ProjectSettings.globalize_path(HOOK_PACK_PATH)
+	var tmp_path := pack_path + ".tmp"
 	var zp := ZIPPacker.new()
-	if zp.open(pack_path) != OK:
+	if zp.open(tmp_path) != OK:
 		_log_critical("[Hooks] Failed to create hook pack ZIP")
 		return ""
 
@@ -1800,19 +2357,39 @@ func _generate_hook_pack() -> String:
 			_log_critical("[Hooks] Failed to preprocess: " + script_path)
 			continue
 
+		# Validate the transformed script parses before packing it.
+		# Strip class_name to avoid "hides a global script class" error.
+		var validate_src := transformed
+		var vcn_regex := RegEx.new()
+		vcn_regex.compile("(?m)^class_name\\s+.*$")
+		validate_src = vcn_regex.sub(validate_src, "# class_name stripped for validation")
+		var validate := GDScript.new()
+		validate.source_code = validate_src
+		var verr := validate.reload(true)
+		if verr != OK:
+			_log_critical("[Hooks] Transformed %s has parse errors (error %d) — skipping" % [script_path, verr])
+			var vlines := transformed.split("\n")
+			for vj in mini(50, vlines.size()):
+				_log_debug("[Hooks]   %3d | %s" % [vj + 1, vlines[vj]])
+			continue
+
 		var zip_internal_path := script_path.replace("res://", "")
 		zp.start_file(zip_internal_path)
 		zp.write_file(transformed.to_utf8_buffer())
 		zp.close_file()
 		any_success = true
-		_log_info("[Hooks] Hooked: %s (%d methods)" % [script_path, hooked_methods.size()])
+		_log_info("[Hooks] Hooked: %s (%d methods) — validated OK" % [script_path, hooked_methods.size()])
 
 	zp.close()
 
 	if not any_success:
-		DirAccess.remove_absolute(pack_path)
+		DirAccess.remove_absolute(tmp_path)
 		return ""
 
+	# Atomic rename: tmp → final path.  Prevents corrupt ZIPs from partial writes.
+	if FileAccess.file_exists(pack_path):
+		DirAccess.remove_absolute(pack_path)
+	DirAccess.rename_absolute(tmp_path, pack_path)
 	return pack_path
 
 # Archive scanner

--- a/modloader.gd
+++ b/modloader.gd
@@ -48,11 +48,11 @@ var _override_registry: Dictionary = {}
 var _mod_script_analysis: Dictionary = {}
 var _archive_file_sets: Dictionary = {}
 
-# Hook system state
-var _hook_registry: Dictionary = {}       # "res://path.gd::method" -> { before: [Callable], after: [Callable] }
-var _hook_script_paths: Dictionary = {}   # "res://path.gd" -> true  (scripts that need hook-pack entries)
+# Hooks
+var _hook_registry: Dictionary = {}       # "res://path.gd::method" -> { before: [], after: [] }
+var _hook_script_paths: Dictionary = {}   # "res://path.gd" -> true
 var _class_name_to_path: Dictionary = {}  # "Camera" -> "res://Scripts/Camera.gd"
-var _hook_call_depth: Dictionary = {}     # "res://path.gd::method" -> int  (reentrancy guard)
+var _hook_call_depth: Dictionary = {}     # reentrancy guard per key
 
 var _re_take_over: RegEx
 var _re_extends: RegEx
@@ -289,14 +289,8 @@ func _run_pass_1() -> void:
 			hook_pack_path = ""
 		else:
 			archive_paths.append(hook_pack_path)
-	elif not _hook_script_paths.is_empty():
+	elif not _loaded_mod_ids.is_empty():
 		_log_critical("[Hooks] Hook pack generation failed — hooks will not work")
-
-	if _hook_script_paths.is_empty():
-		var pack_file := ProjectSettings.globalize_path(HOOK_PACK_PATH)
-		if FileAccess.file_exists(pack_file):
-			_static_wipe_hook_cache()
-			_log_info("[Hooks] Cleaned up unused hook artifacts")
 
 	if archive_paths.size() > 0:
 		_log_info("Preparing two-pass restart — %d archive(s)" % archive_paths.size())
@@ -319,6 +313,10 @@ func _run_pass_1() -> void:
 	if FileAccess.file_exists(PASS_STATE_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		_restore_clean_override_cfg()
+	var pack_file := ProjectSettings.globalize_path(HOOK_PACK_PATH)
+	if FileAccess.file_exists(pack_file):
+		_static_wipe_hook_cache()
+		_log_info("[Hooks] Cleaned up unused hook artifacts")
 	await _finish_single_pass()
 
 func _finish_with_existing_mounts() -> void:
@@ -1232,7 +1230,6 @@ func load_all_mods(pass_label: String = "") -> void:
 	_mod_script_analysis.clear()
 	_archive_file_sets.clear()
 	_hook_registry.clear()
-	_hook_script_paths.clear()
 	_hook_call_depth.clear()
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
@@ -1318,7 +1315,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	_loaded_mod_ids[mod_id] = true
 
-	# Parse [hooks] before [autoload] — mods with hooks but no autoloads still work.
+	# [hooks] is optional — all class_name methods are pre-wrapped.
 	if cfg != null and cfg.has_section("hooks"):
 		for key in cfg.get_section_keys("hooks"):
 			var script_path := str(key)
@@ -1327,11 +1324,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 				method_name = method_name.strip_edges()
 				if method_name.is_empty():
 					continue
-				_hook_script_paths[script_path] = true
-				var hook_key := script_path + "::" + method_name
-				if not _hook_registry.has(hook_key):
-					_hook_registry[hook_key] = { "before": [], "after": [] }
-				_log_info("  Hook declared: %s :: %s [%s]" % [script_path, method_name, mod_name])
+				_log_info("  Hook hint: %s :: %s [%s]" % [script_path, method_name, mod_name])
 
 	if cfg == null or not cfg.has_section("autoload"):
 		return
@@ -1422,21 +1415,21 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 	# Filename tiebreaker for stable sort.
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
-# Apply hook pack scripts on Pass 2.  load_resource_pack() with text .gd files
-# does NOT override binary-tokenized .gd from the game PCK.  So we read the
-# hooked source from the vanilla cache + imposter functions, create a new GDScript,
-# and use take_over_path() to replace the cached binary version — same technique
-# the Godot Mod Loader uses for script extensions.
+# Apply hook pack scripts via take_over_path.  class_name is stripped to avoid
+# "hides a global script class" — scripts with typed array refs are excluded
+# upstream in _generate_hook_pack() to prevent Array[Object] identity errors.
 func _apply_hook_pack_scripts() -> void:
 	var hook_pack := ProjectSettings.globalize_path(HOOK_PACK_PATH)
 	if not FileAccess.file_exists(hook_pack):
 		return
 
-	# Read the transformed scripts from the hook pack ZIP.
 	var zr := ZIPReader.new()
 	if zr.open(hook_pack) != OK:
-		_log_warning("[Hooks] Could not open hook pack for take_over_path application")
+		_log_warning("[Hooks] Could not open hook pack for script application")
 		return
+
+	var cn_regex := RegEx.new()
+	cn_regex.compile("(?m)^class_name\\s+.*$")
 
 	var applied := 0
 	for file_path in zr.get_files():
@@ -1447,40 +1440,29 @@ func _apply_hook_pack_scripts() -> void:
 		if source.is_empty():
 			continue
 
-		# Strip class_name to avoid "hides a global script class" crash.
-		# The class is already registered from the game's PCK — we just need
-		# the script to compile and take over the path.
-		var cn_regex := RegEx.new()
-		cn_regex.compile("(?m)^class_name\\s+.*$")
-		var stripped_source := cn_regex.sub(source, "")
-
+		var stripped := cn_regex.sub(source, "")
 		var new_script := GDScript.new()
-		new_script.source_code = stripped_source
+		new_script.source_code = stripped
 		var err := new_script.reload()
 		if err != OK:
-			_log_critical("[Hooks] take_over_path: failed to compile %s (error %d)" % [res_path, err])
+			_log_critical("[Hooks] Compile failed for %s (error %d)" % [res_path, err])
 			continue
-
 		new_script.take_over_path(res_path)
+		_hook_script_paths[res_path] = true
 		applied += 1
-		_log_info("[Hooks] take_over_path: applied %s" % res_path)
+		_log_info("[Hooks] take_over_path: %s" % res_path)
 
 	zr.close()
 	if applied > 0:
 		_log_info("[Hooks] Applied %d hooked script(s) via take_over_path" % applied)
 
-# Script hooks — lets multiple mods modify methods on vanilla class_name scripts.
-# Mods declare hooks in mod.txt [hooks]; the preprocessor rewrites vanilla methods
-# with dispatch wrappers. Mods register callables via add_hook() at runtime.
-
+# Hook API — mods call add_hook() to intercept methods on class_name scripts.
 # before=true: fires before vanilla (return true to skip). before=false: fires after.
-# Method must be declared in mod.txt [hooks].
 func add_hook(script_path: String, method_name: String, callback: Callable, before: bool = true) -> void:
 	var key := script_path + "::" + method_name
-	if not _hook_script_paths.has(script_path):
-		_log_warning("[Hooks] add_hook() for undeclared script %s — add [hooks] to mod.txt" % script_path)
+	if not _hook_script_paths.is_empty() and not _hook_script_paths.has(script_path):
+		_log_warning("[Hooks] add_hook() for unwrapped script %s — not a class_name script?" % script_path)
 	if not _hook_registry.has(key):
-		_log_warning("[Hooks] add_hook() for undeclared method %s::%s — hook will not fire" % [script_path, method_name])
 		_hook_registry[key] = { "before": [], "after": [] }
 	var list_key := "before" if before else "after"
 	if callback in _hook_registry[key][list_key]:
@@ -1600,7 +1582,7 @@ func _get_hardcoded_class_map() -> Dictionary:
 # ─── GDSC Binary Token Detokenizer ───────────────────────────────────────────
 # Reconstructs GDScript source from Godot's binary-tokenized .gdc format (GDSC).
 # Used when the game exports with binary tokenization and load().source_code is
-# empty.  Only called on-demand for scripts listed in mod [hooks] sections.
+# empty.  Called for all class_name scripts during hook pack generation.
 # Supports TOKENIZER_VERSION 100 (Godot 4.0-4.4) and 101 (Godot 4.5-4.6).
 
 const _GDSC_MAGIC := "GDSC"
@@ -2006,12 +1988,13 @@ func _read_vanilla_source(script_path: String) -> String:
 		var cached := FileAccess.get_file_as_string(cache_file)
 		if not cached.is_empty():
 			var live := load(script_path) as GDScript
-			if live and ("func _vanilla_" not in live.source_code):
+			if live and not live.source_code.is_empty() \
+					and ("func _vanilla_" not in live.source_code):
 				if live.source_code != cached:  # game updated
 					_save_vanilla_source(script_path, live.source_code)
 					return live.source_code
 				return cached
-			return cached  # live is hooked — trust cache
+			return cached  # live is hooked or binary-tokenized — trust cache
 
 	var script := load(script_path) as GDScript
 	if script == null:
@@ -2042,7 +2025,7 @@ func _save_vanilla_source(script_path: String, source: String) -> void:
 		f.store_string(source)
 		f.close()
 
-func _preprocess_script(script_path: String, hooked_methods: Array[String]) -> String:
+func _preprocess_script(script_path: String) -> String:
 	var source := _read_vanilla_source(script_path)
 	if source.is_empty():
 		_log_critical("[Hooks] Failed to read vanilla source for: " + script_path)
@@ -2070,19 +2053,12 @@ func _preprocess_script(script_path: String, hooked_methods: Array[String]) -> S
 
 	var method_info := {}
 	for m in own_methods:
-		if m["name"] in hooked_methods:
-			var info := _extract_method_info(script, lines, m)
-			if info != null:
-				method_info[m["name"]] = info
-			else:
-				_log_warning("[Hooks] Could not extract method info for: %s::%s" % [script_path, m["name"]])
-
-	for hm in hooked_methods:
-		if hm not in method_info:
-			_log_warning("[Hooks] Method '%s' not found in %s — check mod.txt [hooks]" % [hm, script_path])
+		var info := _extract_method_info(script, lines, m)
+		if info != null:
+			method_info[m["name"]] = info
 
 	if method_info.is_empty():
-		_log_warning("[Hooks] No hookable methods found in: " + script_path)
+		_log_debug("[Hooks] No hookable own methods in: " + script_path)
 		return ""
 
 	var sorted_methods := method_info.keys()
@@ -2106,7 +2082,6 @@ func _preprocess_script(script_path: String, hooked_methods: Array[String]) -> S
 			if comment_pos >= 0 and super_pos > comment_pos:
 				continue  # super( is inside a comment
 			# Check if super( is inside a string literal.
-			var in_string := false
 			var dquotes := 0
 			var squotes := 0
 			for ci in super_pos:
@@ -2288,6 +2263,21 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 	var lines := PackedStringArray()
 	lines.append(info["signature_line"])
 
+	var call_args := ", ".join(info["param_names"])
+	var vanilla_call := "_vanilla_" + method_name + "(" + call_args + ")"
+	var fast_call := vanilla_call
+	if info["is_async"]:
+		fast_call = "await " + fast_call
+
+	# Fast-path: no hooks registered → call vanilla directly.
+	lines.append('\tif not ModLoader._hook_registry.has("%s::%s"):' % [script_path, method_name])
+	if info["return_type"] == "void":
+		lines.append("\t\t" + fast_call)
+		lines.append("\t\treturn")
+	else:
+		lines.append("\t\treturn " + fast_call)
+
+	# Full dispatch — before hooks, arg mutation, vanilla call, after hooks.
 	var args_str := "[" + ", ".join(info["param_names"]) + "]"
 	lines.append("\tvar __hook_args := " + args_str)
 
@@ -2295,7 +2285,6 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 	lines.append('\tvar __skip := ModLoader._call_before_hooks("%s", "%s", %s, __hook_args)' \
 			% [script_path, method_name, self_ref])
 
-	# Return appropriate default when skip is true.
 	if info["return_type"] == "typed":
 		var default_val := _get_type_default(info["return_type_id"])
 		lines.append("\tif __skip: return %s" % default_val)
@@ -2305,8 +2294,6 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 	for i in info["param_names"].size():
 		lines.append("\t%s = __hook_args[%d]" % [info["param_names"][i], i])
 
-	var call_args := ", ".join(info["param_names"])
-	var vanilla_call := "_vanilla_" + method_name + "(" + call_args + ")"
 	if info["is_async"]:
 		vanilla_call = "await " + vanilla_call
 
@@ -2323,10 +2310,40 @@ func _generate_imposter(script_path: String, method_name: String, info: Dictiona
 
 	return "\n".join(lines)
 
-func _generate_hook_pack() -> String:
-	if _hook_script_paths.is_empty():
-		return ""
+func _find_typed_array_class_refs() -> Dictionary:
+	# Find class_names used as typed array elements (e.g. Array[SlotData]).
+	# These can't be wrapped — take_over_path breaks the pointer identity check
+	# in container_type_validate.h (godotengine/godot#97433).
+	# Only scans class_name scripts; refs from other scripts aren't detected.
+	var refs: Dictionary = {}  # class_name -> true
+	var re := RegEx.new()
+	re.compile("Array\\[([A-Z]\\w+)\\]")
+	for script_path: String in _class_name_to_path.values():
+		var source := _read_vanilla_source(script_path)
+		if source.is_empty():
+			continue
+		for m in re.search_all(source):
+			var type_name := m.get_string(1)
+			if _class_name_to_path.has(type_name):
+				refs[type_name] = true
+	if not refs.is_empty():
+		_log_info("[Hooks] Class names referenced in typed arrays (not wrappable): %s"
+				% ", ".join(refs.keys()))
+	return refs
 
+func _generate_hook_pack() -> String:
+	if _class_name_to_path.is_empty():
+		return ""
+	if _loaded_mod_ids.is_empty():
+		return ""  # No mods loaded — no one to call add_hook()
+
+	var unsafe_class_names := _find_typed_array_class_refs()
+
+	var _path_to_class_name: Dictionary = {}
+	for k: String in _class_name_to_path:
+		_path_to_class_name[_class_name_to_path[k]] = k
+
+	_hook_script_paths.clear()
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(HOOK_PACK_DIR))
 
 	var pack_path := ProjectSettings.globalize_path(HOOK_PACK_PATH)
@@ -2336,8 +2353,17 @@ func _generate_hook_pack() -> String:
 		_log_critical("[Hooks] Failed to create hook pack ZIP")
 		return ""
 
+	var vcn_regex := RegEx.new()
+	vcn_regex.compile("(?m)^class_name\\s+.*$")
+
 	var any_success := false
-	for script_path: String in _hook_script_paths:
+	var total_methods := 0
+	for script_path: String in _class_name_to_path.values():
+		# Skip scripts whose class_name is referenced in typed arrays.
+		var cn: String = _path_to_class_name.get(script_path, "")
+		if cn in unsafe_class_names:
+			_log_info("[Hooks] Skipped %s — class_name '%s' used in typed arrays" % [script_path, cn])
+			continue
 		# Warn if a mod also ships a direct replacement for this script.
 		if _override_registry.has(script_path):
 			var claims: Array = _override_registry[script_path]
@@ -2345,24 +2371,12 @@ func _generate_hook_pack() -> String:
 				_log_warning("[Hooks] %s is hooked but also replaced by '%s' — hooks will wrap the modded version, not vanilla"
 						% [script_path, claim["mod_name"]])
 
-		var hooked_methods: Array[String] = []
-		for key: String in _hook_registry:
-			if key.begins_with(script_path + "::"):
-				hooked_methods.append(key.split("::")[1])
-		if hooked_methods.is_empty():
-			continue
-
-		var transformed := _preprocess_script(script_path, hooked_methods)
+		var transformed := _preprocess_script(script_path)
 		if transformed.is_empty():
-			_log_critical("[Hooks] Failed to preprocess: " + script_path)
 			continue
 
 		# Validate the transformed script parses before packing it.
-		# Strip class_name to avoid "hides a global script class" error.
-		var validate_src := transformed
-		var vcn_regex := RegEx.new()
-		vcn_regex.compile("(?m)^class_name\\s+.*$")
-		validate_src = vcn_regex.sub(validate_src, "# class_name stripped for validation")
+		var validate_src := vcn_regex.sub(transformed, "# class_name stripped for validation")
 		var validate := GDScript.new()
 		validate.source_code = validate_src
 		var verr := validate.reload(true)
@@ -2373,18 +2387,25 @@ func _generate_hook_pack() -> String:
 				_log_debug("[Hooks]   %3d | %s" % [vj + 1, vlines[vj]])
 			continue
 
+		# Count wrapped methods via _vanilla_ prefix in transformed source.
+		var method_count := transformed.count("func _vanilla_")
+		total_methods += method_count
+
 		var zip_internal_path := script_path.replace("res://", "")
 		zp.start_file(zip_internal_path)
 		zp.write_file(transformed.to_utf8_buffer())
 		zp.close_file()
 		any_success = true
-		_log_info("[Hooks] Hooked: %s (%d methods) — validated OK" % [script_path, hooked_methods.size()])
+		_hook_script_paths[script_path] = true
+		_log_info("[Hooks] Wrapped: %s (%d methods)" % [script_path, method_count])
 
 	zp.close()
 
 	if not any_success:
 		DirAccess.remove_absolute(tmp_path)
 		return ""
+
+	_log_info("[Hooks] Hook pack: %d scripts, %d methods total" % [_hook_script_paths.size(), total_methods])
 
 	# Atomic rename: tmp → final path.  Prevents corrupt ZIPs from partial writes.
 	if FileAccess.file_exists(pack_path):
@@ -2826,10 +2847,7 @@ func _compute_state_hash(archive_paths: PackedStringArray, prepend_autoloads: Ar
 			var ver: String = (entry["cfg"] as ConfigFile).get_value("mod", "version", "")
 			if not ver.is_empty():
 				parts.append("v:%s=%s" % [entry["mod_id"], ver])
-	var sorted_hooks := _hook_registry.keys()
-	sorted_hooks.sort()
-	for key in sorted_hooks:
-		parts.append("h:" + key)
+	parts.append("ml:" + MODLOADER_VERSION)
 	return "\n".join(parts).md5_text()
 
 func _write_heartbeat() -> void:
@@ -2950,12 +2968,11 @@ func _print_conflict_summary() -> void:
 	if not _hook_script_paths.is_empty():
 		_log_info("")
 		_log_info("--- Hooked Scripts ---")
-		for script_path: String in _hook_script_paths:
-			var methods: Array[String] = []
-			for key: String in _hook_registry:
-				if key.begins_with(script_path + "::"):
-					methods.append(key.split("::")[1])
-			_log_info("  %s: %s" % [script_path, ", ".join(methods)])
+		_log_info("  %d scripts wrapped" % _hook_script_paths.size())
+		for key: String in _hook_registry:
+			var entry: Dictionary = _hook_registry[key]
+			if entry["before"].size() > 0 or entry["after"].size() > 0:
+				_log_info("  Active: %s (%d before, %d after)" % [key, entry["before"].size(), entry["after"].size()])
 
 	_log_info("============================================")
 	_log_info("")


### PR DESCRIPTION
Mods can now call `ModLoader.add_hook()` on any method of any class_name script without needing a `[hooks]` section in mod.txt. The modloader pre-wraps every own method at startup.

## What changed

**Hook pack generation** now processes all 58 class_name scripts instead of only the ones declared in `[hooks]`. 21 scripts with own methods get wrapped (314 methods total). The rest are data classes with no hookable methods.

**Fast-path bypass** on every imposter. When no hooks are registered for a method, it does a single `_hook_registry.has()` check and calls the vanilla method directly. No array allocation, no dispatch overhead. Only methods with active hooks pay the full cost.

**Typed array safety**. `take_over_path()` requires stripping `class_name`, which breaks Godot's typed array pointer identity (godotengine/godot#97433). A new function `_find_typed_array_class_refs()` scans all class_name scripts for `Array[ClassName]` patterns and excludes those scripts from the hook pack automatically. Currently 9 class_names are excluded, mostly data/save classes (SlotData, ItemData, EventData, etc).

**`[hooks]` section is now optional**. If present it's logged as a hint for backwards compatibility. Mods don't need it anymore.

**Bug fix**: `_read_vanilla_source()` was returning empty when the vanilla cache existed but the live script was binary-tokenized (empty `source_code`). The cache comparison treated this as "game updated" and saved the empty string. Fixed by checking `source_code.is_empty()` before comparing.

## How it works

```
# Before: mod had to declare hooks in mod.txt
[hooks]
"res://Scripts/Controller.gd"="Movement, Jump"

# After: just call add_hook() in your autoload
func _ready():
    ModLoader.add_hook("res://Scripts/Controller.gd", "Movement", _my_callback, true)
```

Generated imposters look like this:
```gdscript
func Movement(delta):
    if not ModLoader._hook_registry.has("res://Scripts/Controller.gd::Movement"):
        _vanilla_Movement(delta)
        return
    var __hook_args := [delta]
    var __skip := ModLoader._call_before_hooks("res://Scripts/Controller.gd", "Movement", self, __hook_args)
    if __skip: return
    delta = __hook_args[0]
    _vanilla_Movement(delta)
    ModLoader._call_after_hooks("res://Scripts/Controller.gd", "Movement", self, __hook_args, [])
```

## Known limitations

- Scripts whose class_name is used in typed arrays (`Array[SlotData]`, etc) can't be wrapped. `take_over_path()` changes the script pointer identity which breaks Godot's typed array validation. This is tracked across several open engine issues (godotengine/godot#97433, godotengine/godot#94378, godotengine/godot#83542). The auto-detection handles this but only scans class_name scripts, not every script in the game.
- `Compiler bug: unresolved assign` on KnifeRig.gd. Godot engine bug during compilation, non-fatal. The script compiles and works.
- `_compute_state_hash()` now includes `MODLOADER_VERSION` instead of hook registry keys, so upgrading the modloader forces hook pack regeneration.

## Testing

Tested with a 21-hook test suite across 10 scripts covering before hooks, after hooks, arg mutation, skip hooks, multiple hooks on the same method, lifecycle method hooks, and hooks on scripts that were never declared in any `[hooks]` section. 13/21 hooks confirmed firing in a single play session (remaining 8 need specific gameplay triggers like throwing grenades or going fishing).