### PR TITLE
Boot-log cleanup + autoload instance swap + registry smoke probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods,
 ## Requirements
 
 - Road to Vostok (PC, Steam)
-- Mods packaged as `.vmz` or `.pck` files
+- Mods packaged as `.vmz` or `.pck`. Unpacked folders are also accepted in Developer Mode.
 
 ## Installation
 
@@ -68,7 +68,7 @@ modworkshop=12345
 | `id` | Unique ID. Duplicates are skipped. |
 | `version` | Version string for update comparison |
 | `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
-| `[autoload]` | `Name="res://path.gd"` - instantiated as a Node after mods mount. Prefix with `!` for [early autoloads](#early-autoloads). |
+| `[autoload]` | `Name="res://path.gd"` (or `"res://path.tscn"`) -- instantiated as a Node after mods mount. Prefix with `!` for [early autoloads](#early-autoloads). |
 | `[updates] modworkshop` | ModWorkshop ID for update checking |
 
 Mods without `mod.txt` still mount as resource packs. Their files override vanilla resources, but no autoloads run.
@@ -77,7 +77,7 @@ Mods without `mod.txt` still mount as resource packs. Their files override vanil
 
 The hook system preserves tetrahydroc's exact RTVModLib API surface -- `hook()` / `unhook()` / `_caller` / `skip_super()` / `frameworks_ready`, hook-name format, callback signatures. Mod code written against RTVModLib runs unchanged here.
 
-The implementation under the hood is different. Rather than generating `Framework<Name>.gd` subclasses of vanilla and applying them via `take_over_path`, the loader rewrites vanilla source directly and ships it AT the vanilla `res://` path. Mod scripts that subclass vanilla get the same rewrite treatment shipped at their own path. Both rewrites land in a single hook pack mounted with `replace_files=true`; nothing on disk is modified.
+The implementation under the hood is different. Rather than generating `Framework<Name>.gd` subclasses of vanilla and applying them via `take_over_path`, the loader rewrites vanilla source directly and ships it AT the vanilla `res://` path. Mod scripts that subclass vanilla get the same rewrite treatment shipped at their own path. Both rewrites land in a single hook pack mounted with `replace_files=true`. The pack itself is written to `user://modloader_hooks/`, but no game files or mod archives are modified.
 
 Mods that don't use RTVModLib at all also work unchanged. Because dispatch lives inside the vanilla script, a mod that just does `extends Camera` (or uses `take_over_path`, `[script_overrides]`, etc.) inherits hook dispatch for free -- the mod author doesn't need to know the loader exists.
 
@@ -87,7 +87,7 @@ Both approaches aim at the same end state: hooks fire reliably regardless of whe
 
 **The extends-wrapper approach** (tetrahydroc's RTVModLib standalone, and this loader's earlier generations) builds a subclass `FrameworkController extends Controller`, puts hook dispatch in the wrapper's method overrides, then `take_over_path`s the wrapper onto `res://Scripts/Controller.gd`. When a mod like ImmersiveXP also `take_over_path`s the same vanilla path, the framework wrapper gets applied AFTER the mod and ends up on top of the chain. Wrapper's `Movement(delta)` dispatches, then `super()` calls into the mod's `Movement`, which may or may not call `super()` to vanilla. Hooks fire regardless of the mod's super() call because the wrapper's dispatch is above both.
 
-That works in theory. In practice it trips [Godot bug #83542](https://github.com/godotengine/godot/issues/83542) for class_name scripts that a mod has already taken over: `Resource::set_path(take_over=true)` clears `ResourceCache` but not `ScriptServer::global_classes`, so `extends "res://Scripts/Controller.gd"` compiles against the orphaned class-name registration and emits `Could not find class "Controller"`. With IXP enabled that broke four framework wrappers (Controller, Camera, Door, WeaponRig) -- the four IXP overrides. Hooks on those scripts silently stopped working.
+That works in theory. In practice it trips [Godot bug #83542](https://github.com/godotengine/godot/issues/83542) for class_name scripts that a mod has already taken over: `Resource::set_path(take_over=true)` clears `ResourceCache` but not `ScriptServer::global_classes`, so `extends "res://Scripts/Controller.gd"` compiles against the orphaned class-name registration and emits `Could not find class "Controller"`. ImmersiveXP `overrideScript()`s 21 vanilla scripts; six of those target `class_name`'d vanillas (Controller, Camera, Door, WeaponRig, Item, Mine), and those six are the ones that trip #83542 under the extends-wrapper approach. Hooks on those scripts stop working.
 
 **This loader's source-rewrite approach** avoids ever triggering #83542 by not using `extends "res://Scripts/X.gd"` at the loader level. The rewritten vanilla ships at the vanilla path itself, with `class_name` intact, so the class registry stays consistent with what's actually at the path. The class_name-swap crash path (`Resource::set_path` not clearing `global_name`) is also moot because nothing is being moved off its canonical path by the loader.
 
@@ -95,41 +95,54 @@ Mod-subclass rewriting plays the same role as "apply framework wrapper on top of
 
 ### Scope of this approach
 
-- **Every vanilla method gets dispatch.** No `[rtvmodlib] needs=` opt-in. The rewrite generator ships wrappers for every hookable vanilla script under `res://Scripts/` (126 in the tested RTV build, minus the skip lists for runtime-sensitive and serialized-resource scripts).
+- **Every vanilla method gets dispatch.** No `[rtvmodlib] needs=` opt-in. The rewrite generator ships wrappers for every hookable vanilla script under `res://Scripts/`. In the current RTV build that's 161 scripts (5,776 hook points) out of 176 total -- 15 are skipped: 7 runtime-sensitive (`MuzzleFlash`, `Hit`, `Explosion`, etc., where dispatch-wrapper overhead breaks short-lived effects or coroutine timing), 7 data/save resource scripts (whose path is embedded in saved files, so wrapping would break save-load), and 1 zero-byte PCK stub the game ships (`CasettePlayer.gd`). Exact counts for your install appear in the boot log: `[RTVCodegen] parsed RTV.pck -- N total file(s), M .gd script(s) under res://Scripts/`, `[RTVCodegen] Skip lists: ...`, and `[RTVCodegen] Generated K rewritten vanilla script(s), L hook points`.
 - **Mods that subclass vanilla get rewritten too.** Any `.gd` file in an enabled mod's archive whose first non-trivial line is `extends "res://Scripts/<X>.gd"` (where `<X>` is a vanilla we hook) gets the same rename+dispatch transform shipped at the mod's own path.
 - **Timing.** The hook pack is mounted with `replace_files=true` at ModLoader's class-level static init, before any game autoload runs. Mod autoloads that do `load(...).take_over_path(...)` on our rewritten files inherit our wrappers via their `extends` chain.
 - **Scene-preloaded vanilla deferred to lazy-compile.** Some vanilla scripts (e.g. `AISpawner.gd`) have module-scope `preload()` of PackedScenes whose `ext_resource` references other vanilla scripts (e.g. `AI_Bandit.tscn` referencing `AI.gd`). Compiling those vanillas eagerly would fire their scene preloads before mod autoloads run, baking ext_resource Script references against the pre-override cache. `take_over_path` then clears those references' paths to empty (per `Resource::set_path`), and scene instances spawn with orphan scripts. To avoid this, vanilla scripts with module-scope scene preloads are skipped from eager compile. They lazy-compile via VFS mount precedence after mod overrides have run, so scenes resolve ext_resources against the post-override cache.
 - **Legacy-GDScript autofix.** Mod sibling scripts (non-subclass `.gd` files in the archive, typically preloaded from subclasses) are scanned for Godot-3-era patterns -- bodyless `if`/`elif`/`else` blocks, `tool` / `onready var` / `export var` -- and rewritten to strict-parser-compatible Godot 4 form. The fixed source lands in the hook pack overlay; the mod's `.vmz` stays untouched. Necessary because `script.reload()` inside a mod's `overrideScript` cascades strict re-parse through preloaded siblings, rejecting patterns that Godot's lenient first-compile would have tolerated.
 - **Post-ready `take_over_path` not covered.** If a mod does `take_over_path` on a vanilla script AFTER `frameworks_ready` has emitted (rather than during its autoload), we rely on the incoming script's own `extends` chain to route through our rewrite. If the mod's replacement script is a file-backed subclass of the vanilla we hook, it's already been rewritten in the hook pack. If it's a fully runtime-constructed script, it won't have dispatch.
-- **`RTVModLib.vmz` coexistence.** If tetrahydroc's standalone RTVModLib mod is enabled, this loader stands down so the two don't double-swap. The `Engine.get_meta("RTVModLib")` API surface is the same in both, so mods don't need to branch on which is active.
+- **`RTVModLib.vmz` coexistence.** If tetrahydroc's standalone RTVModLib mod is also enabled, both systems will try to wrap the same vanilla scripts -- this isn't supported, pick one. (`_register_rtv_modlib_meta` refuses to overwrite an existing `Engine.get_meta("RTVModLib")` and logs a warning, but the rest of the loader still runs.) The `Engine.get_meta("RTVModLib")` API surface (`hook` / `unhook` / `_caller` / `skip_super` / `frameworks_ready`, etc.) is identical between the two, so mod code is portable across whichever ends up registered first.
 
 ### How it works
 
-At launch the loader walks `RTV.pck`'s file table, detokenizes every `res://Scripts/*.gd` from its compiled bytecode, and rewrites each one:
+At launch the loader walks `RTV.pck`'s file table, detokenizes every `res://Scripts/*.gd` from its compiled bytecode, and rewrites each one. Vanilla `Controller.Movement(delta)` (a void method) ends up looking like the following in the hook pack. Diagnostic instrumentation emitted by the generator (per-hook firing counters in `Engine.meta` for runtime tracking) is omitted here for readability; see `_rtv_dispatch_inline_src` in modloader.gd for the full output.
 
 ```gdscript
-# Vanilla Controller.gd (simplified)
+# Vanilla Controller.gd (body simplified)
 func Movement(delta):
     velocity.x = move_x * walkSpeed
     move_and_slide()
 
 # Rewritten Controller.gd shipped in the hook pack
-func _rtv_vanilla_Movement(delta):           # original body, renamed
+func _rtv_vanilla_Movement(delta):    # original body, renamed
     velocity.x = move_x * walkSpeed
     move_and_slide()
 
-func Movement(delta):                        # new dispatch wrapper
-    var _lib = Engine.get_meta("RTVModLib", null)
-    if !_lib: return _rtv_vanilla_Movement(delta)
+func Movement(delta):                 # new dispatch wrapper
+    var _lib = Engine.get_meta("RTVModLib") if Engine.has_meta("RTVModLib") else null
+    if !_lib:
+        _rtv_vanilla_Movement(delta)
+        return
+    # Fast path: no mod has called hook() this session.
+    if not _lib._any_mod_hooked:
+        _rtv_vanilla_Movement(delta)
+        return
+    # Re-entry guard: a mod's wrapper called super() into here. Run vanilla and bail.
     if _lib._wrapper_active.has("controller-movement"):
-        return _rtv_vanilla_Movement(delta)   # re-entry guard
+        _rtv_vanilla_Movement(delta)
+        return
     _lib._wrapper_active["controller-movement"] = true
     _lib._caller = self
     _lib._dispatch("controller-movement-pre", [delta])
     var _repl = _lib._get_hooks("controller-movement")
     if _repl.size() > 0:
+        var _prev_skip = _lib._skip_super
+        _lib._skip_super = false
         _repl[0].callv([delta])
-        if !_lib._skip_super: _rtv_vanilla_Movement(delta)
+        var _did_skip = _lib._skip_super
+        _lib._skip_super = _prev_skip
+        if !_did_skip:
+            _rtv_vanilla_Movement(delta)
     else:
         _rtv_vanilla_Movement(delta)
     _lib._dispatch("controller-movement-post", [delta])
@@ -152,7 +165,7 @@ The pack is mounted via `ProjectSettings.load_resource_pack(zip, replace_files=t
 Mods like IXP ship scripts that `extends "res://Scripts/Camera.gd"` and override a subset of methods. The loader also rewrites those at codegen time:
 
 - Scan every enabled mod's `.vmz`. Find `.gd` files whose first non-trivial line is `extends "res://Scripts/<X>.gd"` where `<X>` is a vanilla we hook.
-- Apply the same rename+dispatch transform, but with a distinct prefix (`_rtv_mod_<name>` instead of `_rtv_vanilla_<name>`) so the mod body doesn't shadow vanilla's via virtual dispatch.
+- Apply the same rename+dispatch transform, but with the prefix `_rtv_mod_` (literal, not per-mod) instead of `_rtv_vanilla_` so the mod body doesn't shadow vanilla's via virtual dispatch.
 - Ship the rewritten mod script at its own path (e.g. `ImmersiveXP/Camera.gd`) in the same hook pack with `replace_files=true`. The mod's `.vmz` is never modified.
 - When IXP's autoload calls `load("res://ImmersiveXP/Camera.gd")`, mount precedence returns our rewritten version. IXP's existing `overrideScript()` logic then `take_over_path`s our rewritten IXP Camera onto the vanilla path. Dispatch fires from IXP's wrapper regardless of whether IXP's body calls `super()`.
 
@@ -179,7 +192,10 @@ func _on_lib_ready():
     _lib = Engine.get_meta("RTVModLib")
     _lib.hook("controller-jump-pre", _on_jump_pre)
 
-func _on_jump_pre():
+func _on_jump_pre(_delta):
+    # Callback signature must match the wrapped method.
+    # Controller.Jump(_delta) takes one arg, so the dispatcher calls
+    # callv([delta]) -- a zero-arg callback would raise CALL_ERROR.
     _lib._caller.jumpVelocity = 20.0
 ```
 
@@ -204,12 +220,12 @@ All members live on the meta object returned by `Engine.get_meta("RTVModLib")`.
 |--------|------|---------|
 | `frameworks_ready` | signal | Emitted once after wrappers are mounted and applied. |
 | `_is_ready` | bool | True once `frameworks_ready` has emitted. |
-| `_caller` | Node | The instance dispatching the current hook. Valid only inside a callback. |
+| `_caller` | Node | Instance whose method triggered dispatch. Set before each callback, never reset -- outside a callback it's the last dispatched instance (stale, possibly freed). Snapshot synchronously if you need it later. |
 | `_skip_super` | bool | Set by `skip_super()` during a replace hook. |
 | `hook(name, callback, priority=100)` | int | Register. Returns hook id, or `-1` if a replace hook is already owned. Lower priority runs first (default 100). |
 | `unhook(id)` | void | Remove by id. |
 | `has_hooks(name)` | bool | Any registrations at this name. |
-| `has_replace(name)` | bool | Replace hook registered at this bare name. |
+| `has_replace(name)` | bool | True if any hook is registered at this name. To detect a replace owner specifically, pass the bare name -- presence at a bare key implies a replace, since `hook()` only allows one. (Implementation is currently identical to `has_hooks()`.) |
 | `get_replace_owner(name)` | int | Owner id, or `-1` if none. Lets a mod detect a conflict and fall back to `-pre` / `-post`. |
 | `skip_super()` | void | Inside a replace hook, prevents the original method from running. |
 | `seq()` | int | Monotonic dispatch counter (debug). |
@@ -245,7 +261,7 @@ Only one replace per name. `hook()` returns `-1` if another mod already owns the
 
 ### Examples
 
-The three examples below are tetrahydroc's, copied from his RTVModLib README.
+The three examples below are adapted from tetrahydroc's RTVModLib README.
 
 #### AI Kill Tracker
 
@@ -363,9 +379,9 @@ func _custom_loot():
 
 - **`hook()` returns `-1`**: another mod owns the replace slot. Use `get_replace_owner()` to detect, then fall back to `-pre` or `-post`.
 - **Callback never fires**: you registered before `frameworks_ready` emitted. Always `await lib.frameworks_ready` if `_is_ready` is false. All hookable scripts are wrapped by default, so no opt-in is needed.
-- **`_caller` is null**: read outside a callback, or in a `-callback` (deferred) hook after the source was freed. Snapshot `_caller` synchronously and reference the snapshot.
+- **`_caller` is wrong or invalid**: the loader sets `_caller` before each dispatch and never clears it. Reading outside your hook (or from a `-callback` deferred handler) returns either the LAST dispatched instance (stale) or, if that source was freed, an invalid reference. Snapshot `_caller` synchronously inside your hook and reference the snapshot afterward.
 - **Hook name doesn't match anything**: format is `<scriptname>-<methodname>[-suffix]` lowercase. Underscore-prefixed methods keep the underscore: `pickup-_ready-post`, not `pickup-ready-post`.
-- **`hooked but also replaced by ...`**: another mod replaces the same vanilla script via `[script_overrides]`. The wrapper's `super()` flows into the override, not vanilla.
+- **`[RTVCodegen] <path> is rewritten and also overridden by <mod> -- override displaces the rewrite, hooks won't fire for that path`**: another mod ships a `[script_overrides]` entry for the same vanilla script. The override displaces our rewrite at that path, so dispatch never fires for nodes that use it.
 
 Hook cache: `%APPDATA%\Road to Vostok\modloader_hooks\`
 The cache is regenerated every launch. To force a clean state, delete the `modloader_hooks` folder.
@@ -379,7 +395,7 @@ Prefix an autoload with `!` to load it before the game's own autoloads:
 EarlySetup="!res://MyMod/EarlySetup.gd"
 ```
 
-This triggers a two-pass launch. The mod loader writes the autoload to `override.cfg`, restarts the game, and your node is in the scene tree before the game's autoloads run.
+This works via the loader's two-pass restart sequence: on Pass 1 the mod loader writes the autoload into `override.cfg`'s `[autoload_prepend]` section, then restarts; on Pass 2 your node is in the scene tree before the game's autoloads run. (The two-pass restart fires whenever any enabled mod changes the persisted state, not specifically because of the `!` prefix -- the early autoload just takes effect on the second pass.)
 
 Regular autoloads (without `!`) load after all mods mount. Only use `!` when your mod genuinely needs to run before game autoloads.
 
@@ -391,14 +407,14 @@ Regular autoloads (without `!`) load after all mods mount. Only use `!` when you
 
 - **Wait it out.** After 2 failed launches, the mod loader automatically resets to a clean state.
 - **Disable ModLoader entirely:** Create an empty file named `modloader_disabled` (no extension) in the game folder. On next launch, the mod loader skips all work -- no archives mount, no UI shows, no autoloads run. Delete the file to re-enable. Use this when ModLoader itself is broken and you can't reach the UI.
-- **Manual safe-mode reset:** Create an empty file named `modloader_safe_mode` (no extension) in the game folder. On next launch, the mod loader resets state and deletes the file.
+- **Manual safe-mode reset:** Create an empty file named `modloader_safe_mode` (no extension) in the game folder. On next launch, the mod loader resets `override.cfg`, deletes pass state, clears the heartbeat, then deletes the safe-mode file. Note: this does NOT wipe the hook pack -- use **Reset to Vanilla** or `modloader_disabled` for a full reset.
 - **Full reset:** Delete `override.cfg` from the game folder and replace it with a fresh copy from the mod loader release.
 
 **Crash-safe recovery:** If the game is killed during the two-pass restart phase (before Pass 2 finishes applying the hook pack), ModLoader leaves a `user://modloader_pass2_dirty` marker. Next cold boot detects it and force-wipes hook pack + override.cfg + pass state before retrying -- so a half-written hook pack can't poison the next launch.
 
 ## Conflict Report
 
-With Developer Mode enabled, a copy of the runtime log is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch. Look for these markers:
+With Developer Mode enabled, the modloader's own log buffer (everything emitted via `[ModLoader]` lines) is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch. Look for these markers:
 
 | Message | Meaning |
 |---------|---------|
@@ -407,7 +423,7 @@ With Developer Mode enabled, a copy of the runtime log is written to `%APPDATA%\
 | **DATABASE OVERRIDE** | A mod replaced `Scripts/Database.gd`. Normal for overhauls, may block other mods' scene overrides. |
 | **BAD ZIP** | Backslash file paths in the archive. Re-pack with 7-Zip. |
 
-The summary block also lists how many framework overrides the loader applied this run and which hooks had registrations.
+The summary block also lists which hooks had registrations. (Under source-rewrite the "Framework Overrides Active" section in the summary stays silent -- that section is for the dormant `[rtvmodlib] needs=` -> `Framework<Name>.gd` path, which doesn't populate `_hook_swap_map` under the current source-rewrite mechanism.)
 
 ## Best Practices
 
@@ -416,7 +432,7 @@ The summary block also lists how many framework overrides the loader applied thi
 - **Use `super()` in lifecycle methods.** Skipping it breaks other mods that override the same class.
 - **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't. All vanilla scripts are hooked automatically, just register callbacks through `Engine.get_meta("RTVModLib")`.
 - **If you replace Database.gd**, every `preload()` path must exist or the game breaks.
-- **`UpdateTooltip()` is inventory-only.** World-item tooltips come from `HUD._physics_process` reading `gameData.tooltip`.
+- **`UpdateTooltip()` is the world-item tooltip path.** Each interactable (`Pickup`, `Door`, `Bed`, `Fire`, `LootContainer`, `Trader`, `Furniture`, etc.) implements `UpdateTooltip()`, which writes to `gameData.tooltip`; `HUD._physics_process` polls and renders. To change a world tooltip, hook the relevant class's `UpdateTooltip` (e.g. `lootcontainer-updatetooltip-post`).
 - **Test with other mods installed** and check the conflict report.
 
 ## Contributing
@@ -434,9 +450,9 @@ Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
 
 ## Recovery (Technical Details)
 
-- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. If it persists, the mod loader increments a crash counter. After 2 crashes, it wipes `override.cfg` and all two-pass state.
+- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. The restart counter (stored in pass state) is incremented every time the loader writes pass state for a Pass 2 restart -- so it ticks on every modloader-triggered restart, not on heartbeat detection. If the next launch finds a leftover heartbeat AND the counter is at or above `MAX_RESTART_COUNT` (2), the loader wipes `override.cfg` and all two-pass state to break the loop. Otherwise it logs a warning and clears the heartbeat.
 - **Pass 2 dirty marker:** `user://modloader_pass2_dirty` is written at the start of Pass 2 and deleted when Pass 2 finishes. If present on next cold boot, Pass 2 was interrupted (force-quit, crash, power loss) and the hook pack may be half-written. Static init detects the marker and force-wipes state before ModLoader runs.
-- **Disabled flag:** An empty `modloader_disabled` file in the game folder makes ModLoader sit idle for that session. Static init resets override.cfg, pass state, and the hook pack, then returns immediately. The UI never shows. Delete the file to re-enable.
+- **Disabled flag:** An empty `modloader_disabled` file in the game folder makes ModLoader sit idle for that session. Static init resets `override.cfg`, deletes pass state, clears the pass-2 dirty marker, and wipes the hook pack, then returns immediately. The UI never shows. Delete the file to re-enable.
 - **Safe mode flag:** An empty `modloader_safe_mode` file triggers a one-shot full reset on next launch, then is deleted.
 - **State files:** `user://mod_pass_state.cfg` stores archive paths + hook pack path for the two-pass restart. Cleared by the Reset button, the disabled flag, by entering zero-mod state via the UI, or by a Pass 2 crash.
 
@@ -444,9 +460,9 @@ Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
 
 ## Engine Compatibility
 
-Tested against Godot 4.6.1. Reviewed against the Godot 4.7 milestone as of April 2026 (feature freeze imminent, dev snapshot 5 released) -- no breaking changes identified within Road to Vostok's first-party mod support window.
+Tested against Godot 4.6.1 (the version Road to Vostok ships with -- verifiable in the boot banner: `Godot Engine v4.6.1.stable.official.14d19694e`). Reviewed against the Godot 4.7 milestone -- no breaking changes identified within Road to Vostok's first-party mod support window.
 
-If a future Godot version changes how `res://` paths resolve inside mounted resource packs, the hook pack's mount-precedence recipe (`.gd` + `.remap` + empty `.gdc`) will stop winning over the PCK. The `[STABILITY] VFS canary FAILED` alarm trips on first launch and the loader logs a critical error. Users can fall back to tetrahydroc's standalone `RTVModLib` mod, which uses the extends-wrapper approach (`Framework<Name>.gd` subclasses applied at runtime via `take_over_path`). The fallback handles the typical case, but has a known issue with overhaul mods like ImmersiveXP that extend vanilla via `class_name` (Godot [#83542](https://github.com/godotengine/godot/issues/83542)) -- the exact bug our current in-place rewrite sidesteps.
+If a future Godot version changes how `res://` paths resolve inside mounted resource packs, the hook pack's mount-precedence recipe (`.gd` + `.gd.remap` + empty `.gdc`) will stop winning over the PCK. The `[STABILITY] VFS canary FAILED` alarm trips on first launch and the loader logs a critical error. Users can fall back to tetrahydroc's standalone `RTVModLib` mod, which uses the extends-wrapper approach (`Framework<Name>.gd` subclasses applied at runtime via `take_over_path`). The fallback handles the typical case, but trips Godot [#83542](https://github.com/godotengine/godot/issues/83542) on overhaul mods that `take_over_path` on `class_name`'d vanilla scripts: the take-over orphans vanilla's `class_name` registration in `ScriptServer`, after which extends-by-path resolution against that vanilla fails with `Could not find class`. ImmersiveXP triggers this on Controller, Camera, Door, WeaponRig, Item, and Mine (the six vanilla scripts in IXP's `overrideScript()` list that declare `class_name`). Our source-rewrite sidesteps the bug by never calling `take_over_path` on a `class_name`'d vanilla.
 
 The three specific engine behaviors that would trigger the fallback:
 

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -551,6 +551,21 @@ func _compute_state_hash(archive_paths: PackedStringArray, prepend_autoloads: Ar
 	for entry in _pending_script_overrides:
 		parts.append("so:%s=%s" % [entry["vanilla_path"], entry["mod_script_path"]])
 	parts.append("ml:" + MODLOADER_VERSION)
+	# Include modloader.gd's mtime so any rebuild of the loader itself
+	# triggers a restart, even when the mod set is unchanged. Rationale:
+	# _finish_with_existing_mounts regenerates the hook pack in place on
+	# a process that already has the old pack mounted. ZIPPacker.open
+	# rewrites the file but ProjectSettings.load_resource_pack dedupes by
+	# path (see lifecycle.gd comment), so the re-mount is a no-op and the
+	# VFS keeps the OLD mount's cached file offsets. If the new pack's
+	# entry layout differs from the old pack's (common when the rewriter
+	# changes between builds), every read of a moved entry fails at
+	# file_access_zip.cpp:141 (unzGoToFilePos on a stale offset). Forcing
+	# a restart on modloader rebuild means Pass 2's fresh engine mounts
+	# the new pack with a fresh index -- no stale cache to fight.
+	var self_mtime: int = FileAccess.get_modified_time("res://modloader.gd")
+	if self_mtime > 0:
+		parts.append("ml_mtime:%d" % self_mtime)
 	return "\n".join(parts).md5_text()
 
 func _write_heartbeat() -> void:

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -315,7 +315,14 @@ func _probe_tree_walk() -> void:
 			_log_info("[TREEWALK] %s | found %d instance(s); sample: %s (%s) script=%s has_mod_rename=%s chain_depth=%d expected_mod=%s" \
 					% [vp, info.count, info.name, info.cls, info.script_path, info.has_mod, info.depth, mod_name])
 		else:
-			_log_warning("[TREEWALK] %s | NO INSTANCES FOUND in scene tree after 12s. Mod declared override but no node carries this script -- either the class is never instantiated in this scene, or instances have a different script.resource_path than expected." \
+			# Not a warning: the probe runs at t+12s (typically still in menu
+			# or loading shelter) while most overrideScript targets only
+			# instantiate in World/Combat scenes loaded later (AI, Door,
+			# Pickup, Helicopter, etc.). An absent instance here is
+			# expected, not broken. InstanceProbe (node_added) verifies
+			# when instances actually spawn. Info-level keeps the signal
+			# without the false alarm.
+			_log_info("[TREEWALK] %s | not instantiated in current scene tree at t+12s (typical for classes that load with World scene; node_added probe will verify on spawn)" \
 					% vp)
 	# Dump top script paths by count. The expected paths above are included.
 	# Anything UNEXPECTED here that matches a class name pattern of something

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -104,6 +104,93 @@ func _verify_script_overrides() -> void:
 			else:
 				status = "UNKNOWN: neither _rtv_mod_ nor _rtv_vanilla_ methods -- rewrite likely did not run"
 			_log_info("[OverrideVerify] %s | %s | %s | src_head=[%s]" % [mod_name, vp, status, src_head])
+
+	# Post-override autoload instance check. If any vanilla we hooked is also
+	# a game autoload, the autoload instance was created BEFORE any mod
+	# autoload ran overrideScript. take_over_path updates ResourceCache but
+	# NOT live instances (Resource::set_path only touches the cache; it does
+	# not walk the scene tree). So /root/<AutoloadName>.get_script() may
+	# still point at the rewritten vanilla (now orphaned after take_over_path
+	# cleared its path_cache), even though load(vanilla_path) returns mod's
+	# script. Report which autoloads actually got their instance script
+	# updated, and auto-swap the stale ones. Relevant for RTVCoop and any
+	# mod that overrides autoload scripts like Loader.gd, Settings.gd, etc.
+	var autoload_names: Array[String] = ["Database", "GameData", "Settings",
+			"Menu", "Loader", "Inputs", "Mode", "Profiler", "Simulation"]
+	var autoload_paths: Dictionary = {}  # autoload_name -> res://Scripts/<Name>.gd
+	for an: String in autoload_names:
+		autoload_paths[an] = "res://Scripts/" + an + ".gd"
+	var any_overridden_autoload := false
+	for an: String in autoload_names:
+		if expected_map.has(autoload_paths[an]):
+			any_overridden_autoload = true
+			break
+	if any_overridden_autoload:
+		_log_info("[AutoloadInstanceProbe] === Post-override autoload instance check ===")
+		var root := get_tree().root
+		var swap_count: int = 0
+		for an: String in autoload_names:
+			var ap: String = autoload_paths[an]
+			if not expected_map.has(ap):
+				continue
+			var node: Node = root.get_node_or_null(an)
+			if node == null:
+				_log_info("[AutoloadInstanceProbe] %s | node NOT in tree (not a live autoload)" % an)
+				continue
+			var iscr := node.get_script() as GDScript
+			if iscr == null:
+				_log_info("[AutoloadInstanceProbe] %s | node has no script attached" % an)
+				continue
+			var cur_has_mod: bool = false
+			for m0 in iscr.get_script_method_list():
+				if str(m0["name"]).begins_with("_rtv_mod_"):
+					cur_has_mod = true
+					break
+			# Auto-swap: game autoload was instantiated BEFORE any mod ran
+			# overrideScript, so its ScriptInstance still holds the pre-override
+			# rewritten vanilla (orphaned by take_over_path -- resource.cpp:92
+			# clears old path_cache entry but never walks the scene tree).
+			# load(ap) now returns the mod subclass from the remapped cache;
+			# set_script swaps the instance script in place. Inherited property
+			# slots (mod extends rewritten vanilla) survive via type overlap;
+			# any state built into vanilla-only slots by _ready is lost --
+			# unavoidable without engine-level refresh. Matches RTVCoop's manual
+			# set_script pattern for Loader, and Godot's own reload_scripts
+			# pattern at gdscript.cpp:2419.
+			var swapped: bool = false
+			if not cur_has_mod:
+				var new_scr: GDScript = load(ap) as GDScript
+				if new_scr != null and new_scr != iscr:
+					node.set_script(new_scr)
+					swapped = true
+					swap_count += 1
+					iscr = node.get_script() as GDScript
+			var ipath: String = iscr.resource_path if iscr != null else ""
+			var ihas_mod: bool = false
+			var ihas_vanilla: bool = false
+			if iscr != null:
+				for m in iscr.get_script_method_list():
+					var mn: String = str(m["name"])
+					if mn.begins_with("_rtv_mod_"): ihas_mod = true
+					elif mn.begins_with("_rtv_vanilla_"): ihas_vanilla = true
+					if ihas_mod and ihas_vanilla: break
+			var expected_mod: String = expected_map[ap]
+			var istatus: String
+			if ihas_mod:
+				istatus = "OK: instance runs mod's body (has _rtv_mod_* methods)"
+				if swapped:
+					istatus = "FIXED via set_script swap -- " + istatus
+			elif ipath == "" and ihas_vanilla:
+				istatus = "BROKEN: instance holds ORPHAN script (empty resource_path, _rtv_vanilla_* only) -- swap attempted but did not resolve"
+			elif ihas_vanilla:
+				istatus = "BROKEN: instance runs vanilla body (has _rtv_vanilla_* only; resource_path=%s)" % ipath
+			else:
+				istatus = "UNKNOWN: instance script has no _rtv_* methods"
+			_log_info("[AutoloadInstanceProbe] %s | expected mod=%s | instance_path=%s | %s" \
+					% [an, expected_mod, ipath if ipath != "" else "<empty>", istatus])
+		if swap_count > 0:
+			_log_info("[AutoloadInstanceProbe] Auto-swapped %d stale autoload instance(s) to mod body" % swap_count)
+
 	# Layer B: arm the node_added probe. One-shot per vanilla_path.
 	if expected_map.is_empty():
 		return

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -94,11 +94,23 @@ func _verify_script_overrides() -> void:
 			# rewritten parent. Distinguish from actual cache-stale vanilla
 			# by looking for "extends \"res://Scripts/..." in the source.
 			var is_mod_subclass: bool = src.contains("extends \"res://Scripts/")
+			# Skip-listed vanilla scripts (RTV_SKIP_LIST: Explosion, Hit, Mine,
+			# Message, MuzzleFlash, ParticleInstance, TreeRenderer) are NOT
+			# rewritten by our hook pipeline because dispatch wrappers would
+			# break their runtime semantics (short-lived instances, coroutine
+			# lifetime, GPUParticles draw_pass corruption). Mod subclasses
+			# that extend these aren't rewritten either -- they rely on
+			# Godot's standard class-inheritance virtual dispatch. So
+			# "no _rtv_* methods" is the CORRECT state for these, not an
+			# error. Classify separately.
+			var is_skip_listed: bool = vp.get_file() in RTV_SKIP_LIST
 			var status: String
 			if has_mod_rename:
 				status = "OK: mod's script serves this path (has _rtv_mod_* methods)"
 			elif has_vanilla_rename and is_mod_subclass:
 				status = "OK: mod's subclass serves this path (no method overrides -- inherits vanilla dispatch)"
+			elif is_skip_listed and is_mod_subclass:
+				status = "OK: skip-listed vanilla (%s) -- mod subclass inherits unrewritten vanilla via Godot virtual dispatch (no hooks for runtime-sensitive classes)" % vp.get_file()
 			elif has_vanilla_rename:
 				status = "STALE: cache still serves vanilla -- overrideScript take_over_path did not win"
 			else:
@@ -239,9 +251,22 @@ func _on_override_probe_node_added(node: Node) -> void:
 		if has_mod_rename and has_vanilla_rename:
 			break
 	var expected_mod: String = _override_probe_expected[sp]
+	# Skip-listed vanillas (RTV_SKIP_LIST) aren't rewritten; mod subclasses
+	# that extend them ride Godot's normal virtual dispatch and thus have
+	# neither _rtv_mod_ nor _rtv_vanilla_ method prefixes. Classify
+	# separately so we don't flag correct pass-through as STALE/UNKNOWN.
+	var is_skip_listed: bool = sp.get_file() in RTV_SKIP_LIST
 	var status: String
 	if has_mod_rename:
 		status = "OK: instance uses mod's script"
+	elif is_skip_listed:
+		# Verify pass-through: instance script should be a subclass of vanilla
+		# (mod's Override.gd extending res://Scripts/<SkipListed>.gd).
+		var src: String = (scr as GDScript).source_code if scr is GDScript else ""
+		if src.contains("extends \"res://Scripts/") or src.contains("extends\"res://Scripts/"):
+			status = "OK: skip-listed pass-through (instance is mod subclass extending unrewritten vanilla; methods resolve via Godot virtual dispatch)"
+		else:
+			status = "UNKNOWN: skip-listed vanilla but instance source doesn't extend res://Scripts/ -- possible bare vanilla (override did not take)"
 	elif has_vanilla_rename:
 		status = "STALE SCENE: instance uses vanilla -- PackedScene captured pre-override script binding (cache may be OK, but scene ext_resource is stale)"
 	else:

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -126,6 +126,7 @@ var _original_scripts: Dictionary = {}   # res_path -> vanilla script ref (UID i
 var _vanilla_id_to_path: Dictionary = {} # script.get_instance_id() -> res_path
 var _class_name_to_path: Dictionary = {} # "Camera" -> "res://Scripts/Camera.gd"
 var _all_game_script_paths: Array[String] = []  # populated by _enumerate_game_scripts from PCK parse; DirAccess can't list PCK contents in 4.6
+var _pck_zero_byte_paths: Dictionary = {}  # res_path -> true for entries the base game PCK ships as 0-byte (e.g. CasettePlayer.gd in RTV 4.6.1). Populated by _parse_pck_file_list; checked by detokenize + hook-gen to skip silently. These files are not hookable and any vanilla or mod preload() of them will fail at engine level -- not a modloader bug.
 var _scripts_with_scene_preloads: Dictionary = {}  # filename -> PackedStringArray of scene paths; scripts listed here are deferred from eager load+reload in _activate_rewritten_scripts. Rationale: their module-scope preload() fires at parse time; if we force-load them before mod autoloads run overrideScript(), scenes bake Script ext_resources to the pre-override vanilla. take_over_path then orphans those refs and instantiate() produces nodes with vanilla body, not mod body. Deferring to lazy-compile lets mod overrides run first -- the preload chain fires via extends resolution during mod's own overrideScript call, AFTER take_over_path took effect for prior targets. VFS mount precedence still serves our rewrite on lazy-load.
 var _node_swap_connected := false
 var _swap_count: int = 0

--- a/src/framework_wrappers.gd
+++ b/src/framework_wrappers.gd
@@ -39,21 +39,27 @@ func _collect_needed_from_mods() -> Dictionary:
 func _activate_hooked_scripts() -> void:
 	var needed := _collect_needed_from_mods()
 	if needed.is_empty():
-		_log_info("[Hooks] No mod declared [rtvmodlib] needs -- nothing to activate")
 		return
+
+	# In the source-rewrite era, [rtvmodlib] needs= is a no-op: every hookable
+	# vanilla script gets dispatch automatically via the hook pack, so there
+	# are no per-framework Framework<Name>.gd files to activate. The declaration
+	# stays compatible with tetra's standalone RTVModLib mod; we just don't
+	# need to act on it here. Legacy Framework-subclass activation remains
+	# below for the (currently unused) [rtvmodlib] needs= -> node_added path
+	# but only fires if a Framework<Name>.gd exists in the pack.
+	_log_info("[RTVModLib] [rtvmodlib] needs declarations are no-op under source-rewrite (%d frameworks requested; all hookable scripts already dispatched via hook pack)" % needed.size())
 
 	var activated := 0
 	for key in needed.keys():
 		var vanilla_path := _resolve_framework_vanilla_path(key)
 		if vanilla_path == "":
-			_log_warning("[RTVModLib] requested framework '%s' has no vanilla script -- skipped" % key)
 			continue
 		# Load via the mounted pack (res://) rather than user://. GDScript's
 		# extends-chain resolution for class_name parents misbehaves for user://
 		# scripts in 4.6.
 		var framework_file := HOOK_PACK_MOUNT_BASE.path_join("Framework" + vanilla_path.get_file())
 		if not ResourceLoader.exists(framework_file):
-			_log_warning("[RTVModLib] Framework not in pack for '%s' at %s -- skipped" % [key, framework_file])
 			continue
 		if _register_override(framework_file, vanilla_path):
 			activated += 1

--- a/src/framework_wrappers.gd
+++ b/src/framework_wrappers.gd
@@ -36,6 +36,16 @@ func _collect_needed_from_mods() -> Dictionary:
 	return needed
 
 
+# DEAD-LOOP MARKER (verified 2026-04-19):
+# Function runs every launch but the body loop below never enters
+# _register_override, because the ResourceLoader.exists(Framework<X>.gd) gate
+# is always false: Framework<X>.gd files are no longer generated (see
+# _rtv_generate_override further down, zero callers). The early-return paths
+# (_defer_to_tetra_modlib, empty needed) and the no-op log line still fire as
+# documented. Kept for the pending dead-code cleanup pass; once removed the
+# whole [rtvmodlib] needs= -> node_added chain (this function plus
+# _register_override / _connect_node_swap / _on_node_added / _deferred_swap)
+# can go too.
 func _activate_hooked_scripts() -> void:
 	var needed := _collect_needed_from_mods()
 	if needed.is_empty():
@@ -81,6 +91,12 @@ func _resolve_framework_vanilla_path(key_lower: String) -> String:
 			return script_path
 	return ""
 
+# DEAD CODE (verified 2026-04-19): only call site is _activate_hooked_scripts
+# above, gated behind a ResourceLoader.exists(Framework<X>.gd) check that's
+# always false under source-rewrite. Remove with the Step-E cleanup. Original
+# rationale comment preserved below in case the function ever needs to come
+# back.
+#
 # class_name scripts can't be take_over_path'd safely: Resource::set_path
 # doesn't clear global_name, so ScriptServer ends up with the moved script's
 # class_name colliding with the evicted original (corrupts the class, see
@@ -129,6 +145,10 @@ func _register_override(framework_path: String, expected_vanilla_path: String) -
 	_hook_swap_map[original_path] = script
 	return true
 
+# DEAD CODE EFFECTIVELY (verified 2026-04-19): function runs but always exits
+# at the _hook_swap_map.is_empty() check below, because _hook_swap_map is only
+# populated by _register_override (never called). The node_added signal never
+# connects, so _on_node_added below never fires either. Remove with Step E.
 func _connect_node_swap() -> void:
 	if _node_swap_connected:
 		return
@@ -138,6 +158,8 @@ func _connect_node_swap() -> void:
 	_node_swap_connected = true
 	_log_info("[RTVModLib] node_added connected -- tracking %d script(s)" % _hook_swap_map.size())
 
+# DEAD CODE (verified 2026-04-19): node_added signal never connects (see
+# _connect_node_swap above), so this never fires. Remove with Step E.
 func _on_node_added(node: Node) -> void:
 	var node_script = node.get_script()
 	if node_script == null:
@@ -162,6 +184,10 @@ func _on_node_added(node: Node) -> void:
 	if node_script != framework_script:
 		call_deferred("_deferred_swap", node, framework_script, path)
 
+# DEAD CODE (verified 2026-04-19): only call site is _on_node_added (via
+# call_deferred), which itself never fires. Remove with Step E. Original
+# rationale comment preserved below.
+#
 # Swap a vanilla-script node to its framework wrapper: snapshot props,
 # set_script, restore, then fire _ready so the wrapper dispatches.
 #

--- a/src/gdsc_detokenizer.gd
+++ b/src/gdsc_detokenizer.gd
@@ -83,6 +83,11 @@ const _SPACE_AFTER := {
 }
 
 func _detokenize_script(script_path: String) -> String:
+	# Zero-byte PCK entries (base game ships CasettePlayer.gd empty in RTV
+	# 4.6.1) have nothing to decode. Return empty silently so callers don't
+	# misread this as an IO failure.
+	if _pck_zero_byte_paths.has(script_path):
+		return ""
 	# Try multiple methods to read raw bytes -- FileAccess on res:// can fail for
 	# PCK-embedded files depending on the container format (RSCC, encryption, etc.).
 	var raw := PackedByteArray()

--- a/src/header.gd
+++ b/src/header.gd
@@ -1,5 +1,7 @@
 ## Metro Mod Loader -- community mod loader for Road to Vostok (Godot 4.6+).
 ## Loads .vmz/.pck archives from <game>/mods/ via a pre-game config window.
+## Unpacked folder mods are also recognized when Developer Mode is enabled
+## (toggle in the launcher's Mods tab).
 ## Two-pass architecture: mounts archives at file-scope, optionally restarts to
 ## prepend mod autoloads before the game's own autoloads via [autoload_prepend].
 ##

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -48,8 +48,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		dir.list_dir_end()
 
 	# STABILITY canary B: verify the GDSC tokenizer format is one we support
-	# before any rewrite work. Loud, single-message failure beats 126 silent
-	# "Empty detokenized source" warnings.
+	# before any rewrite work. One loud, actionable message beats a flood of
+	# "Empty detokenized source" warnings, one per hookable script.
 	var tok_version := _probe_gdsc_version()
 	if tok_version != -1 and tok_version != 100 and tok_version != 101:
 		_log_critical("[STABILITY] Unsupported GDSC tokenizer v%d on Godot %s. This ModLoader supports v100 (Godot 4.0-4.4) and v101 (Godot 4.5-4.6). Hook pack generation disabled -- script hooks will not fire. See README for supported Godot versions." \

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -67,6 +67,15 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		_log_warning("[RTVCodegen] script enumeration failed -- falling back to class_name list (%d)" % _class_name_to_path.size())
 		for path: String in _class_name_to_path.values():
 			script_paths.append(path)
+	# Skip-list breakdown -- gives the README an evidence trail for "we wrap N
+	# scripts, skip M". The actual rewritten count is logged below by the
+	# "Generated N rewritten" line; this just records the static skip-list sizes.
+	_log_info("[RTVCodegen] Skip lists: %d runtime-sensitive, %d data, %d serialized (total %d skipped from rewrite)" % [
+		RTV_SKIP_LIST.size(),
+		RTV_RESOURCE_DATA_SKIP.size(),
+		RTV_RESOURCE_SERIALIZED_SKIP.size(),
+		RTV_SKIP_LIST.size() + RTV_RESOURCE_DATA_SKIP.size() + RTV_RESOURCE_SERIALIZED_SKIP.size(),
+	])
 
 	# Pre-read mod sibling scripts BEFORE opening ZIPPacker on the hook pack.
 	# When the hook pack from a previous session is mounted via

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -78,7 +78,20 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# file_access_zip.cpp:137, breaking mod autoload compilation.
 	# Reading here, while the old mount is still valid, keeps the sibling
 	# source snapshot safe. Writes happen later via zp.start_file.
-	var sibling_fixes: Dictionary = {}  # p -> {fixed_src, af (Dictionary), reload_stripped}
+	#
+	# Emit EVERY iterated sibling into the new hook pack, not just ones
+	# autofix changed. Rationale: if a previous session's hook pack already
+	# owns a sibling path and we skip emitting it because autofix is
+	# idempotent, the new hook pack on disk won't contain that path. Godot's
+	# load_resource_pack(replace_files=true) gives the newest mount
+	# precedence, and VFS resolves paths against whichever mount claims
+	# them. If the new mount doesn't claim a path the old mount did, VFS
+	# can end up routing through the old (now stale-indexed) mount and
+	# fail at file_access_zip.cpp:141 (the unzGoToFilePos failure, distinct
+	# from :137's "Cannot open file"). Emitting unconditionally keeps the
+	# new pack a superset of the old for every sibling path we read, so
+	# there are no holes for the stale mount to answer.
+	var sibling_fixes: Dictionary = {}  # p -> {fixed_src, af, reload_stripped, changed}
 	for archive_file: String in _archive_file_sets:
 		var paths_set: Dictionary = _archive_file_sets[archive_file]
 		for p: String in paths_set:
@@ -98,12 +111,11 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			# take_over_path. Eliminates RTVCoop's Cannot-reload spam.
 			var rl := _rtv_strip_helper_reload(fixed_src)
 			fixed_src = rl["source"]
-			if fixed_src == norm:
-				continue  # already clean, no overlay needed
 			sibling_fixes[p] = {
 				"fixed_src": fixed_src,
 				"af": af,
 				"reload_stripped": int(rl["stripped"]),
+				"changed": fixed_src != norm,
 			}
 
 	var zip_abs := ProjectSettings.globalize_path(HOOK_PACK_ZIP)
@@ -308,6 +320,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	for mp in mod_packed:
 		subclass_paths[mp["res_path"]] = true
 	var sibling_fixed := 0
+	var sibling_carried := 0
 	var sibling_total_bodyless := 0
 	var sibling_total_reload_stripped := 0
 	for p: String in sibling_fixes:
@@ -317,22 +330,29 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		var fixed_src: String = fix["fixed_src"]
 		var af: Dictionary = fix["af"]
 		var reload_stripped: int = int(fix["reload_stripped"])
+		var changed: bool = bool(fix["changed"])
 		var zip_rel: String = p.trim_prefix("res://")
 		if zp.start_file(zip_rel) != OK:
 			_log_warning("[Autofix] Failed to pack sibling zip entry %s" % zip_rel)
 			continue
 		zp.write_file(fixed_src.to_utf8_buffer())
 		zp.close_file()
-		sibling_fixed += 1
-		sibling_total_bodyless += int(af["bodyless"])
-		sibling_total_reload_stripped += reload_stripped
-		if reload_stripped > 0:
-			_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
-		_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
-				% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
+		if changed:
+			sibling_fixed += 1
+			sibling_total_bodyless += int(af["bodyless"])
+			sibling_total_reload_stripped += reload_stripped
+			if reload_stripped > 0:
+				_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
+			_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
+					% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
+		else:
+			sibling_carried += 1
 	if sibling_fixed > 0:
 		_log_info("[Autofix] %d mod sibling script(s) repaired (%d bodyless blocks, %d reload() stripped) -- packed into hook pack overlay" \
 				% [sibling_fixed, sibling_total_bodyless, sibling_total_reload_stripped])
+	if sibling_carried > 0:
+		_log_debug("[Autofix] Carried %d unchanged mod sibling script(s) forward into new hook pack -- preserves VFS coverage across regen" \
+				% sibling_carried)
 
 	# STABILITY canary C: add a tiny known-content file to the hook pack so we
 	# can verify VFS mount precedence independently of the script-rewriting

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -689,6 +689,32 @@ func _activate_rewritten_scripts(filenames: Array[String]) -> void:
 			_log_info("[RTVCodegen] AUTOLOAD-CHECK %s: script=%s script_has_rename=%s instance_has_rename=%s" \
 					% [aname, scr.resource_path, has_rename, instance_methods_has_rename])
 
+	# Registry smoke probe (runs unconditionally). Verifies tetra's
+	# const->dict rewrite + _get() injection on Database actually
+	# executed and serves scenes at runtime. Without this, a silent
+	# regression in the Database transform would only surface when a
+	# mod's lib.register() call returned stale data -- this probe
+	# catches it at boot instead.
+	var db_node: Node = get_tree().root.get_node_or_null("Database")
+	if db_node == null:
+		_log_warning("[RegistryProbe] Database autoload not in tree -- cannot verify const->dict transform")
+	elif not ("_rtv_vanilla_scenes" in db_node):
+		_log_warning("[RegistryProbe] Database._rtv_vanilla_scenes missing -- const->dict rewrite did not execute; lib.register/override will not see vanilla ids")
+	else:
+		var vs: Dictionary = db_node._rtv_vanilla_scenes
+		var scene_count: int = vs.size()
+		if scene_count == 0:
+			_log_warning("[RegistryProbe] Database._rtv_vanilla_scenes empty -- regex extracted no entries from Database.gd; check vanilla const syntax")
+		else:
+			var probe_key: String = vs.keys()[0]
+			var probe_result = db_node.get(probe_key)
+			if probe_result is PackedScene:
+				_log_info("[RegistryProbe] Database: _rtv_vanilla_scenes=%d entries; get('%s') returns PackedScene -- const->dict transform + _get() injection OK" \
+						% [scene_count, probe_key])
+			else:
+				_log_warning("[RegistryProbe] Database: _rtv_vanilla_scenes=%d entries but get('%s') returned %s (not PackedScene) -- _get() injection broken" \
+						% [scene_count, probe_key, type_string(typeof(probe_result))])
+
 	# Reset counters before probes. The dispatch template increments
 	# _rtv_dispatch_count on entry, _rtv_dispatch_no_lib when the _lib
 	# null-check trips, and _rtv_dispatch_by_hook per hook_base.

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -83,6 +83,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# from COMPILE-PROOF log lines how many scripts fell into the
 	# GDScriptCache-pinned bucket vs the live-inline bucket.
 	var _step_b_allowlist: Array[String] = []
+	var zero_byte_skipped: int = 0
 	for script_path: String in script_paths:
 		var filename := script_path.get_file()
 
@@ -90,6 +91,12 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			_log_debug("[RTVCodegen] Skipped %s (runtime-sensitive)" % filename)
 			continue
 		if filename in RTV_RESOURCE_SERIALIZED_SKIP or filename in RTV_RESOURCE_DATA_SKIP:
+			continue
+		# Skip zero-byte PCK entries (base game ships empty .gd files for
+		# some scripts; CasettePlayer.gd in RTV 4.6.1). Detokenize cannot
+		# read content that doesn't exist. Not a modloader failure.
+		if _pck_zero_byte_paths.has(script_path):
+			zero_byte_skipped += 1
 			continue
 		if not _step_b_allowlist.is_empty() and filename not in _step_b_allowlist:
 			continue
@@ -316,6 +323,9 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# replace_files=true is the default in 4.6 but pass explicitly -- the whole
 	# design depends on our Scripts/*.gd + .gd.remap entries winning over the
 	# PCK's same-path entries in Godot's VFS layering.
+	if zero_byte_skipped > 0:
+		_log_info("[RTVCodegen] Skipped %d zero-byte PCK entry(ies) (base game ships empty .gd files -- not hookable, not a modloader failure): %s" \
+				% [zero_byte_skipped, ", ".join(_pck_zero_byte_paths.keys())])
 	if script_count > 0:
 		if defer_activation:
 			# Pass 1 pre-restart: write the zip + persist pass_state so Pass 2's

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -266,6 +266,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		subclass_paths[mp["res_path"]] = true
 	var sibling_fixed := 0
 	var sibling_total_bodyless := 0
+	var sibling_total_reload_stripped := 0
 	var sibling_skipped_noop := 0
 	for archive_file: String in _archive_file_sets:
 		var paths_set: Dictionary = _archive_file_sets[archive_file]
@@ -284,6 +285,13 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			var norm := raw.replace("\r\n", "\n").replace("\r", "\n")
 			var af := _rtv_autofix_legacy_syntax(norm)
 			var fixed_src: String = af["source"]
+			# Second pass: strip redundant `.reload()` calls in helpers that
+			# also do take_over_path. Kills the "Cannot reload script while
+			# instances exist" error RTVCoop fires on every launch.
+			var rl := _rtv_strip_helper_reload(fixed_src)
+			fixed_src = rl["source"]
+			var reload_stripped: int = int(rl["stripped"])
+			sibling_total_reload_stripped += reload_stripped
 			if fixed_src == norm:
 				sibling_skipped_noop += 1
 				continue  # already clean, no overlay needed
@@ -295,11 +303,13 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			zp.close_file()
 			sibling_fixed += 1
 			sibling_total_bodyless += int(af["bodyless"])
+			if reload_stripped > 0:
+				_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
 			_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
 					% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
 	if sibling_fixed > 0:
-		_log_info("[Autofix] %d mod sibling script(s) repaired (%d bodyless blocks) -- packed into hook pack overlay (%d already clean, no overlay written)" \
-				% [sibling_fixed, sibling_total_bodyless, sibling_skipped_noop])
+		_log_info("[Autofix] %d mod sibling script(s) repaired (%d bodyless blocks, %d reload() stripped) -- packed into hook pack overlay (%d already clean, no overlay written)" \
+				% [sibling_fixed, sibling_total_bodyless, sibling_total_reload_stripped, sibling_skipped_noop])
 
 	# STABILITY canary C: add a tiny known-content file to the hook pack so we
 	# can verify VFS mount precedence independently of the script-rewriting

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -27,9 +27,15 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# clean.
 	var hook_dir := ProjectSettings.globalize_path(HOOK_PACK_DIR)
 	DirAccess.make_dir_recursive_absolute(hook_dir)
-	var old_zip := ProjectSettings.globalize_path(HOOK_PACK_ZIP)
-	if FileAccess.file_exists(old_zip):
-		DirAccess.remove_absolute(old_zip)
+	# Do NOT delete the old hook pack zip here. If a previous session mounted
+	# it via ProjectSettings.load_resource_pack (_mount_previous_session), the
+	# VFS still holds a file handle to the zip. Deleting the file on disk
+	# invalidates that handle, causing every VFS read that routes through the
+	# hook pack overlay to fail at core/io/file_access_zip.cpp:137 with "Cannot
+	# open file". In practice that breaks any load() of a path present in the
+	# overlay -- including rewritten vanilla scripts and sibling-rewritten mod
+	# autoload scripts. ZIPPacker.open below opens for write and atomically
+	# replaces the file on save, so leaving the old file in place is safe.
 	var dir := DirAccess.open(hook_dir)
 	if dir != null:
 		dir.list_dir_begin()

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -68,6 +68,44 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		for path: String in _class_name_to_path.values():
 			script_paths.append(path)
 
+	# Pre-read mod sibling scripts BEFORE opening ZIPPacker on the hook pack.
+	# When the hook pack from a previous session is mounted via
+	# ProjectSettings.load_resource_pack, Godot holds a FileAccessZIP handle
+	# to the file. ZIPPacker.open below opens the same file for writing,
+	# which on Windows invalidates that read handle once the in-progress
+	# zip is modified. Any VFS read that routes through the hook pack
+	# overlay AFTER zp.open then fails with "Cannot open file" at
+	# file_access_zip.cpp:137, breaking mod autoload compilation.
+	# Reading here, while the old mount is still valid, keeps the sibling
+	# source snapshot safe. Writes happen later via zp.start_file.
+	var sibling_fixes: Dictionary = {}  # p -> {fixed_src, af (Dictionary), reload_stripped}
+	for archive_file: String in _archive_file_sets:
+		var paths_set: Dictionary = _archive_file_sets[archive_file]
+		for p: String in paths_set:
+			if not p.ends_with(".gd"):
+				continue
+			if p.begins_with("res://Scripts/"):
+				continue  # vanilla, handled in the main rewrite loop
+			if not ResourceLoader.exists(p):
+				continue
+			var raw := FileAccess.get_file_as_string(p)
+			if raw.is_empty():
+				continue
+			var norm := raw.replace("\r\n", "\n").replace("\r", "\n")
+			var af := _rtv_autofix_legacy_syntax(norm)
+			var fixed_src: String = af["source"]
+			# Strip redundant `.reload()` calls in helpers that also do
+			# take_over_path. Eliminates RTVCoop's Cannot-reload spam.
+			var rl := _rtv_strip_helper_reload(fixed_src)
+			fixed_src = rl["source"]
+			if fixed_src == norm:
+				continue  # already clean, no overlay needed
+			sibling_fixes[p] = {
+				"fixed_src": fixed_src,
+				"af": af,
+				"reload_stripped": int(rl["stripped"]),
+			}
+
 	var zip_abs := ProjectSettings.globalize_path(HOOK_PACK_ZIP)
 	var zp := ZIPPacker.new()
 	if zp.open(zip_abs) != OK:
@@ -261,55 +299,40 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# replace_files=true precedence then serves the fixed version to
 	# Godot's parser, restoring the pre-hooks compat surface for mods
 	# with bodyless `if` blocks and Godot-3-era annotations.
+	# Write pre-collected sibling autofix results to the hook pack. Reads
+	# happened earlier (before zp.open); here we just emit the fixed bytes.
+	# Skip any sibling whose path was also packed as a mod subclass earlier
+	# in this call -- the mod subclass rewrite is the canonical version,
+	# and double-packing would leave two entries in the zip.
 	var subclass_paths: Dictionary = {}
 	for mp in mod_packed:
 		subclass_paths[mp["res_path"]] = true
 	var sibling_fixed := 0
 	var sibling_total_bodyless := 0
 	var sibling_total_reload_stripped := 0
-	var sibling_skipped_noop := 0
-	for archive_file: String in _archive_file_sets:
-		var paths_set: Dictionary = _archive_file_sets[archive_file]
-		for p: String in paths_set:
-			if not p.ends_with(".gd"):
-				continue
-			if p.begins_with("res://Scripts/"):
-				continue  # vanilla, handled upstream
-			if subclass_paths.has(p):
-				continue  # already packed via mod-subclass rewrite
-			if not ResourceLoader.exists(p):
-				continue
-			var raw := FileAccess.get_file_as_string(p)
-			if raw.is_empty():
-				continue
-			var norm := raw.replace("\r\n", "\n").replace("\r", "\n")
-			var af := _rtv_autofix_legacy_syntax(norm)
-			var fixed_src: String = af["source"]
-			# Second pass: strip redundant `.reload()` calls in helpers that
-			# also do take_over_path. Kills the "Cannot reload script while
-			# instances exist" error RTVCoop fires on every launch.
-			var rl := _rtv_strip_helper_reload(fixed_src)
-			fixed_src = rl["source"]
-			var reload_stripped: int = int(rl["stripped"])
-			sibling_total_reload_stripped += reload_stripped
-			if fixed_src == norm:
-				sibling_skipped_noop += 1
-				continue  # already clean, no overlay needed
-			var zip_rel: String = p.trim_prefix("res://")
-			if zp.start_file(zip_rel) != OK:
-				_log_warning("[Autofix] Failed to pack sibling zip entry %s" % zip_rel)
-				continue
-			zp.write_file(fixed_src.to_utf8_buffer())
-			zp.close_file()
-			sibling_fixed += 1
-			sibling_total_bodyless += int(af["bodyless"])
-			if reload_stripped > 0:
-				_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
-			_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
-					% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
+	for p: String in sibling_fixes:
+		if subclass_paths.has(p):
+			continue
+		var fix: Dictionary = sibling_fixes[p]
+		var fixed_src: String = fix["fixed_src"]
+		var af: Dictionary = fix["af"]
+		var reload_stripped: int = int(fix["reload_stripped"])
+		var zip_rel: String = p.trim_prefix("res://")
+		if zp.start_file(zip_rel) != OK:
+			_log_warning("[Autofix] Failed to pack sibling zip entry %s" % zip_rel)
+			continue
+		zp.write_file(fixed_src.to_utf8_buffer())
+		zp.close_file()
+		sibling_fixed += 1
+		sibling_total_bodyless += int(af["bodyless"])
+		sibling_total_reload_stripped += reload_stripped
+		if reload_stripped > 0:
+			_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
+		_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
+				% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
 	if sibling_fixed > 0:
-		_log_info("[Autofix] %d mod sibling script(s) repaired (%d bodyless blocks, %d reload() stripped) -- packed into hook pack overlay (%d already clean, no overlay written)" \
-				% [sibling_fixed, sibling_total_bodyless, sibling_total_reload_stripped, sibling_skipped_noop])
+		_log_info("[Autofix] %d mod sibling script(s) repaired (%d bodyless blocks, %d reload() stripped) -- packed into hook pack overlay" \
+				% [sibling_fixed, sibling_total_bodyless, sibling_total_reload_stripped])
 
 	# STABILITY canary C: add a tiny known-content file to the hook pack so we
 	# can verify VFS mount precedence independently of the script-rewriting

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -45,8 +45,13 @@ func hook(hook_name: String, callback: Callable, priority: int = 100) -> int:
 			or hook_name.ends_with("-callback"))
 	if is_replace and _hooks.has(hook_name) and (_hooks[hook_name] as Array).size() > 0:
 		var owner_id: int = (_hooks[hook_name] as Array)[0]["id"]
-		push_warning("RTVModLib: replace hook '" + hook_name \
-				+ "' already owned (id=" + str(owner_id) + "), registration rejected")
+		# Info-level, not warning: rejection is normal API behavior (replace
+		# slots are single-owner by design). Caller checks the -1 return
+		# code. Promoting this to push_warning() made every test assertion
+		# and every mod-conflict check spam Godot's stderr even though it's
+		# expected. Debug-gated so verbose logs still show it when needed.
+		_log_debug("[RTVModLib] replace hook '%s' already owned (id=%d), registration rejected" \
+				% [hook_name, owner_id])
 		return -1
 	if not _hooks.has(hook_name):
 		_hooks[hook_name] = []

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -181,7 +181,7 @@ func download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 	if err != OK:
 		req.queue_free()
 		return false
-	# request_completed → [result, http_code, headers, body]
+	# request_completed -> [result, http_code, headers, body]
 	var res: Array = await req.request_completed
 	req.queue_free()
 

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -231,17 +231,6 @@ func _apply_script_overrides() -> void:
 	if applied > 0:
 		_log_info("[Overrides] Applied %d script override(s)" % applied)
 
-# --- RTVModLib runtime (port of Main.gd) ------------------------------------
-# Mods opt in via mod.txt:
-#     [rtvmodlib]
-#     needs=["LootContainer","Trader"]    # array literal
-#     needs=LootContainer,Trader           # or comma string
-# Only requested frameworks get take_over_path'd. Matches RTVModLib's
-# per-script opt-in instead of wrapping every game script.
-
-# If RTVModLib.vmz is loaded, we stand down -- both of us doing take_over_path
-# + node_added would double-swap every instance.
-
 func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		archive_file: String, load_index: int) -> void:
 	var zr := ZIPReader.new()

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -353,8 +353,12 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 			(analysis["class_names"] as Array).append(cn)
 
 	if not analysis["uses_dynamic_override"]:
-		analysis["uses_dynamic_override"] = "get_base_script()" in text \
-				or "take_over_path(parentScript" in text
+		# Previous narrow match (get_base_script() + take_over_path(parentScript)
+		# missed RTVCoop's pattern: script.take_over_path(gamePath) where gamePath
+		# is a literal arg that doesn't start with "parentScript". Matching any
+		# take_over_path() call is a superset that still catches AI Overhaul /
+		# MCM / other parentScript-style callers.
+		analysis["uses_dynamic_override"] = "take_over_path(" in text
 
 	# UpdateTooltip() is inventory-UI only. World-item tooltips are written directly
 	# by HUD._physics_process from gameData.tooltip -- this override has no effect there.

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -155,7 +155,7 @@ func _collect_module_scope_scene_preloads(source: String) -> PackedStringArray:
 				scenes.append(scene_path)
 	return scenes
 
-# Minimal PCK header + file-table parser. V2 (Godot 4.0–4.5) has 16 reserved
+# Minimal PCK header + file-table parser. V2 (Godot 4.0-4.5) has 16 reserved
 # dwords before the directory; V3 (Godot 4.6+) replaces them with an explicit
 # 64-bit directory offset. Reference: core/io/file_access_pack.cpp.
 func _parse_pck_file_list(pck_path: String) -> PackedStringArray:

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -207,12 +207,20 @@ func _parse_pck_file_list(pck_path: String) -> PackedStringArray:
 					% [pck_path, path_len, i])
 			break
 		var path := f.get_buffer(path_len).get_string_from_utf8()
-		f.get_64()        # offset
-		f.get_64()        # size
-		f.get_buffer(16)  # md5
-		f.get_32()        # per-file flags (V2 and V3)
+		f.get_64()              # offset
+		var size: int = f.get_64()
+		f.get_buffer(16)        # md5
+		f.get_32()              # per-file flags (V2 and V3)
 		if not path.is_empty():
 			result.append(path)
+			# Track zero-byte entries so downstream detokenize skips them
+			# silently instead of logging misleading "Cannot read bytes"
+			# warnings. The base game may ship empty .gd entries (e.g.
+			# CasettePlayer.gd in RTV 4.6.1) that we cannot hook and that
+			# any preload() call would fail regardless of modloader.
+			if size == 0 and path.ends_with(".gd"):
+				var res_path := path if path.begins_with("res://") else "res://" + path.trim_prefix("/")
+				_pck_zero_byte_paths[res_path] = true
 
 	f.close()
 	return result

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -676,6 +676,80 @@ func _rtv_autofix_legacy_syntax(source: String) -> Dictionary:
 		"export": fix_export,
 	}
 
+# Comment out `<var>.reload()` lines inside mod helper functions that also
+# call `take_over_path`. Rationale: mod override helpers (RTVCoop's _override,
+# CustomItemTest's override_script, etc.) often do:
+#   var script = load(modPath); script.reload(); script.take_over_path(gamePath)
+# The reload() call is a no-op unless source changed between load and call.
+# Our hook pack owns the mod subclass source, so reload is always redundant.
+# Worse: if the mod had already set_script(script) on a live node earlier
+# (RTVCoop does this for /root/Loader), reload fails at gdscript.cpp:756 with
+# "Cannot reload script while instances exist." take_over_path succeeds right
+# after, so the override still works, but the error spams stderr each launch.
+# Stripping the reload eliminates the error with no behavior change.
+#
+# Scope: only strips lines where the stripped-edges content ends with
+# ".reload()" AND the enclosing function body contains ".take_over_path(".
+# Comments out with a "# modloader stripped" note so the change is visible
+# if a mod author inspects the rewritten source.
+#
+# Source must be LF-normalized by the caller.
+func _rtv_strip_helper_reload(source: String) -> Dictionary:
+	var lines: PackedStringArray = source.split("\n")
+	var out: PackedStringArray = PackedStringArray()
+	var stripped: int = 0
+	var i: int = 0
+	while i < lines.size():
+		var line: String = lines[i]
+		if not line.begins_with("func "):
+			out.append(line)
+			i += 1
+			continue
+		# Collect function body: header + subsequent indented lines.
+		var start: int = i
+		var end: int = i + 1
+		while end < lines.size():
+			var bl: String = lines[end]
+			if bl.length() > 0 and not (bl[0] == "\t" or bl[0] == " "):
+				break
+			end += 1
+		# Does this function body call take_over_path anywhere?
+		var has_tov: bool = false
+		for k in range(start, end):
+			if ".take_over_path(" in lines[k]:
+				has_tov = true
+				break
+		if has_tov:
+			for k in range(start, end):
+				var bl: String = lines[k]
+				var trimmed: String = bl.strip_edges()
+				# Match bare `<ident>.reload()` statement lines (nothing else
+				# on the line). Preserves the original indent and leaves a
+				# comment trail.
+				if trimmed.ends_with(".reload()") and not trimmed.begins_with("#"):
+					var before_paren: int = trimmed.find(".reload()")
+					var ident_part: String = trimmed.substr(0, before_paren)
+					var is_bare_call: bool = true
+					for c in ident_part:
+						if not (c == "_" or c == "." or (c >= "a" and c <= "z") \
+								or (c >= "A" and c <= "Z") or (c >= "0" and c <= "9")):
+							is_bare_call = false
+							break
+					if is_bare_call:
+						var indent_len: int = 0
+						while indent_len < bl.length() and (bl[indent_len] == "\t" or bl[indent_len] == " "):
+							indent_len += 1
+						var indent: String = bl.substr(0, indent_len)
+						out.append(indent + "# " + bl.substr(indent_len) + "  # modloader: stripped (redundant + fires Cannot-reload error if instance exists)")
+						stripped += 1
+						continue
+				out.append(bl)
+		else:
+			for k in range(start, end):
+				out.append(lines[k])
+		i = end
+	return {"source": "\n".join(out), "stripped": stripped}
+
 # Produces ONE inline dispatch wrapper that calls _rtv_vanilla_<name>(...).
 #
 # Mirrors _rtv_generate_override's templates but:

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -149,7 +149,7 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 			if body_line.begins_with("return ") and body_line.length() > 7:
 				has_return_value = true
 
-		# Explicit return type override (void → no value; anything else → has value).
+		# Explicit return type override (void -> no value; anything else -> has value).
 		if return_type != null and return_type != "void":
 			has_return_value = true
 		if return_type != null and return_type == "void":
@@ -168,6 +168,12 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 
 	return script
 
+# DEAD CODE (verified 2026-04-19): zero callers. Grep `_rtv_generate_override(`
+# returns only this definition. Was the codegen for the original extends-wrapper
+# path; the source-rewrite era replaced it with _rtv_dispatch_inline_src below.
+# Kept as scaffolding in case the [rtvmodlib] needs= -> Framework<X>.gd path
+# ever needs to be revived. Remove with Step E.
+#
 # Produce one Framework<Name>.gd source. Three method templates (matching
 # generate_override in the Rust):
 #   _ready   -- has a _rtv_ready_done flag so super() doesn't double-fire


### PR DESCRIPTION
## Summary

13 commits porting scene-preload-session follow-ups onto tetra's src/ split
(PR #13), plus defense-in-depth + doc-audit cleanup. Verified end-to-end
against RTVCoop + RTVModLibTests (82 pass / 0 fail / 3 skip) across both
force-restart and skip-restart paths.

### Boot-log cleanup (ported from monolith)

- `e0efae9` **Follow-ups**: don't pre-delete the mounted hook pack before
  repacking (was invalidating the VFS handle, cascading to `Cannot open
  file` at `file_access_zip.cpp:137`); collapse `[rtvmodlib] needs=` noise
  into one info line (the per-framework path is unreachable under source-
  rewrite anyway).
- `212b1db` **Broaden uses_dynamic_override detector**: narrow match
  `take_over_path(parentScript` missed RTVCoop's `take_over_path(gamePath)`
  pattern. Detecting any `take_over_path(` is a superset that still catches
  AI Overhaul + MCM.
- `1198141` **Auto-swap stale autoload instances to mod body**: `take_over_path`
  updates ResourceCache but not live instances. Added a post-override probe
  that `set_script`'s each affected autoload onto the mod's subclass, so
  `/root/Simulation` etc. actually run the mod's body. Verified RTVCoop's
  Simulation override now fires.
- `feb3f31` **Detect zero-byte PCK entries**: RTV 4.6.1 ships
  `res://Scripts/CasettePlayer.gd` as a 0-byte entry. Detokenize silently
  returns empty; one info line explains the skip instead of misleading
  warnings.
- `7066975` **Strip redundant `.reload()` in take_over_path helpers**:
  RTVCoop fires `GDScript::reload` at `gdscript.cpp:756` every launch,
  erroring because the target script has live instances. The reload is a
  no-op anyway (source hasn't changed since load); commenting it out
  eliminates the confusing stderr spam.
- `10d7c63` **Classify RTV_SKIP_LIST pass-through as OK**: Explosion /
  Mine / Hit / etc. are intentionally not rewritten; mod subclasses that
  extend them ride Godot's standard virtual dispatch. Treat as OK instead
  of STALE/UNKNOWN.
- `0e6252c` **Downgrade non-error log output**: hook-rejection (single-
  owner replace slots, normal API behavior) and TREEWALK-absent (probe
  runs at t+12s before most classes instantiate) shouldn't be warnings.

### Scene-preload + VFS refactor

- `028b621` **Pre-read mod sibling sources before opening ZIPPacker**:
  on Windows, `ZIPPacker.open` invalidates the existing `FileAccessZIP`
  handle for a mounted pack. Any VFS read routed through that overlay
  after `zp.open` fails at `file_access_zip.cpp:137`. Reading siblings
  first, while the old mount is still valid, fixes mod-sibling autofix.
- `75674d7` **Registry smoke probe**: one-line boot assertion that tetra's
  Database const->dict rewrite + injected `_get()` are actually wired up.
  Three distinct failure modes each get their own warning. Complements
  Section R's 14 API-level tests.
- `c0b15dd` **Force restart on modloader rebuild + emit all siblings**:
  two-part VFS coherence fix. (a) Include `modloader.gd`'s mtime in the
  state hash so any rebuild triggers a full restart and Pass 2 mounts the
  new pack on a fresh VFS (dodging the path-dedupe trap where
  `load_resource_pack` is a no-op on same path). (b) Emit every iterated
  mod sibling into the new pack unconditionally (defense-in-depth for the
  skip-restart path, keeping the new pack a superset of any previous
  session's pack).
- `c05258a` **Log skip-list sizes**: evidence trail for the README's
  "wrap N, skip M" claims.

### Doc-audit cleanup

- `c864187` **README fact-check**: 24 audited claims cross-checked against
  source + a live boot log. Dispatch-wrapper code sample replaced with
  current `_rtv_vanilla_*` inline rewrite, IXP override count corrected,
  Godot 4.7 aspirational notes dropped, etc.
- `c19bff9` **src/ doc cleanup**: DEAD CODE markers above 6 functions
  whose chain is dead under source-rewrite (grep-confirmed zero live call
  paths), canary B wording re-framed (dropped stale "126" count), orphan
  RTVModLib-runtime / stand-down comments removed, ASCII-only in code
  comments.

## Verified

Five consecutive clean-green test runs against RTVModLibTests + RTVCoop:

- `[RegistryProbe] Database: _rtv_vanilla_scenes=323 entries; get('Potato') returns PackedScene -- const->dict transform + _get() injection OK`
- `[STABILITY] VFS canary OK`
- `[AutoloadInstanceProbe] Simulation | FIXED via set_script swap -- OK`
- 37 `[RTVCoop] OK:` override lines (zero STALE)
- Section R (Registry, 14 tests) all pass
- Sync phases: **82 pass / 0 fail / 3 skip** (3 skips are pre-existing
  BOUNDED edge-case tests, not regressions)
- Real gameplay: scene transition Cabin -> Village, AI spawning, trader
  interaction, door interactions (G7 blocking hit 5 then disabled),
  **749,425 wrapper calls in 30s with zero no-lib fallbacks**
- Both force-restart (mtime changed) AND skip-restart (mtime stable)
  paths exercised; defense-in-depth (`Carried N unchanged siblings`)
  fires correctly on both.

## Test plan

- [x] RTVModLibTests Sections A-D (core API, dispatch, edge cases, caller
      tracking): 68 pass
- [x] RTVModLibTests Section R (Registry, new): 14 pass
- [x] Force-restart path (modloader rebuild triggers state-hash mismatch):
      clean
- [x] Skip-restart path (mod state + modloader unchanged): clean
- [x] RTVCoop 37 overrideScript targets all OK (including skip-listed
      Explosion + Mine)
- [x] Auto-swap fires on stale Simulation autoload
- [x] Gameplay: scene transition, AI spawn, trader open, door interact
- [x] ASCII-only code + docs (verified via unicode grep)
- [x] `bash build.sh` produces a modloader.gd that matches deployed (md5)