### PR TITLE
docs: add developer wiki + sync workflow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,39 @@
+name: wiki-sync
+
+on:
+  push:
+    branches:
+      - development
+      - master
+    paths:
+      - docs/wiki/**
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push docs/wiki to GitHub Wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.wiki.git" wiki
+          rsync -a --delete --exclude='.git' docs/wiki/ wiki/
+          cd wiki
+          git config user.name  "wiki-sync[bot]"
+          git config user.email "actions@github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes."
+          else
+            git commit -m "sync from ${REPO}@${SHA}"
+            git push
+          fi

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,139 @@
+# Architecture
+
+The mod loader runs in two stages:
+
+1. **Static init** (before `_ready`): mounts archives from the previous session, preempts `class_name` scripts Godot would otherwise pin to PCK bytecode, and checks sentinel files.
+2. **`_ready`**: dispatches to **Pass 1** (show UI + optionally restart) or **Pass 2** (post-restart finalization), based on a cmdline arg.
+
+## Entry points
+
+| Stage | Trigger | Code |
+|---|---|---|
+| Static init | Module-scope var initializer evaluates before `_ready` | `var _filescope_mounted := _mount_previous_session()` at [src/constants.gd:161](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L161) |
+| `_ready` | Godot calls it after scene enters tree | [src/lifecycle.gd:7](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L7) |
+
+The static-init trick works because Godot evaluates `var = <call>()` initializers at script-load time. The mounts land in VFS before any autoload scene graph resolves, so game autoloads can `preload(res://ModPath/Foo.gd)` without the archive being explicitly mounted in `_ready`.
+
+## Static init (`_mount_previous_session`)
+
+Defined at [src/boot.gd:32](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L32). Sequence:
+
+1. **Disabled sentinel check** -- if `<exe_dir>/modloader_disabled` exists, force vanilla state and return. See [Stability-Canaries](Stability-Canaries) for the escape hatches.
+2. **Crashed Pass 2 recovery** -- if `user://modloader_pass2_dirty` exists, Pass 2 was interrupted before cleanup; full wipe.
+3. **Pre-init cache snapshot** -- probe 16 `class_name` scripts Godot is known to pre-compile ([boot.gd:71-88](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L71)) and classify each as tokenized (PCK-pinned) / source-loaded (our prior-session rewrite) / not-yet-loaded.
+4. **Load pass state** from `user://mod_pass_state.cfg`; early return if missing.
+5. **Version mismatch** -- if saved `modloader_version` != current `MODLOADER_VERSION`, wipe state (pass-state format may have changed).
+6. **Exe mtime check** -- if the game exe was updated since last session, wipe hook cache (vanilla scripts may have changed).
+7. **Archive existence scan** -- if any archive from last session is missing, write a clean `override.cfg` and reset.
+8. **Mount loop** -- each archive via `ProjectSettings.load_resource_pack`, with `.vmz -> .zip` fallback.
+9. **Hook pack preempt mount** ([boot.gd:208-287](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L208)) -- mount `user://modloader_hooks/framework_pack.zip` with `replace_files=true`, then force a fresh source-compile of each pinned-probe script via `ResourceLoader.load(..., CACHE_MODE_IGNORE)` + `take_over_path`. Non-pinned scripts are left to Godot's lazy-compile path.
+10. **Test pack mount** (dev-only, gated on `user://test_pack_precedence.zip` presence).
+
+The hook pack preempt is the only way to rewire scripts Godot pre-compiles during `class_cache` population. Once pinned, runtime `source_code + reload()` and `CACHE_MODE_IGNORE + take_over_path` both fail against autoload-backed scripts (see [Limitations](Limitations)).
+
+## Pass 1 (normal launch)
+
+Defined at [src/lifecycle.gd:34](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L34). Outline:
+
+```
+check crash recovery (heartbeat + restart count)
+check safe mode sentinel
+compile regex, build class_name lookup, load dev-mode setting
+collect_mod_metadata()          # scan <exe>/mods/ -- no mounting
+clean_stale_cache
+load_ui_config
+await show_mod_ui()             # user configures and clicks Launch Game
+save_ui_config
+load_all_mods()                 # mount archives, scan, queue autoloads
+_apply_script_overrides         # from [script_overrides] in mod.txt
+sections    = _build_autoload_sections()
+archive_paths = _collect_enabled_archive_paths()
+new_hash    = _compute_state_hash(...)
+
+if new_hash == old_hash and not empty:
+    _finish_with_existing_mounts()     # fast path -- same mod set as last session
+    return
+
+if archive_paths not empty:
+    _register_rtv_modlib_meta
+    _generate_hook_pack(defer_activation=true)    # Pass 2 activates
+    _write_heartbeat
+    _write_override_cfg(sections.prepend)
+    _write_pass_state(archive_paths, new_hash)
+    OS.set_restart_on_exit(true, args + "--modloader-restart")
+    get_tree().quit()
+else:
+    remove pass_state, restore clean override.cfg, wipe hook cache
+    _finish_single_pass()
+```
+
+`defer_activation=true` on the first-time pack generation is deliberate: without it, activation runs against the already-pinned PCK bytecode in this engine process, fires a misleading `"hooks WILL NOT fire this session"` STABILITY alarm, then restarts anyway. Passing `defer_activation=true` writes the zip + pass state and lets Pass 2's fresh engine mount it cleanly. See [hook_pack.gd:392-402](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L392).
+
+## Pass 2 (post-restart)
+
+Triggered by `--modloader-restart` in `OS.get_cmdline_user_args()`. Defined at [src/lifecycle.gd:160](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L160).
+
+Archives are already mounted at file-scope (static init handled it). Early autoloads are already in the tree (Godot loaded them from `[autoload_prepend]`). This pass:
+
+1. Writes `user://modloader_pass2_dirty` sentinel first thing. If Pass 2 crashes before cleanup, next launch's static init detects the marker and force-wipes.
+2. Restores `[script_overrides]` from pass state and applies them.
+3. Clears restart counter.
+4. Re-runs metadata collection + `load_all_mods("Pass 2")`. Archives already file-scope-mounted skip re-mount via `_filescope_mounted.has(full_path)` check.
+5. Generates + mounts the hook pack (this time without `defer_activation`).
+6. Instantiates pending autoloads (skips ones already in tree from `[autoload_prepend]`).
+7. `_emit_frameworks_ready` -- runs verification probes (see [Developer-Mode](Developer-Mode)).
+8. Deletes heartbeat, clears the Pass 2 dirty marker.
+9. `reload_current_scene()` if any archives or autoloads changed.
+
+## override.cfg lifecycle
+
+`override.cfg` is written directly to the game directory (not `user://`) because Godot reads it at engine startup before any script runs. Canonical layout ([boot.gd:177](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L177)):
+
+```
+[autoload_prepend]
+<early_autoload1>="*<path>"
+<early_autoload2>="*<path>"
+ModLoader="*res://modloader.gd"
+
+[autoload]
+
+<preserved>
+```
+
+Three invariants:
+
+- **ModLoader is always in `[autoload_prepend]`, last entry.** `[autoload_prepend]` is reverse-insertion -- last listed = first loaded. This ensures ModLoader's static-init mount runs before any mod autoload's script references resolve. See the rationale at [boot.gd:470-475](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L470).
+- **Late autoloads never appear in `override.cfg`.** If they did, Godot would try to load them before archives are mounted in static init. They're instantiated manually in `_finish_*` helpers after mounts land.
+- **Atomic write via `.tmp` + rename.** [boot.gd:483-498](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L483). `DirAccess.rename()` on Windows won't overwrite, so the target is removed first.
+
+Non-autoload sections (`[display]`, `[input]`, etc.) are preserved via `_read_preserved_cfg_sections` ([fs_archive.gd:49](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd#L49)) and re-concatenated.
+
+## Pass state
+
+`user://mod_pass_state.cfg` persists between sessions. Keys in `[state]`:
+
+| Key | Purpose |
+|---|---|
+| `restart_count` | Crash-loop guard -- `_check_crash_recovery` wipes when `>= MAX_RESTART_COUNT` (2) |
+| `mods_hash` | md5 of archive paths + mtimes + autoloads + script_overrides + `MODLOADER_VERSION` + `modloader.gd` mtime. Mismatch forces restart |
+| `archive_paths` | `PackedStringArray` replayed by static init's mount loop |
+| `modloader_version` | Version wipe check -- format may have changed |
+| `exe_mtime` | Game-update detection |
+| `timestamp` | Unix time, diagnostic only |
+| `script_overrides` | `[{vanilla_path, mod_script_path, mod_name, priority}]` for Pass 2 to replay |
+| `hook_pack_path` | Static init mounts this at next boot |
+| `hook_pack_exe_mtime` | Separate invalidation key for hook pack |
+
+Writer: `_write_pass_state` at [boot.gd:515](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L515). Hash computed at [boot.gd:535](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L535).
+
+Including `modloader.gd`'s own mtime in the hash is load-bearing ([boot.gd:554-568](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L554)): `ProjectSettings.load_resource_pack` dedupes by path, so rebuilding the loader without a restart would leave the old hook pack mount active with stale file offsets.
+
+## Heartbeat + safe mode
+
+- **Heartbeat file** (`user://modloader_heartbeat.txt`) written before restart, deleted post-Pass-2-cleanup. A surviving heartbeat means last launch crashed.
+- **Restart counter** in pass state, incremented by `_write_pass_state`. `_check_crash_recovery` at [boot.gd:581](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L581) force-resets when it hits `MAX_RESTART_COUNT` (2).
+- **Safe mode file** (`<exe>/modloader_safe_mode`) -- user-placed. `_check_safe_mode` at [boot.gd:596](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L596) detects, wipes state, removes the sentinel.
+- **Disabled sentinel** (`<exe>/modloader_disabled`) -- user-placed, sticky. Checked at static init by `_is_modloader_disabled` at [boot.gd:8](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L8). Modloader sits idle for the whole session until the user removes the file.
+- **Pass 2 dirty marker** (`user://modloader_pass2_dirty`) -- written at Pass 2 start, deleted at Pass 2 end. Detected at next static init to force-wipe on interrupted runs.
+
+See [Stability-Canaries](Stability-Canaries) for the escape hatches in detail.

--- a/docs/wiki/Build.md
+++ b/docs/wiki/Build.md
@@ -1,0 +1,134 @@
+# Build
+
+The installable artifact `modloader.gd` is **built** from `src/*.gd` -- not edited directly. The editing surface is the `src/` tree; `modloader.gd` is produced on demand.
+
+## build.sh
+
+Source: [build.sh](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh).
+
+Concatenates `src/*.gd` into a single `modloader.gd` at the repo root. Explicit ordering (not filename-based sort) is in the `FILES` array:
+
+```bash
+FILES=(
+    "$SRC/header.gd"
+    "$SRC/constants.gd"
+    "$SRC/logging.gd"
+    "$SRC/fs_archive.gd"
+    "$SRC/boot.gd"
+    "$SRC/mod_discovery.gd"
+    "$SRC/mod_loading.gd"
+    "$SRC/conflict_report.gd"
+    "$SRC/ui.gd"
+    "$SRC/hooks_api.gd"
+    "$SRC/registry.gd"
+    "$SRC/framework_wrappers.gd"
+    "$SRC/gdsc_detokenizer.gd"
+    "$SRC/pck_enumeration.gd"
+    "$SRC/rewriter.gd"
+    "$SRC/hook_pack.gd"
+    "$SRC/lifecycle.gd"
+    "$SRC/debug.gd"
+)
+```
+
+Dependencies flow top-down -- earlier files may not reference code defined later. This mirrors how GDScript parses a file.
+
+### Invariants enforced by build.sh
+
+Post-concat sanity checks ([build.sh:57-69](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L57)):
+
+- **Exactly one `extends` line**, and it must be at the very top ([header.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/header.gd)).
+- **At most one `class_name`** declaration (currently there is none -- the loader is ModLoader autoload).
+
+Missing source file aborts before concat ([build.sh:46-48](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L46)).
+
+### Running it
+
+```bash
+./build.sh
+```
+
+Produces `modloader.gd` at the repo root. Run after any `src/` edit and before testing in-game.
+
+`modloader.gd` is **not committed** (see `.gitignore`). It's downloaded from GitHub Releases by end users via the installer scripts:
+
+```
+/releases/latest/download/modloader.gd
+/releases/latest/download/override.cfg
+```
+
+## release-please
+
+Source: [.github/workflows/release-please.yml](https://github.com/ametrocavich/vostok-mod-loader/blob/development/.github/workflows/release-please.yml).
+
+Automates version bumps and changelog generation from [Conventional Commits](https://www.conventionalcommits.org/).
+
+### Flow
+
+1. PR merges to `master`.
+2. `release-please-action@v4` parses Conventional Commits since the last tag.
+3. Opens a follow-up PR titled something like "chore(main): release 2.3.2" that bumps `MODLOADER_VERSION` in [src/constants.gd:13](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L13) and updates `CHANGELOG.md`.
+4. Merging that PR creates the git tag + GitHub Release.
+5. On release creation, the workflow rebuilds `modloader.gd` via `./build.sh` and uploads it (plus `override.cfg`) as release assets.
+
+The workflow only rebuilds on release creation -- normal `master` pushes don't trigger a build.
+
+### Version-bump mapping
+
+From [CONTRIBUTING.md](https://github.com/ametrocavich/vostok-mod-loader/blob/development/CONTRIBUTING.md):
+
+**Triggers a bump:**
+
+| Type | Bump | Example |
+|---|---|---|
+| `feat:` | minor (2.3.0 -> 2.4.0) | new feature or user-facing behavior |
+| `fix:` | patch (2.3.0 -> 2.3.1) | bug fix |
+| `feat!:` / `fix!:` | major (2.3.0 -> 3.0.0) | breaking change |
+
+**No bump** (appears under "Miscellaneous" in changelog):
+
+`chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `build:`, `ci:`, `style:`.
+
+### Where the version lives
+
+The bump is applied by release-please to a single line:
+
+```gdscript
+# x-release-please-start-version
+const MODLOADER_VERSION := "2.3.1"
+# x-release-please-end
+```
+
+Mods read the version at runtime via:
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+if lib.major_version() >= 3:
+    use_new_api()
+```
+
+Accessors ([hooks_api.gd:9-19](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L9)): `version() -> String`, `major_version() -> int`, `minor_version() -> int`, `patch_version() -> int`. All static.
+
+## Branch model
+
+From [CONTRIBUTING.md](https://github.com/ametrocavich/vostok-mod-loader/blob/development/CONTRIBUTING.md):
+
+- **`development`** -- target for all contributor PRs. Feature branches merge here via **squash** (keeps each PR as a single clean conventional commit).
+- **`master`** -- release branch. Only maintainer PRs from `development -> master` land here, via **rebase-merge** so every individual commit is preserved for release-please to read.
+
+Contributor workflow:
+
+1. Branch off `development`.
+2. PR against `development`.
+3. PR title follows `<type>: <description>` (release-please reads this).
+4. On merge: squashed into one commit on `development`.
+
+Maintainers batch accumulated work into a `development -> master` PR when it's time to cut a release. Rebase-merge preserves individual commits so release-please can build an accurate changelog.
+
+## Wiki sync
+
+This wiki is generated from [docs/wiki/*.md](https://github.com/ametrocavich/vostok-mod-loader/tree/development/docs/wiki) via [.github/workflows/wiki-sync.yml](https://github.com/ametrocavich/vostok-mod-loader/blob/development/.github/workflows/wiki-sync.yml).
+
+The workflow triggers on push to `development` or `master` when `docs/wiki/**` changes. It clones `<repo>.wiki.git` using the default `GITHUB_TOKEN` (scoped to `contents: write`), rsyncs `docs/wiki/` into the clone with `--delete`, and pushes a commit. Since the wiki git repo is considered part of the repo's content scope, no PAT is needed.
+
+To edit a page, PR changes to `docs/wiki/*.md` on `development`. The wiki updates itself on merge.

--- a/docs/wiki/Developer-Mode.md
+++ b/docs/wiki/Developer-Mode.md
@@ -1,0 +1,170 @@
+# Developer Mode
+
+Dev mode is a per-user setting that unlocks folder-mod loading, verbose logging, and a battery of diagnostic probes. Off by default.
+
+## How to enable
+
+UI toolbar checkbox in the Mods tab: **Developer Mode** ([ui.gd:294-315](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L294)). Toggle persists to `[settings] developer_mode` in `user://mod_config.cfg`.
+
+Loading the saved value runs at Pass-1 boot via [ui.gd:7 `_load_developer_mode_setting`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L7). Log line `"Developer mode: ON"` if enabled.
+
+## What it unlocks
+
+### 1. Unpacked folder mods
+
+Subdirectories of `<exe>/mods/` are recognized as mod archives and zipped to `user://vmz_mount_cache/<name>_dev.zip` on the fly. Without dev mode, subdirectories are ignored ([mod_discovery.gd:25](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L25)).
+
+Folder entries show `[dev folder]` label in red in the UI ([ui.gd:441-446](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L441)).
+
+Use case: in-development mods you haven't packaged yet.
+
+### 2. Verbose logging (`_log_debug`)
+
+`_log_debug` ([logging.gd:20](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/logging.gd#L20)) is gated on `_developer_mode`. When off, debug-level lines are dropped silently.
+
+Debug-level entries include:
+
+- Skip-list rejections from the rewriter (`"[RTVCodegen] Skipped <file> (runtime-sensitive)"`)
+- Per-mod rewrite summaries (`"[RTVCodegen] Rewrote Scripts/<file> (N hooks)"`)
+- Sibling-autofix carry-forward (`"[Autofix] Carried N unchanged mod sibling script(s) forward into new hook pack"`)
+- Stale cache cleanup (`"Removed stale cache: <name>"`)
+- Replace-hook rejection details (`"[RTVModLib] replace hook '<name>' already owned (id=N), registration rejected"`)
+- FileAccess / ResourceLoader existence diagnostics for failed autoload loads
+
+### 3. Conflict report
+
+`_print_conflict_summary` + `_write_conflict_report` ([conflict_report.gd:383,430](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L383)) always run, but are particularly useful in dev mode paired with the verbose logs.
+
+Writes `user://modloader_conflicts.txt` with every log line from the session.
+
+Console summary includes:
+
+- Mods loaded count
+- Conflicted resource paths with per-claim breakdown (marking `<-- wins` on the last entry)
+- Framework overrides active (legacy path, usually empty)
+- Hook registrations per name
+
+### 4. Source scanner
+
+[mod_loading.gd:319 `_scan_gd_source`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L319) runs per-mod when the mod has `.gd` files. Captures:
+
+- `take_over_literal_paths` -- `take_over_path("res://...")` literal calls
+- `extends_paths` -- `extends "res://..."` paths
+- `extends_class_names` -- `extends ClassName` references (breaks override chains)
+- `class_names` -- own `class_name` declarations (interacts with Godot bug #83542)
+- `uses_dynamic_override` -- any `take_over_path(` call (superset)
+- `lifecycle_no_super` -- list of lifecycle methods (`_ready`, `_process`, etc.) in scripts with `extends` that don't call `super(`
+- `calls_base` -- `base(` -- Godot-3 pattern, usually a removed parent method
+- `preload_paths` -- all `preload("res://...")`
+- `override_methods` -- `extends_path -> [method_names]` for collision detection
+
+Consumed by downstream diagnostics and stored in `_mod_script_analysis`.
+
+### 5. Override timing warnings
+
+[conflict_report.gd:8 `_log_override_timing_warnings`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L8) (dev-only) logs which mods use `overrideScript()` -- those overrides only apply after scene reload:
+
+```
+<ModName> uses overrideScript() on: Controller.gd, Camera.gd
+  -- applies after scene reload
+```
+
+### 6. OverrideVerify (Layers A and B)
+
+Runs once after `frameworks_ready` from [hooks_api.gd:40](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L40).
+
+**Layer A -- cache-level check** ([conflict_report.gd:55-118](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L55)). For each mod that uses `overrideScript`, loads the target path post-autoloads and classifies by renamed-method prefix:
+
+- `_rtv_mod_*` methods present -> `OK: mod's script serves this path`
+- `_rtv_vanilla_*` only, `extends "res://Scripts/"` source -> `OK: mod's subclass serves this path (no method overrides -- inherits vanilla dispatch)`
+- Skip-listed vanilla + mod subclass -> `OK: skip-listed vanilla (<file>) -- mod subclass inherits unrewritten vanilla via Godot virtual dispatch`
+- `_rtv_vanilla_*` only, not a subclass -> `STALE: cache still serves vanilla -- overrideScript take_over_path did not win`
+- Neither prefix -> `UNKNOWN: neither _rtv_mod_ nor _rtv_vanilla_ methods -- rewrite likely did not run`
+
+**AutoloadInstanceProbe** ([conflict_report.gd:120-204](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L120)) inspects the 9 known autoloads (`Database, GameData, Settings, Menu, Loader, Inputs, Mode, Profiler, Simulation`). If any is stale (no `_rtv_mod_` methods on its live script), **auto-swaps** via `node.set_script(load(vanilla_path))` and re-classifies. Reports:
+
+- `OK: instance runs mod's body`
+- `FIXED via set_script swap -- <status>`
+- `BROKEN: instance holds ORPHAN script` (empty resource_path, swap attempted but didn't resolve)
+- `BROKEN: instance runs vanilla body`
+
+Matches RTVCoop's manual `set_script` pattern and Godot's own `reload_scripts` at `gdscript.cpp:2419`. See the comment at [conflict_report.gd:161-171](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L161).
+
+**Layer B -- node_added probe** ([conflict_report.gd:206-217](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L206)): arms `get_tree().node_added.connect(_on_override_probe_node_added)`. One-shot per vanilla path. Classifies instance scripts as they enter the tree.
+
+**Tree-walk fallback** ([conflict_report.gd:294 `_probe_tree_walk`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L294)): dev-mode only, scheduled at t+12s after `frameworks_ready`. Full scene-tree walk, covers cases where `node_added` missed a node. Dumps top 30 script paths by count.
+
+### 7. Live-probe hooks
+
+[hook_pack.gd:599-623](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L599) registers real hooks via the public `hook()` API on 8 well-known methods:
+
+| Hook | Fires |
+|---|---|
+| `loader-_physics_process-pre` | Every tick from game start |
+| `simulation-_process-pre` | Every tick |
+| `profiler-_process-pre` | Every tick |
+| `menu-_ready-pre` | Menu UI init |
+| `settings-loadpreferences-pre` | User loads preferences |
+| `controller-_physics_process-pre` | Every tick in world |
+| `character-_physics_process-pre` | Every tick in world |
+| `camera-_physics_process-pre` | Every tick in world |
+
+Counters live in `Engine.meta("_rtv_probe_counts")`. 30-second timer ([hook_pack.gd:755-820](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L755)) logs per-hook counts + first-arg samples.
+
+Verdict logs:
+
+- **DISPATCH-LIVE / DISPATCH-DEAD**: `"DISPATCH-LIVE: N wrapper call(s) in 30s"` (OK) or `"DISPATCH-DEAD: 0 wrapper calls in 30s -- game code not hitting rewrite"` (critical).
+- **HOOK-API-LIVE / HOOK-API-DEAD**: `"HOOK-API-LIVE: N callback fires total across probes -- full chain verified"` (OK) or `"HOOK-API-DEAD: 0 callback fires -- dispatch runs but _hooks lookup/callback is broken"` (critical).
+
+If DISPATCH-LIVE fires but HOOK-API-DEAD, the dispatch wrapper runs but callbacks aren't registered -- `_hooks` dict state broken. If DISPATCH-DEAD, the wrapper itself isn't running -- VFS mount or activation broken.
+
+### 8. AUTOLOAD-CHECK
+
+[hook_pack.gd:692-719](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L692) (dev-only). For each of the 9 known autoloads, logs:
+
+```
+[RTVCodegen] AUTOLOAD-CHECK <name>: script=<path> script_has_rename=<bool> instance_has_rename=<bool>
+```
+
+If `script_has_rename=true` but `instance_has_rename=false`, the autoload node is still holding a pointer to the old bytecode via its `get_script()` -- rewrite isn't reaching the actual game instance.
+
+### 9. IXP-VERIFY
+
+[hook_pack.gd:785-820](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L785) (inside the 30s timer, dev-only). For Controller / Camera / WeaponRig, finds the first instance via `_rtv_collect_nodes_by_class`, walks its extends chain up to depth 6, and logs:
+
+```
+[IXP-VERIFY] <class> instance script: path=<path> src_len=<n> ixp_content=<bool> rewrite_content=<bool>
+[IXP-VERIFY]   base[1]: path=<path> src_len=<n> ixp=<bool> rewrite=<bool>
+[IXP-VERIFY]   base[2]: ...
+```
+
+Detects ImmersiveXP markers (`"ImmersiveXP"`, `"IXP "`, `"overrideScript"`) to confirm IXP's `take_over_path` chain is intact. If IXP is active: instance script shows IXP markers, base chain walks IXP -> our rewrite -> engine class. If IXP failed: instance script is our rewrite directly (no IXP ancestor).
+
+### 10. Registry smoke probe
+
+**Always runs** (not gated on dev mode) at [hook_pack.gd:721-745](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L721). Verifies `Database._rtv_vanilla_scenes` is populated and `db.get(first_key)` returns a PackedScene. Warns on failure.
+
+### 11. Dispatch-live counters
+
+Every dispatch wrapper increments counters in `Engine.meta`:
+
+- `_rtv_dispatch_count` -- total wrapper calls this session
+- `_rtv_dispatch_no_lib` -- calls where `RTVModLib` meta was missing (fallback path)
+- `_rtv_dispatch_by_hook` -- dict of per-hook-base counts
+- First wrapper call per hook prints `"[RTV-WRAPPER-FIRST] <hook_base>"` exactly once
+
+These run regardless of dev mode but the 30s summary log is dev-only.
+
+## Dev-mode gate placement
+
+The gate is applied at the logging helper and at specific diagnostic entry points. The underlying telemetry (Engine meta counters, `_report_lines` append) runs unconditionally. Turning dev mode on in the UI surfaces the already-collected data; turning it off hides the summary logs but doesn't change loader behavior.
+
+## What dev mode does NOT change
+
+- Pass-1 / Pass-2 restart logic: same in both modes.
+- Hook pack generation + mount: same.
+- `RTVModLib` API: same.
+- Override.cfg writing: same.
+- Stability canary A / B / C alarms: always fire at their critical levels.
+
+Dev mode is strictly additive -- extra logging and probes, no behavior changes in the loading path itself.

--- a/docs/wiki/GDSC-Detokenizer.md
+++ b/docs/wiki/GDSC-Detokenizer.md
@@ -1,0 +1,155 @@
+# GDSC Detokenizer
+
+The loader needs source access to every vanilla `.gd` it rewrites. For exported games, Godot ships `.gdc` binary-tokenized bytecode, not source. `load(path).source_code` returns empty for tokenized scripts. The detokenizer at [src/gdsc_detokenizer.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd) reconstructs readable source from the binary format.
+
+## Supported versions
+
+`TOKENIZER_VERSION` 100 (Godot 4.0-4.4) and 101 (Godot 4.5-4.6). Version 102+ isn't supported -- [STABILITY canary B](Stability-Canaries#canary-b-gdsc-tokenizer-version) probes and refuses to generate a hook pack rather than cascading warnings through every script.
+
+## Binary format
+
+The `.gdc` file starts with a 12-byte header:
+
+| Offset | Bytes | Meaning |
+|---|---|---|
+| 0 | 4 | Magic `"GDSC"` ([gdsc_detokenizer.gd:13](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L13)) |
+| 4 | 4 | Version (u32, 100 or 101) |
+| 8 | 4 | Decompressed size (u32, 0 = uncompressed) |
+
+If decompressed size is non-zero, the rest of the file is ZSTD-compressed ([gdsc_detokenizer.gd:143](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L143)): `compressed.decompress(decompressed_size, FileAccess.COMPRESSION_ZSTD)`.
+
+### Metadata block
+
+V100 uses 20 bytes (4-byte padding), V101 uses 16 bytes:
+
+| Offset (v100) | Offset (v101) | Meaning |
+|---|---|---|
+| 0 | 0 | `ident_count` (u32) |
+| 4 | 4 | `const_count` (u32) |
+| 8 | 8 | `line_count` (u32) |
+| 16 | 12 | `token_count` (u32) |
+
+### Identifiers
+
+XOR-obfuscated UTF-32. Each identifier:
+
+```
+len (u32)
+char_0 (u32, XOR 0xb6 per byte before assembling)
+char_1 (u32, XOR 0xb6 per byte)
+...
+```
+
+Per-byte XOR happens before combining to a code point ([gdsc_detokenizer.gd:173-178](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L173)):
+
+```gdscript
+var b0 = buf[offset] ^ 0xb6
+var b1 = buf[offset+1] ^ 0xb6
+var b2 = buf[offset+2] ^ 0xb6
+var b3 = buf[offset+3] ^ 0xb6
+var code_point = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+```
+
+### Constants
+
+Variant-encoded, sequential. `bytes_to_var` doesn't report consumed size, so the detokenizer round-trips through `var_to_bytes` to advance the offset:
+
+```gdscript
+var val = bytes_to_var(remaining)
+constants.append(val)
+var encoded = var_to_bytes(val)
+offset += encoded.size()
+```
+
+### Line + column maps
+
+Two parallel sections, each `line_count * 8` bytes:
+
+```
+line_map: [(token_index: u32, line: u32), ...]
+col_map:  [(token_index: u32, column: u32), ...]
+```
+
+These are **load-bearing** for reconstruction -- v101 has no NEWLINE/INDENT/DEDENT/EOF tokens in the stream (unlike v100). Line breaks and indentation are derived from the maps, not from the tokens themselves. See [gdsc_detokenizer.gd:252-259](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L252).
+
+### Token stream
+
+Each token is 5 or 8 bytes depending on whether the high bit (`0x80`) is set on the first byte:
+
+```
+raw_type (u32 for 5-byte, or u32 for 8-byte)
+token_type = raw_type & 0x7F
+data_index = raw_type >> 8
+```
+
+Token type IDs ([gdsc_detokenizer.gd:18-27](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L18)):
+
+| Range | Category |
+|---|---|
+| 0-3 | EMPTY, ANNOTATION, IDENTIFIER, LITERAL |
+| 4-15 | Comparison + logical ops (`<`, `<=`, `==`, `!=`, `and`, `or`, `not`, `!`) |
+| 16-21 | Bitwise (`&`, `|`, `~`, `^`, `<<`, `>>`) |
+| 22-27 | Arithmetic (`+`, `-`, `*`, `**`, `/`, `%`) |
+| 28-39 | Assignment ops |
+| 40-50 | Control flow (`if`, `elif`, `else`, `for`, `while`, `break`, `continue`, `pass`, `return`, `match`, `when`) |
+| 51-72 | Declaration keywords (`as`, `assert`, `await`, `breakpoint`, `class`, `class_name`, `const`, `enum`, `extends`, `func`, `in`, `is`, `namespace`, `preload`, `self`, `signal`, `static`, `super`, `trait`, `var`, `void`, `yield`) |
+| 73-78 | Brackets (`[`, `]`, `{`, `}`, `(`, `)`) |
+| 79-87 | Punctuation (`,`, `;`, `.`, `..`, `...`, `:`, `$`, `->`, `_`) |
+| 88-90 | NEWLINE, INDENT, DEDENT (skipped in v101 reconstruction) |
+| 91-94 | PI, TAU, INF, NAN |
+| 99 | EOF |
+
+## Reconstruction
+
+[gdsc_detokenizer.gd:238 `_gdsc_reconstruct`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L238) walks the token stream and rebuilds text line-by-line:
+
+- `line_map[i]` tells the reconstructor when to advance to a new line (inserts blank lines if the next mapped line is more than one ahead).
+- First visible token on each line reads `col_map[i]` and converts to tabs: `tabs = col / 4`.
+- INDENT (89) / DEDENT (90) tokens are skipped -- column map handles indentation.
+- Spacing is emitted via two lookup tables: `_SPACE_BEFORE` (tokens needing leading space) and `_SPACE_AFTER` (trailing space). Identifiers + literals + annotations + any keyword get a leading space unless preceded by `(`, `[`, `.`, `$`, `~`, `!`, indent, or newline.
+
+Literal token types (strings, nodepaths, vectors, colors, etc.) go through [gdsc_detokenizer.gd:353 `_gdsc_variant_to_source`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L353):
+
+```gdscript
+TYPE_STRING      -> '"%s"' % value.c_escape()
+TYPE_STRING_NAME -> '&"%s"'
+TYPE_NODE_PATH   -> '^"%s"'
+TYPE_VECTOR2     -> "Vector2(%s, %s)"
+TYPE_COLOR       -> "Color(%s, %s, %s, %s)"
+# ...
+```
+
+Floats without `.` or `e` in the string form get a `.0` appended so the round-tripped source parses as float, not int.
+
+## Vanilla source cache
+
+The detokenizer caches reconstructed source under `user://modloader_hooks/vanilla/<path>`. Subsequent sessions skip the decode step.
+
+### Why never `load()` during detokenize
+
+Critical comment at [gdsc_detokenizer.gd:395-402](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L395):
+
+> IMPORTANT: do NOT call `load(script_path)` here, not even to "verify" the live script. Any `load()` triggers `ResourceFormatLoaderGDScript` to read the PCK's `.gdc` (via the PCK's stale `.gd.remap`) and cache the tokenized result at `script_path`. Subsequent hook-pack mounts + loads hit that cached entry instead of our rewrite. Cache must stay cold until the hook pack is mounted.
+
+The three-method raw-bytes read ([gdsc_detokenizer.gd:92-114](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L92)) uses `FileAccess` exclusively -- never `ResourceLoader`:
+
+1. `FileAccess.open(script_path, READ)` direct
+2. `FileAccess.open(ProjectSettings.globalize_path(script_path), READ)`
+3. `FileAccess.get_file_as_bytes(script_path.replace(".gd", ".gdc"))`
+
+### Stale-overlay paranoia check
+
+After detokenizing, [gdsc_detokenizer.gd:419-422](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L419) rejects source containing `_rtv_ready_done` or `Engine.get_meta("RTVModLib"` -- that would mean a prior-session overlay contaminated the input:
+
+```
+[Hooks] Detokenized source for <path> already contains rewrite markers
+  -- possible stale overlay. Delete <HOOK_PACK_DIR> and restart.
+```
+
+## Probe
+
+[gdsc_detokenizer.gd:437 `_probe_gdsc_version`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L437) reads the first 4 bytes from one of four known-readable vanilla scripts (`Camera.gd`, `Controller.gd`, `Audio.gd`, `AI.gd`), confirms the `"GDSC"` magic, and returns the version byte. Used by [STABILITY canary B](Stability-Canaries#canary-b-gdsc-tokenizer-version) to bail out cleanly on unsupported tokenizer formats.
+
+## Zero-byte entries
+
+Some vanilla `.gd` entries are zero bytes in the base game PCK (e.g. `CasettePlayer.gd` in RTV 4.6.1). Detected during PCK enumeration ([pck_enumeration.gd:214-223](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd#L214)) and recorded in `_pck_zero_byte_paths`. The detokenizer returns empty silently for these paths ([gdsc_detokenizer.gd:89-90](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L89)) rather than logging misleading "Cannot read bytes" warnings -- these files can't be hooked regardless.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,38 @@
+# Metro Mod Loader -- Developer Wiki
+
+Internal documentation for contributors to the community mod loader for Road to Vostok (Godot 4.6+).
+
+End-user install instructions and mod-author quick-start live in the repo [README](https://github.com/ametrocavich/vostok-mod-loader/blob/development/README.md). This wiki covers how the loader actually works inside.
+
+## Scope
+
+- How the two-pass launch works and why it exists
+- The `src/*.gd` module layout and what each file owns
+- The source-rewrite hook system (rewriter + hook pack + RTVModLib API)
+- The GDSC binary-tokenizer detokenizer
+- Stability canaries, crash recovery, safe mode, and sentinel files
+- Known Godot quirks the loader works around
+
+## Sections
+
+- [Architecture](Architecture) -- launch flow, two-pass restart, static-init mount, override.cfg lifecycle
+- [Modules](Modules) -- per-file tour of the `src/` tree
+- [Hooks](Hooks) -- RTVModLib API, source rewriter, hook pack generation + mount
+- [Mod-Format](Mod-Format) -- mod.txt schema, autoload `!` prefix, `[script_overrides]`, `[rtvmodlib] needs=`
+- [GDSC-Detokenizer](GDSC-Detokenizer) -- binary token format v100/v101, vanilla source cache
+- [Stability-Canaries](Stability-Canaries) -- A/B/C runtime probes, safe-mode + crash-recovery sentinels
+- [Build](Build) -- `build.sh` concat order, release-please, version bump flow
+- [Developer-Mode](Developer-Mode) -- what the dev flag unlocks, debug probes
+- [Limitations](Limitations) -- known Godot quirks, bug #83542, scene-preload defer, supported/unsupported patterns
+
+## Source-of-truth rules
+
+This wiki is generated from `docs/wiki/` in the main repo and synced to the GitHub Wiki via [.github/workflows/wiki-sync.yml](https://github.com/ametrocavich/vostok-mod-loader/blob/development/.github/workflows/wiki-sync.yml). To edit a page, PR changes to `docs/wiki/*.md` -- the wiki updates itself on merge.
+
+Every significant claim in these pages cites `src/<file>.gd:<line>`. If source drifts, the wiki is stale -- open an issue or submit a PR.
+
+## Target audience
+
+- **Contributors** wanting to understand what each module does before modifying it
+- **Mod authors** looking for deeper semantics than the README covers (e.g. why `!` prefixes on autoload values, when hooks actually fire)
+- **Anyone debugging** an unfamiliar boot-log entry, wondering which module emitted it

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -1,0 +1,217 @@
+# Hooks
+
+The hook system lets mods intercept vanilla method calls -- run code before/after, replace the implementation entirely, or receive a deferred callback. The public API matches tetrahydroc's RTVModLib mod exactly; the implementation under the hood is different.
+
+## Public API
+
+Mods reach the loader via `Engine.get_meta("RTVModLib")`. Source: [src/hooks_api.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+
+# Wait until all mod autoloads finished overrideScript calls.
+await lib.frameworks_ready
+
+var id = lib.hook("controller-_physics_process-pre", func(delta): print(delta), 100)
+lib.unhook(id)
+
+if lib.has_replace("weaponrig-shoot"):
+    print("another mod already replaced shoot")
+```
+
+### Methods
+
+| Method | Purpose |
+|---|---|
+| `hook(name, callback, priority=100) -> int` | Register a callback, return its id. Replace hooks are single-owner (returns -1 if already taken) |
+| `unhook(id) -> void` | Remove a hook by id (linear scan across all hook names) |
+| `has_hooks(name) -> bool` | Any callbacks registered at this name? |
+| `has_replace(name) -> bool` | Is a replace hook registered at this bare name? |
+| `get_replace_owner(name) -> int` | Returns id of the current replace owner, or -1 |
+| `skip_super() -> void` | Inside a replace callback: prevent the vanilla body from running on return |
+| `seq() -> int` | Monotonic dispatch counter, useful for tests |
+| `static version() -> String` | `MODLOADER_VERSION` |
+| `static major_version() -> int` | Parse major from `MODLOADER_VERSION` |
+| `static minor_version() -> int` | Same, minor |
+| `static patch_version() -> int` | Same, patch |
+
+### Signal
+
+- `frameworks_ready` -- emitted once after all mod autoloads finished. Mods that depend on overrideScript completion should `await` this.
+
+## Hook names
+
+Hook names follow this convention (documented at [constants.gd:102-103](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L102)):
+
+```
+<scriptname>-<methodname>[-pre|-post|-callback]
+```
+
+Both `scriptname` and `methodname` are lowercased. `scriptname` is the `.gd` filename without extension. For example, `res://Scripts/Controller.gd`'s `_physics_process` method lowercases to `controller-_physics_process`.
+
+Suffixes:
+
+| Suffix | Fires | Args | Return? |
+|---|---|---|---|
+| `-pre` | Before vanilla body (or before replace) | Same as the vanilla method | Ignored |
+| (none) | In place of vanilla. **First registration wins, subsequent registrations are rejected** (returns -1). Within a replace callback, call `lib.skip_super()` to suppress vanilla | Same as vanilla | Return value becomes the method's return |
+| `-post` | After vanilla (or after replace if no `skip_super`) | Same as vanilla | Ignored |
+| `-callback` | Deferred via `Callable.bindv(args).call_deferred()` | Same as vanilla | Ignored |
+
+## Dispatch semantics
+
+The dispatch wrapper template lives at [rewriter.gd:766](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L766). For every hookable vanilla method, the rewriter emits roughly this structure:
+
+```
+func <name>(args):
+    # Dispatch-live probes (increment Engine meta counters)
+    ...
+
+    var _lib = Engine.get_meta("RTVModLib") if Engine.has_meta("RTVModLib") else null
+    if !_lib:
+        return _rtv_vanilla_<name>(args)
+
+    # Global short-circuit: if no mod has ever called hook(), skip everything
+    if not _lib._any_mod_hooked:
+        return _rtv_vanilla_<name>(args)
+
+    # Re-entry guard: don't double-dispatch if a mod's wrapper calls super()
+    # into vanilla's wrapper
+    if _lib._wrapper_active.has("<hook_base>"):
+        return _rtv_vanilla_<name>(args)
+    _lib._wrapper_active["<hook_base>"] = true
+
+    _lib._caller = self
+    _lib._dispatch("<hook_base>-pre", [args])
+
+    var _result
+    var _repl = _lib._get_hooks("<hook_base>")
+    if _repl.size() > 0:
+        var _prev_skip = _lib._skip_super
+        _lib._skip_super = false
+        var _replret = _repl[0].callv([args])
+        var _did_skip = _lib._skip_super
+        _lib._skip_super = _prev_skip
+        if _did_skip:
+            _result = _replret
+        else:
+            _result = _rtv_vanilla_<name>(args)
+    else:
+        _result = _rtv_vanilla_<name>(args)
+
+    _lib._dispatch("<hook_base>-post", [args])
+    _lib._dispatch_deferred("<hook_base>-callback", [args])
+    _lib._wrapper_active.erase("<hook_base>")
+    return _result
+```
+
+Three performance / correctness features:
+
+- **Null-lib fallback**: if `RTVModLib` meta isn't set (loader not finished initializing, or loader failed), the wrapper calls the vanilla body directly. Increments `Engine.get_meta("_rtv_dispatch_no_lib")` counter.
+- **Global short-circuit** ([rewriter.gd:817](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L817)): `_lib._any_mod_hooked` is a sticky bool flipped true by the first `hook()` call. Dispatch wrappers skip every dict/function call when no mod has registered anything. Same approach as godot-mod-loader's `_ModLoaderHooks.any_mod_hooked`.
+- **Re-entry guard** ([rewriter.gd:819-821](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L819)): when a mod subclass's rewritten wrapper fires, its body calls `super()` into vanilla's rewritten wrapper. Without the guard, the vanilla wrapper would dispatch hooks again. The guard flips `_wrapper_active[hook_base]` = true on entry; nested re-entry at the same `hook_base` skips dispatch and runs the body directly. One dispatch per logical call regardless of chain depth.
+
+Void methods, coroutines (`await`), and engine lifecycle methods (`_ready` et al.) use structurally similar templates with appropriate adjustments -- `await` prepended to vanilla calls for coroutines, no `_result` for void, etc.
+
+## Hook registration, step-by-step
+
+Source: [hooks_api.gd:42-65](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L42).
+
+1. Detect replace vs. aspect: `is_replace = not (name ends_with "-pre/-post/-callback")`.
+2. If replace and `_hooks[name]` is non-empty: debug-log the rejection, return `-1`. (Debug-level, not warning -- rejection is normal API behavior per the comment at [hooks_api.gd:49-53](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L49). Promoting to `push_warning` spammed stderr for expected conflicts.)
+3. Create entry `{callback, priority, id}`, append to `_hooks[name]`, sort by priority ascending.
+4. Set `_any_mod_hooked = true` (sticky).
+5. Return `id`, increment `_next_id`.
+
+## Dispatch internals
+
+Source: [hooks_api.gd:101-122](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L101).
+
+```gdscript
+func _dispatch(hook_name: String, args: Array) -> void:
+    if not _hooks.has(hook_name):
+        return
+    var entries: Array = (_hooks[hook_name] as Array).duplicate()
+    for entry in entries:
+        _seq += 1
+        entry["callback"].callv(args)
+```
+
+The `.duplicate()` is load-bearing ([hooks_api.gd:104-108](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L104)): hooks that call `hook()` or `unhook()` mid-dispatch would otherwise mutate the live array during iteration. Snapshotting means new hooks registered during dispatch don't fire in the current dispatch -- they join the next one.
+
+`_dispatch_deferred` uses `callback.bindv(args).call_deferred()` instead, for `-callback` suffix hooks.
+
+## How the code generation works
+
+The loader does source rewriting. For each hookable vanilla script it:
+
+1. Detokenizes the `.gdc` bytecode to reconstructed source (see [GDSC-Detokenizer](GDSC-Detokenizer))
+2. Parses the source with [rewriter.gd:75 `_rtv_parse_script`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L75)
+3. Normalizes line endings (CRLF -> LF)
+4. Runs [rewriter.gd:625 `_rtv_autofix_legacy_syntax`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L625) -- bodyless blocks get `pass`, `tool`/`onready var`/`export var` get `@` annotations
+5. For Database.gd: calls [rewriter.gd:477 `_rtv_rewrite_database_constants`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L477) to convert `const X = preload(...)` entries into a `_rtv_vanilla_scenes` dict
+6. **Pass 1** ([rewriter.gd:380-404](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L380)): rename top-level `func <name>(` to `func _rtv_vanilla_<name>(`, and within renamed bodies rewrite bare `super(` to `super.<orig_name>(`
+7. **Pass 2** ([rewriter.gd:406-414](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L406)): append dispatch wrappers at end-of-file, one per hookable method
+8. For vanilla rewrites (not mod subclasses): call [rewriter.gd:430 `_rtv_registry_injection`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L430) -- currently only adds `_rtv_mod_scenes` / `_rtv_override_scenes` / `_get()` to Database.gd
+
+`_detect_indent_style` ([rewriter.gd:561](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L561)) inspects the source's first indented line to decide whether to emit the wrappers with tabs or spaces. GDScript rejects mixing tabs and spaces in one file; IXP uses 4-space indent, vanilla RTV uses tabs.
+
+## Three-entry pack recipe
+
+Each rewritten vanilla script ships as three zip entries ([hook_pack.gd:212-245](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L212)):
+
+| Entry | Purpose |
+|---|---|
+| `Scripts/<Name>.gd` | Rewritten source |
+| `Scripts/<Name>.gd.remap` | `[remap]\npath="res://Scripts/<Name>.gd"` -- overrides the PCK's `.gd.remap -> .gdc` redirect before GDScript loader runs |
+| `Scripts/<Name>.gdc` | Zero bytes -- Godot prefers a sibling `.gdc` at the same base path even after our remap; an empty `.gdc` can't parse, silently falls back to our `.gd` |
+
+This entire recipe lives in the hook pack zip at `user://modloader_hooks/framework_pack.zip`. The pack mounts with `replace_files=true`, which makes our entries win over the PCK's same-path entries in Godot's VFS layering.
+
+Mod subclass scripts ship **only** as `.gd` (no `.remap`, no `.gdc` shadow). Rationale at [hook_pack.gd:292-304](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L292): the shadow tricks are there to defeat the base game PCK's redirect; mod archives ship source-only, so shadows only change the load pathway from `(direct .gd compile)` to `(bytecode-fail -> .gd fallback)`. The latter triggers stricter re-parse that cascades into the mod's sibling preloads -- breaks mods whose code is valid under lenient first-compile but sloppy under strict (Gotcha #5 in [Limitations](Limitations)).
+
+## Mod subclasses (Step C)
+
+Mods that extend vanilla by path get the same treatment. [rewriter.gd:886 `_scan_mod_extends_targets`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L886) walks each enabled mod archive, looking for `.gd` files whose first non-trivial line is `extends "res://Scripts/<X>.gd"` where `<X>` is a vanilla script already being rewritten.
+
+Each match gets:
+
+- Parsed using the **vanilla** filename so `hook_base` is `"controller-*"` not `"immersivexp/controller-*"` (single hook namespace per vanilla)
+- Rewritten with `_rtv_mod_` prefix (not `_rtv_vanilla_`) -- keeps the mod's renamed body from shadowing vanilla's via virtual dispatch
+- Shipped at the mod's own `res://` path in the hook pack overlay
+
+The re-entry guard in the dispatch template is what makes the mod-wrapper-calls-super-into-vanilla-wrapper chain fire only once.
+
+## Database registry flow
+
+Source: [registry.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry.gd) + [rewriter.gd:439 `_rtv_inject_database_registry`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L439).
+
+1. Rewriter converts `const X = preload(...)` in vanilla Database.gd into `_rtv_vanilla_scenes["X"] = preload(...)` entries.
+2. Rewriter injects `_rtv_mod_scenes` + `_rtv_override_scenes` + a `_get(property)` override on Database.
+3. `_get()` lookup order: `_rtv_override_scenes` -> `_rtv_mod_scenes` -> `_rtv_vanilla_scenes` -> null.
+4. At runtime, mods call `lib.register(lib.Registry.SCENES, "my_item", scene)` or `lib.override(lib.Registry.SCENES, "Potato", better_scene)`.
+5. Vanilla game code calling `Database.get("Potato")` hits the injected `_get()` and resolves through the mod layer before falling back to vanilla.
+
+**Limitation**: direct constant access (`Database.Potato` property syntax) bypasses `_get()`. Mods must use `Database.get("Potato")`.
+
+After activation, the loader runs a registry smoke probe ([hook_pack.gd:721-745](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L721)) that loads Database, checks `_rtv_vanilla_scenes` is populated, and verifies `db.get(first_key) is PackedScene`.
+
+## Activation + fallback
+
+[hook_pack.gd:438 `_activate_rewritten_scripts`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L438) force-activates each rewritten script in Godot's ResourceCache.
+
+Scripts fall into one of three buckets:
+
+1. **Already live** -- static-init preload put our rewrite into the cache. Skip reload (would error with `"Cannot reload script while instances exist"` for autoload-backed Database / GameData / Inputs / Loader / Menu).
+2. **Pinned with source** -- GDScriptCache has our text but compiled methods are vanilla. Mutate `source_code` + `reload()`.
+3. **Pinned tokenized** -- PCK .gdc cached, static-init preload missed. After the `reload()` attempt fails verification, fall back to `ResourceLoader.load(path, "", CACHE_MODE_IGNORE)` + `take_over_path(path)`.
+
+Why the fallback matters ([hook_pack.gd:538-545](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L538)): for scripts originally compiled from `.gdc` bytecode (Camera, WeaponRig -- pre-compiled by the engine during startup because they're referenced by the initial scene graph), `reload()` doesn't re-parse from the mutated `source_code` -- it re-reads bytecode. `CACHE_MODE_IGNORE` goes through `_path_remap -> our .gd` with a fresh source compile.
+
+Scripts with module-scope `preload("res://...tscn|.scn")` are deferred from eager compile (the `_scripts_with_scene_preloads` set). VFS mount precedence still serves the rewrite when game code lazy-loads these paths after mod overrides have run -- this avoids baking Script ext_resources in scenes to the pre-override vanilla. See [Limitations](Limitations).
+
+## Related
+
+- [Stability-Canaries](Stability-Canaries) -- runtime probes that alarm when the dispatch chain breaks
+- [Limitations](Limitations) -- bug #83542, skip-listed scripts, scene preload deferral
+- [Mod-Format](Mod-Format) -- `[rtvmodlib] needs=` (no-op under source-rewrite), `[script_overrides]`

--- a/docs/wiki/Limitations.md
+++ b/docs/wiki/Limitations.md
@@ -1,0 +1,179 @@
+# Limitations
+
+Godot quirks and design constraints the loader works around or can't work around. Most of these were discovered at cost during development -- each section cites the session or bug that surfaced it.
+
+## Godot bug #83542 -- take_over_path on class_name scripts
+
+**Symptom**: calling `take_over_path` on a script that declares `class_name` corrupts Godot's ScriptServer `class_cache`. The first override may work; the second override (or access through the displaced original) can crash or return wrong behavior. For `class_name WeaponRig`: observed as a crash on knife draw.
+
+**Root cause**: `Resource::set_path` with `p_take_over=true` clears the old cached entry's `path_cache` but `global_name` (the `class_name` string) isn't cleared. ScriptServer ends up with the moved script's `class_name` colliding with the evicted original.
+
+**Mitigations in the loader**:
+
+- **Source-rewrite flow avoids it entirely** -- rewritten scripts ship at the original `res://Scripts/<Name>.gd` path, so there's no `take_over_path` on a class_name script. `class_name` stays intact because the rewritten script inherits the PCK's registration. This is the dominant path ([rewriter.gd:309-312](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L309)).
+- **Legacy `_register_override`** ([framework_wrappers.gd:105](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/framework_wrappers.gd#L105)) guards against this explicitly: if the parent script has a `get_global_name()`, it skips `take_over_path` and falls back to `node_added` swapping. Dead code in practice (see [Modules](Modules)) but the guard is there.
+- **Safety scanner** ([mod_loading.gd:409-414](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L409)) detects mods calling `take_over_path` on known class_name paths and logs `"DANGER: <file> calls take_over_path on class_name script <path> (<ClassName>) -- this will crash"` -- critical-level.
+
+**Watch out**: mods that do `script.take_over_path(vanilla_path)` on a vanilla `class_name` script bypass the rewrite system and will re-trigger #83542 in certain configurations. The loader can't safely intercept every such call.
+
+## Scripts deliberately not rewritten
+
+Runtime-sensitive scripts in `RTV_SKIP_LIST` at [constants.gd:47-55](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L47). Dispatch wrappers break their runtime semantics:
+
+| Script | Reason |
+|---|---|
+| `TreeRenderer.gd` | `@tool` script -- editor-only, no runtime hooks needed |
+| `MuzzleFlash.gd` | 50ms flash effect -- dispatch overhead breaks timing |
+| `Hit.gd` | Per-shot instantiated -- overhead compounds under fire |
+| `ParticleInstance.gd` | GPUParticles3D -- `set_script` corrupts draw_passes array |
+| `Message.gd` | await-based `_ready` -- dispatch wrapper doesn't await super, kills coroutine |
+| `Mine.gd` | `queue_free` after detonation -- wrapper lifecycle breaks timing |
+| `Explosion.gd` | await + @onready -- coroutine dies, particles don't emit |
+
+Hooks on methods in these scripts won't fire. Mods should hook alternative call sites.
+
+Resource-serialized scripts at [constants.gd:59-64](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L59) (save data -- `CharacterSave`, `ContainerSave`, `FurnitureSave`, `ItemSave`, `Preferences`, `ShelterSave`, `SlotData`, `SwitchSave`, `TraderSave`, `Validator`, `WorldSave`) aren't rewritten -- `ResourceSaver` embeds the script path into user save files, and wrapping the script would make saves mod-dependent.
+
+Data-resource scripts at [constants.gd:68-77](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L68) (25 entries: `AIWeaponData`, `AttachmentData`, `ItemData`, `LootTable`, `Recipes`, etc.) aren't rewritten -- they're loaded from `res://` only, have no call sites to intercept. Mods should hook the consumers instead.
+
+## Scene-preload deferred compile
+
+**Problem**: vanilla scripts with module-scope `preload("res://...tscn")` fire their preload chain at parse time. If that happens before mod autoloads run `overrideScript`, the scene bakes Script ext_resources to the pre-override vanilla script. When mods later `take_over_path`, the baked refs go empty-path -- subsequent `instantiate()` produces orphan-scripted nodes.
+
+**Detection**: [pck_enumeration.gd:137 `_collect_module_scope_scene_preloads`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd#L137) scans for column-0 `preload("res://X.tscn|.scn")`. Scripts with such preloads are added to `_scripts_with_scene_preloads`.
+
+**Workaround**: the activator ([hook_pack.gd:438](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L438)) skips eager compile for these scripts -- VFS mount precedence (`.gd` + `.gd.remap` + empty `.gdc`) still serves the rewrite when game code lazy-loads them AFTER mod overrides run.
+
+**Exception**: registry targets (currently `Database.gd`) MUST force-activate so the injected `_rtv_mod_scenes` / `_rtv_override_scenes` / `_get()` are live on the autoload instance when mods call `lib.register`. Registry targets don't have the ext_resource staleness problem because mods don't `take_over_path` them -- they use the registry API instead.
+
+See [hook_pack.gd:194-209](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L194).
+
+## Direct const access bypasses `_get()`
+
+The registry relies on Godot's `Node.get(name)` falling through to a script's `_get()` override when the name isn't a declared property. For `Database`:
+
+```gdscript
+# Rewriter converts these:
+const Potato = preload("res://path/Potato.tscn")
+# Into entries in _rtv_vanilla_scenes dict.
+
+# These calls route through the injected _get() (mod overrides applied):
+Database.get("Potato")
+Database["Potato"]
+
+# This one does NOT:
+Database.Potato
+```
+
+Direct property-syntax access to a `const` is resolved at compile time and bypasses `_get()`. Mods must use `Database.get(name)` to pick up registry overrides.
+
+Inline comment at [registry.gd:104-105](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry.gd#L104): "Vanilla game code doing `Database.get(name)` hits the injected `_get()` and resolves through the mod dicts before falling back to vanilla constants."
+
+## CRLF / LF mixing
+
+GDScript rejects files mixing `\r\n` and `\n` line endings with a misleading `"Expected indented block after 'X' block"` error (the real issue is the inconsistent endings, not indentation).
+
+ImmersiveXP ships CRLF-encoded source; the loader's appended wrappers use LF only. Before rewriting, [rewriter.gd:342-343](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L342) strips all CR:
+
+```gdscript
+var src = source.replace("\r\n", "\n").replace("\r", "\n")
+```
+
+## Tabs vs spaces
+
+GDScript also rejects mixed tabs and spaces in one file. IXP uses 4-space indent, vanilla RTV uses tabs. The dispatch wrapper has to match the file's existing style.
+
+[rewriter.gd:561 `_detect_indent_style`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L561) scans the first indented non-empty non-comment line and returns `"\t"` or `" ".repeat(n)`. Dispatch wrappers are generated with that indent.
+
+## Bodyless blocks
+
+Godot 4's parser rejects `if X:` with no indented body (a no-op the author got away with in Godot 3). Common in real-world RTV mods (e.g. AI Overhaul's `AwarenessSystem.gd`).
+
+Autofix: [rewriter.gd:652-676](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L652) scans for block headers (`if`/`elif`/`else`/`for`/`while`/`match`/`func`/`class`/`static func`). If the next non-blank non-comment line isn't indented deeper, injects a `pass` at `header_indent + indent_unit`:
+
+```gdscript
+if some_condition:
+	pass  # [Autofix] injected -- original block had no body
+```
+
+Also migrates `tool` -> `@tool`, `onready var` -> `@onready var`, `export var` -> `@export var`. Does NOT touch `export(Type) var` -- that needs type-annotation transform (left for a future pass).
+
+## `super()` rewriting
+
+When the rewriter renames `func CheckVersion():` to `func _rtv_vanilla_CheckVersion():` and the body contains bare `super()`, Godot's strict reload looks for `_rtv_vanilla_CheckVersion` on the parent -- which vanilla doesn't have. Result: reload failure.
+
+[rewriter.gd:517 `_rewrite_bare_super`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd#L517) rewrites bare `super(` to `super.<orig_name>(` inside renamed bodies. `super.OtherMethod()` passes through untouched (already explicit).
+
+## Windows backslash zip paths
+
+`ZipFile.CreateFromDirectory()` on Windows writes entries with backslash separators. Godot mounts the pack but can't resolve the paths.
+
+Detection at [mod_loading.gd:243-254](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L243):
+
+```
+BAD ZIP: <n> entries use Windows backslash paths.
+  Re-pack with 7-Zip. Example bad entry: 'MyMod\Main.gd'
+```
+
+Not auto-fixed -- users re-pack with 7-Zip or similar.
+
+## Mod-shadowed global_script_class_cache
+
+If a mod ships its own `res://.godot/global_script_class_cache.cfg` (e.g. MCM does), mounting it shadows the game's version with a 1-entry cache. [pck_enumeration.gd:21-26](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd#L21) detects this via a `size() < 10` heuristic and falls back to the hardcoded 58-entry class map.
+
+## Zero-byte PCK entries
+
+Base game ships some `.gd` entries as zero bytes (e.g. `CasettePlayer.gd` in RTV 4.6.1). Detokenize returns empty silently for these paths -- recorded in `_pck_zero_byte_paths` during PCK enumeration ([pck_enumeration.gd:214-223](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd#L214)). Not a loader failure; these files can't be hooked regardless.
+
+## `reload()` doesn't re-parse bytecode
+
+For scripts originally compiled from `.gdc` bytecode (Camera, WeaponRig -- pre-compiled during engine startup because they're referenced by the initial scene graph), mutating `script.source_code` and calling `reload()` doesn't re-parse from the new source -- `reload()` re-reads bytecode instead.
+
+Fallback at [hook_pack.gd:538-566](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L538): after `reload()`, verify the compiled method list has `_rtv_vanilla_*` entries. If not, `ResourceLoader.load(path, "", CACHE_MODE_IGNORE)` + `take_over_path(path)` -- `CACHE_MODE_IGNORE` goes through `_path_remap -> our .gd` with a fresh source compile.
+
+## `load_resource_pack` dedupes by path
+
+`ProjectSettings.load_resource_pack(same_path, true)` called twice in one session is a no-op the second time -- Godot dedupes by path. Used by the loader:
+
+- [boot.gd:554-568](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L554): `modloader.gd` mtime is in the state hash, so rebuilding the loader forces a restart. Without this, the new hook pack would be written but the old mount would serve its stale file offsets.
+- [lifecycle.gd:190-203](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L190): dev-mode test-pack re-apply copies the pack to a unique filename each time, because re-mounting the same path does nothing.
+
+## Class_name collision
+
+Mods that re-declare an existing game `class_name` at a different path trigger a fatal Godot error (`"Class X hides a global script class"`). Scanner at [mod_loading.gd:401-408](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L401) detects this and critical-logs:
+
+```
+CONFLICT: <mod_file> re-declares class_name <ClassName> (game has it at <path>)
+```
+
+Mod authors: don't use `class_name` names already defined in vanilla RTV. See the 58-entry hardcoded class map at [pck_enumeration.gd:33](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd#L33) for the conflict list.
+
+## FileAccess vs ResourceLoader inconsistency
+
+`FileAccess.file_exists()` can return false for `.gd` files inside mounted archives while `ResourceLoader.exists()` returns true for the same path. This is a Godot 4.6 quirk.
+
+Loader consistently uses `ResourceLoader.exists` for resource existence checks and `FileAccess.get_file_as_string` / `FileAccess.get_file_as_bytes` for reading bytes (bypasses ResourceLoader's caching).
+
+## autoload_prepend reverse-insertion
+
+`[autoload_prepend]` with multiple entries: **LAST listed loads FIRST** (reverse insertion). Non-obvious; trips people reading the config for the first time.
+
+The loader always puts `ModLoader="*res://modloader.gd"` last in `[autoload_prepend]` so it loads first. Mod early-autoloads listed above it load after. See [boot.gd:470-479](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L470) for the rationale.
+
+## Heartbeat timing window
+
+There's a narrow window where Pass 1 has written the heartbeat but the OS hasn't flushed to disk yet -- if the process force-quits in that window, the next launch won't see the heartbeat and won't know to recover. Unavoidable without `fsync` (which Godot doesn't expose via GDScript). Not worked around; rare enough in practice to not matter.
+
+## Hook pack file handle invalidation
+
+When a previous session's hook pack is mounted via `ProjectSettings.load_resource_pack`, Godot holds a `FileAccessZIP` handle to the file. `ZIPPacker.open` on the same path opens it for writing; on Windows, this invalidates the read handle once writes flush. VFS reads routing through the mount then fail at `file_access_zip.cpp:137` with "Cannot open file".
+
+Workaround ([hook_pack.gd:30-38](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L30)): the regen path doesn't delete the old pack file first (deletion would invalidate the handle immediately) -- `ZIPPacker.open` replaces atomically on save. Also: mod sibling reads happen BEFORE `ZIPPacker.open` is called on the new pack.
+
+## What's NOT supported
+
+- Scripts that call `take_over_path` on themselves to replace a non-class_name vanilla script generally work, but `class_name` vanillas are risky even after the engine bug #83542 warnings.
+- Hot-reload of mods without a full restart.
+- `export(Type) var` -> `@export var X: Type` auto-migration (the autofix doesn't handle typed exports).
+- Mods that add new `class_name` declarations that collide with vanilla.
+- Calling `lib.hook` before `frameworks_ready` from a mod that isn't an autoload -- mod scene scripts can't register hooks until the tree is up.

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -1,0 +1,159 @@
+# Mod Format
+
+A mod is a zip archive (`.vmz` or `.pck`, plus unpacked folders in developer mode). The archive contents mirror the game's `res://` tree -- a file at `MyMod/foo.gd` inside the zip ends up at `res://MyMod/foo.gd` after mounting.
+
+## Archive types
+
+| Extension | Mount mechanism | mod.txt | Autoloads | Update checking |
+|---|---|---|---|---|
+| `.vmz` | Copied to `user://vmz_mount_cache/<name>.zip` then `ProjectSettings.load_resource_pack` | Yes | Yes | Yes |
+| `.pck` | `ProjectSettings.load_resource_pack` directly | No | No | No |
+| folder | Zipped to `user://vmz_mount_cache/<name>_dev.zip` then mounted. **Developer mode only** | Yes | Yes | Yes |
+| `.zip` | **Rejected.** UI forces the checkbox off and warns "Rename this file from .zip to .vmz to use it" | | | |
+
+`.vmz` is the community convention -- Godot's ZIPReader won't open files with `.vmz` extension directly, so the loader copies them to `<name>.zip` in the cache dir first (see [fs_archive.gd:9 `_static_vmz_to_zip`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd#L9)). Re-extraction triggers when the source `.vmz` mtime is newer than the cache.
+
+## mod.txt
+
+A ConfigFile-format file at the root of the archive. All string values must be quoted (ConfigFile requires it).
+
+```ini
+[mod]
+name="My Mod"
+id="my_mod"
+version="1.0.0"
+priority=0
+
+[autoload]
+MyModMain="res://MyMod/Main.gd"
+EarlyNode="!res://MyMod/Early.gd"
+
+[updates]
+modworkshop=12345
+
+[script_overrides]
+"res://Scripts/SomeVanilla.gd"="res://MyMod/MyOverride.gd"
+
+[rtvmodlib]
+needs=["Controller", "Camera"]
+```
+
+### `[mod]` section
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `name` | string | filename | Display name in the UI |
+| `id` | string | filename | Unique id. Duplicates after the first loaded mod are skipped |
+| `version` | string | `""` | Used by the Updates tab to compare against ModWorkshop |
+| `priority` | int | 0 (or parsed from filename prefix) | Higher loads later, wins file conflicts. Clamped to `-999..999` |
+
+**VostokMods compat**: if the archive filename matches `^(-?\d+)-(.*)`, the numeric prefix is used as a fallback priority when `[mod] priority` isn't set. Example: `100-BetterAI.vmz` loads with `priority=100`. See [mod_discovery.gd:73-85](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L73).
+
+### `[autoload]` section
+
+```
+<autoload_name>="<path>"
+```
+
+Same shape as Godot's project-settings autoloads. Keys become node names in `/root/<name>`, values point to a `.gd` script or `.tscn` scene. Values may have a `*` prefix (deprecated Godot-3 syntax, stripped).
+
+**The `!` prefix** -- value starting with `!` marks the autoload as **early**:
+
+```ini
+[autoload]
+LateNode="res://MyMod/Late.gd"
+EarlyNode="!res://MyMod/Early.gd"
+```
+
+Early autoloads go into `override.cfg`'s `[autoload_prepend]` section, which means Godot loads them BEFORE the game's own autoloads. Late autoloads are instantiated by the loader after mounts land. The loader always puts itself (`ModLoader="*res://modloader.gd"`) last in `[autoload_prepend]`, and reverse-insertion order means it loads first.
+
+Early-autoload `.gd` scripts that only exist inside a mounted archive are extracted to `user://modloader_early/<path>` so Godot can find them before the restart completes its static-init mount. Scenes (`.tscn`) resolve via the file-scope mount directly. See [boot.gd:410 `_ensure_early_autoload_on_disk`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L410).
+
+Duplicate autoload names are logged and skipped (first wins). Paths not present in the archive's file set are logged as `"  Autoload path not found in archive"` with similar-path suggestions to help debug case/typo mistakes.
+
+### `[updates]` section
+
+| Key | Type | Meaning |
+|---|---|---|
+| `modworkshop` | int | ModWorkshop mod id. Enables the Updates tab for this mod |
+
+Version compare uses [mod_discovery.gd:138 `compare_versions`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L138) -- splits on `.`, strips `v`/`V` prefix, pads shorter side with `"0"`, lexicographic int comparison.
+
+### `[script_overrides]` section
+
+```
+"<vanilla_res_path>"="<mod_res_path>"
+```
+
+Full script replacement. The mod script is expected to `extends "<vanilla_res_path>"`. Applied by [mod_loading.gd:199 `_apply_script_overrides`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L199):
+
+1. Sort pending overrides by priority ascending.
+2. For each: `load(mod_path)` -> read `source_code` -> fresh `GDScript.new()` -> assign `source_code` -> `reload()` -> `take_over_path(vanilla_path)`.
+
+Processing in priority order means each subsequent override's `extends` resolves to the previous one, forming a natural chain `ModC -> ModB -> ModA -> vanilla`.
+
+**Interaction with the hook system**: if a script listed in `[script_overrides]` is also a hook target (most vanilla scripts are), the override displaces the rewrite at that path. Hooks won't fire for nodes using the override. The loader warns: `"[RTVCodegen] <path> is rewritten and also overridden by <mods> -- override displaces the rewrite, hooks won't fire for that path"` ([hook_pack.gd:175-177](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L175)).
+
+### `[rtvmodlib]` section
+
+```ini
+[rtvmodlib]
+needs=["Controller", "Camera"]
+```
+
+Declares which vanilla "frameworks" (class_name scripts) the mod wants hooks into. **No-op under source-rewrite** -- the loader already rewrites every hookable vanilla script regardless of `needs=`. Kept for compatibility with tetrahydroc's standalone RTVModLib mod.
+
+The loader logs `"[RTVModLib] [rtvmodlib] needs declarations are no-op under source-rewrite (%d frameworks requested; all hookable scripts already dispatched via hook pack)"` when mods declare this.
+
+See [framework_wrappers.gd:49](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/framework_wrappers.gd#L49) for the dead-code note.
+
+## mod.txt validity states
+
+Tracked per-entry in `_last_mod_txt_status` (see [fs_archive.gd:147 `read_mod_config`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd#L147)):
+
+| Status | Meaning | UI warning |
+|---|---|---|
+| `ok` | Parse succeeded | -- |
+| `none` | No mod.txt at archive root | "Invalid mod -- may not work correctly. Try re-downloading." |
+| `nested:<path>` | `mod.txt` exists but not at root (e.g. in `SubFolder/mod.txt`) -- bad packaging | "Invalid mod -- packaged incorrectly. Try re-downloading." |
+| `parse_error` | ConfigFile.parse failed | "Invalid mod -- may not work correctly. Try re-downloading." |
+| `pck` | N/A (PCK skips mod.txt read) | -- |
+
+UTF-8 BOM is stripped before parsing ([fs_archive.gd:192](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd#L192)) so files saved from Windows editors don't trip ConfigFile.
+
+## Archive packaging gotchas
+
+### Windows backslash paths
+
+Zips repacked via `ZipFile.CreateFromDirectory()` on Windows often write entries with backslash separators (`MyMod\Main.gd` instead of `MyMod/Main.gd`). Godot mounts the pack but can't resolve those paths. Detected during scan ([mod_loading.gd:243-254](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L243)):
+
+```
+BAD ZIP: <n> entries use Windows backslash paths.
+  Re-pack with 7-Zip. Example bad entry: 'MyMod\Main.gd'
+```
+
+### Nested mod.txt
+
+If `mod.txt` isn't at the archive root, packaging is wrong -- the archive probably has an unnecessary wrapper folder. The loader refuses to treat this as a valid mod.
+
+### Database.gd collision
+
+Mods that ship their own `res://Scripts/Database.gd` are flagged:
+
+- First mod wins -- `"  DATABASE OVERRIDE: <mod> replaces Database.gd"`
+- Subsequent mods -- `"  DATABASE COPY: <mod> bundles a private Database.gd at <path>"` + `"    Hardcoded preload() paths may break if companion mods aren't present."`
+
+See [mod_loading.gd:296-302](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L296). Mods should generally use [`lib.register` / `lib.override`](Hooks#database-registry-flow) instead of shipping a full Database replacement.
+
+## File-conflict resolution
+
+When multiple mods claim the same `res://` path, the one with highest priority wins (last to mount, `replace_files=true`). Conflicts are logged to the dev-mode conflict summary (see [Developer-Mode](Developer-Mode)):
+
+```
+--- Conflicted Paths (last loader wins) ---
+CONFLICT: res://Scripts/SomeFile.gd
+    [1] ModA via ModA.vmz
+    [2] ModB via ModB.vmz <-- wins
+```
+
+Within equal priority, load order is stable: mod_name ascii-lowercase, then filename. See [mod_discovery.gd:127 `_compare_load_order`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L127).

--- a/docs/wiki/Modules.md
+++ b/docs/wiki/Modules.md
@@ -1,0 +1,184 @@
+# Modules
+
+Tour of the `src/` tree. Order follows `build.sh`'s `FILES` array, which is the concat order used to produce `modloader.gd`. Dependencies flow top-down -- earlier files may not reference code defined later.
+
+## Fundamentals
+
+### [header.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/header.gd)
+
+10 lines. Top-of-file doc comment plus `extends Node`. This is the only `extends` in the compiled `modloader.gd` -- `build.sh` enforces that invariant.
+
+### [constants.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd)
+
+All module-scope `const`, `var`, and `signal` declarations. Everything has to land here so it's declared before any function body references it. Notable residents:
+
+- `MODLOADER_VERSION` at [constants.gd:13](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L13) -- release-please bumps this via Conventional Commits, bracketed by `x-release-please-start/end` markers
+- `RTV_SKIP_LIST` (7 scripts), `RTV_RESOURCE_SERIALIZED_SKIP` (11), `RTV_RESOURCE_DATA_SKIP` (25) -- scripts the rewriter refuses to touch, each with inline rationale
+- `_filescope_mounted := _mount_previous_session()` at [constants.gd:161](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L161) -- a module-scope var with a function-call initializer. This is what triggers the static-init mount before `_ready`
+
+### [logging.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/logging.gd)
+
+Four helpers: `_log_info`, `_log_warning`, `_log_critical`, `_log_debug`. Each prefixes `[ModLoader][Level] ` and appends to `_report_lines` (later written to `user://modloader_conflicts.txt`). `_log_debug` is gated on `_developer_mode`.
+
+## File + archive helpers
+
+### [fs_archive.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd)
+
+Pure disk I/O. No game logic. VMZ-to-ZIP conversion, mod.txt parsing, zip packing for dev-mode folder mods, `.remap` resolution post-mount, path normalization for tracked extensions.
+
+Includes both static functions (callable from static init before instance state exists) and instance functions.
+
+## Static-init boot layer
+
+### [boot.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd)
+
+The largest domain. Owns:
+
+- `_mount_previous_session` at [boot.gd:32](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L32) -- the static-init entry point triggered by `constants.gd:161`
+- Sentinel handling (disabled, safe mode, Pass 2 dirty marker)
+- `override.cfg` reading + writing (`_write_override_cfg`, `_restore_clean_override_cfg`)
+- Pass state persistence (`_write_pass_state`, `_compute_state_hash`)
+- Heartbeat + crash-recovery logic
+- Hook-cache wiping
+- Early-autoload disk extraction (`_ensure_early_autoload_on_disk`)
+- Stale cache cleanup
+
+See [Architecture](Architecture) for the control flow.
+
+## Discovery + loading
+
+### [mod_discovery.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd)
+
+Scans `<exe>/mods/`, parses mod.txt metadata, handles ModWorkshop version checks and downloads. No mounting -- that's `mod_loading`.
+
+- `collect_mod_metadata` at [mod_discovery.gd:7](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L7) -- the main scanner
+- `compare_versions` -- semver-ish with `v` prefix tolerance
+- `fetch_latest_modworkshop_versions` / `download_and_replace_mod` -- chunked HTTP against `api.modworkshop.net`
+
+### [mod_loading.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd)
+
+Runtime loading pipeline. Mounts archives, scans .gd files for safety issues, registers file-claims, instantiates autoloads, applies `[script_overrides]`.
+
+- `load_all_mods` at [mod_loading.gd:7](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L7) -- entry point
+- `_process_mod_candidate` at [mod_loading.gd:54](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L54) -- per-mod pipeline
+- `_apply_script_overrides` at [mod_loading.gd:199](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_loading.gd#L199) -- sorts by priority asc, `load` + `source_code` + fresh `GDScript.new()` + `reload` + `take_over_path`
+- `scan_and_register_archive_claims` -- detects Windows-backslash zip paths, Database.gd collisions, builds per-file analysis
+- `_instantiate_autoload` -- dispatches PackedScene vs GDScript vs other
+
+### [conflict_report.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd)
+
+Developer-mode diagnostics. Most functions only run when `_developer_mode = true`, except `_print_conflict_summary` + `_write_conflict_report` which always run but filter logs.
+
+Two-layer override verification:
+
+- **Layer A** (`_verify_script_overrides` at [conflict_report.gd:53](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L53)): cache-level check. Loads each declared override target post-autoloads, inspects method names for `_rtv_mod_` / `_rtv_vanilla_` rename prefixes to classify the cache state
+- **Autoload instance check** at [conflict_report.gd:120-204](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/conflict_report.gd#L120): auto-swaps stale autoload instances via `node.set_script(load(ap))`. Matches RTVCoop's manual pattern and Godot's own `reload_scripts` at `gdscript.cpp:2419`
+- **Layer B** (`_on_override_probe_node_added`): one-shot-per-path instance probe armed on `get_tree().node_added`
+- **Tree-walk fallback** (`_probe_tree_walk`): scheduled 12s after `frameworks_ready`, full scene-tree walk for cases `node_added` missed
+
+## UI
+
+### [ui.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd)
+
+Pre-game launcher window. Two tabs (Mods, Updates), dark theme, Reset-to-Vanilla action. Closing the window equals clicking Launch Game.
+
+- `show_mod_ui` at [ui.gd:70](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L70)
+- `build_mods_tab` / `build_updates_tab` -- tab content
+- `make_dark_theme` -- Theme resource with pure-black backgrounds
+- `_reset_to_vanilla_and_restart` -- unchecks every mod, calls `_static_force_vanilla_state`, strips `--modloader-restart` from cmdline so the relaunch is a clean Pass 1
+
+## Public API
+
+### [hooks_api.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd)
+
+The public surface mods call via `Engine.get_meta("RTVModLib")`. Version accessors, `hook`/`unhook`/`has_hooks`/`has_replace`/`get_replace_owner`/`skip_super`/`seq`, plus the internal `_dispatch` / `_dispatch_deferred` helpers used by generated wrappers.
+
+See [Hooks](Hooks) for the full API + semantics.
+
+### [registry.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry.gd)
+
+Public registry verbs: `register`, `override`, `patch`, `remove`, `revert`. Currently only `Registry.SCENES` (on `Database` autoload) is active; inline comments reserve slots for items, loot, recipes, events, sounds, etc.
+
+Per-registry handlers talk to dicts the rewriter injected into vanilla scripts -- `Database.gd` gets `_rtv_vanilla_scenes` / `_rtv_mod_scenes` / `_rtv_override_scenes` + a `_get()` override that routes `Database.get(name)` through the mod layer before vanilla.
+
+**Limitation**: direct constant access (`Database.Potato`) bypasses `_get()`. Mods must use `Database.get("Potato")` to hit the registry.
+
+### [framework_wrappers.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/framework_wrappers.gd)
+
+**Mostly dead code.** The legacy `[rtvmodlib] needs= -> Framework<X>.gd subclass -> node_added` path. Source-rewrite replaced it.
+
+Live:
+- `_collect_needed_from_mods` -- still parses `[rtvmodlib] needs=` across enabled mods
+- `_rtv_collect_nodes_by_class` -- tree walk used by post-activation IXP-VERIFY probe in hook_pack
+
+Dead (marked with "DEAD-LOOP" / "DEAD CODE" comments, verified 2026-04-19):
+- `_activate_hooked_scripts` -- body loop never enters `_register_override` because `Framework<X>.gd` files are no longer generated
+- `_register_override`, `_connect_node_swap`, `_on_node_added`, `_deferred_swap` -- chain never fires
+
+Scheduled for removal; kept as scaffolding in case the Framework-subclass path ever needs revival.
+
+## Codegen pipeline
+
+### [gdsc_detokenizer.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd)
+
+Reads Godot's binary-tokenized `.gdc` scripts and reconstructs source. Required because `load().source_code` is empty for tokenized scripts. Covers TOKENIZER_VERSION 100 (Godot 4.0-4.4) and 101 (Godot 4.5-4.6).
+
+Also owns the vanilla-source cache under `user://modloader_hooks/vanilla/` -- the cache is cold until the hook pack is mounted, to prevent `ResourceFormatLoaderGDScript` from caching the PCK's tokenized result at the rewrite path.
+
+See [GDSC-Detokenizer](GDSC-Detokenizer) for the binary format.
+
+### [pck_enumeration.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/pck_enumeration.gd)
+
+PCK introspection. Parses the game's `RTV.pck` file table to enumerate every `res://Scripts/*.gd` -- `DirAccess.get_files_at()` returns 0-1 entries for PCK-backed paths in Godot 4.6.
+
+- `_build_class_name_lookup` -- loads `res://.godot/global_script_class_cache.cfg`, falls back to a 58-entry hardcoded map if the cache is missing or shadowed by a mod that ships its own 1-entry cache
+- `_enumerate_game_scripts` -- parses PCK, normalizes `.gdc` / `.gd.remap` to `.gd`, filters to `res://Scripts/`, tracks zero-byte entries into `_pck_zero_byte_paths` (base game ships e.g. empty `CasettePlayer.gd` in RTV 4.6.1)
+- `_collect_module_scope_scene_preloads` -- column-0 `preload("res://...tscn|.scn")` matches, used to decide which rewritten scripts get deferred from eager compile
+
+### [rewriter.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/rewriter.gd)
+
+Source-rewrite codegen. Given detokenized vanilla source + a parse structure:
+
+- Renames each non-static method `Foo` to `_rtv_vanilla_Foo` (or `_rtv_mod_Foo` for mod subclasses)
+- Appends a dispatch wrapper at the original name that fires pre/replace/post/callback hooks then calls the renamed body
+- Rewrites bare `super()` inside renamed bodies to `super.<orig_name>()` so the parent's dispatch wrapper resolves (Gotcha #2 in Limitations)
+- Autofixes legacy GDScript 3 syntax: bodyless blocks get a `pass`, `tool`/`onready var`/`export var` get the `@` annotation
+- For `Database.gd`: converts top-level `const X = preload(...)` into a `_rtv_vanilla_scenes` dict entry, injects `_get()` override
+
+Also owns `_scan_mod_extends_targets` -- scans mod archives for `.gd` files whose first non-trivial line is `extends "res://Scripts/<X>.gd"` where `<X>` is a vanilla script already rewritten. Those mod scripts get the same rename+dispatch treatment (with `_rtv_mod_` prefix) shipped at their own res:// path.
+
+See [Hooks](Hooks) for details.
+
+### [hook_pack.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd)
+
+Orchestrates the full rewrite pipeline:
+
+1. Verify GDSC tokenizer version (STABILITY canary B)
+2. Enumerate game scripts
+3. Pre-read mod sibling scripts (before `ZIPPacker.open` invalidates existing VFS handles)
+4. Rewrite each vanilla script, pack as three entries: `Scripts/<Name>.gd` + `.gd.remap` + empty `.gdc` (the recipe that beats the PCK's bytecode)
+5. Rewrite mod subclasses with `_rtv_mod_` prefix
+6. Pack autofixed mod siblings into the overlay
+7. Add VFS canary file (STABILITY canary C)
+8. Mount `user://modloader_hooks/framework_pack.zip` with `replace_files=true`
+9. Verify the canary reads back
+10. Activate: walk each rewritten script, reload or fall back to `CACHE_MODE_IGNORE + take_over_path`
+11. Persist hook pack path to pass state for next session's static-init mount
+
+See [Hooks](Hooks) + [Stability-Canaries](Stability-Canaries).
+
+## Orchestration
+
+### [lifecycle.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd)
+
+Top-level entry point. `_ready` dispatches to `_run_pass_1` or `_run_pass_2`. Finish helpers (`_finish_with_existing_mounts`, `_finish_single_pass`) wrap the non-restart paths by instantiating queued autoloads, running dev-mode diagnostics, calling `_emit_frameworks_ready`, and triggering `reload_current_scene` if anything mounted.
+
+See [Architecture](Architecture).
+
+## Temporary scaffolding
+
+### [debug.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/debug.gd)
+
+Gated behind `[settings] test_pack_precedence = true` in `user://mod_config.cfg`. Default config has no such key, so the entire subsystem is a no-op unless the user explicitly sets it.
+
+Contents: `_test_pack_precedence` (Pass 1 pack-precedence exercise) + `_test_post_autoload_verify` (deferred verify 1s after autoloads). Header comment: "Removable once the rewrite system is proven stable in production."

--- a/docs/wiki/Stability-Canaries.md
+++ b/docs/wiki/Stability-Canaries.md
@@ -1,0 +1,142 @@
+# Stability Canaries
+
+Boot-time probes that alarm loudly when something the loader depends on silently regresses. The design principle: silent breakage is the worst mode, because mods fail in non-obvious ways. One loud actionable log line beats a flood of downstream symptom warnings.
+
+## Canary A: COMPILE-PROOF
+
+**Location**: [hook_pack.gd:658-684](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L658)
+
+**Probes**: after `_activate_rewritten_scripts` completes, inspects `get_script_method_list()` for each rewritten vanilla. The presence of any `_rtv_vanilla_*` method name confirms the rewrite compiled into the cached GDScript.
+
+**Alarm levels**:
+
+- **Zero of N rewrites active** -> critical:
+  ```
+  [STABILITY] ALL N rewrites failed to take effect -- VFS mount, hook pack, or cache eviction is broken.
+  Mods will NOT work this session. Click 'Reset to Vanilla' in the UI
+  or create modloader_disabled in the game folder.
+  ```
+- **Any critical script failed** -> critical. The critical set ([hook_pack.gd:662-664](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L662)): `Controller.gd, Camera.gd, WeaponRig.gd, Door.gd, Trader.gd, Hitbox.gd, LootContainer.gd, Pickup.gd`
+  ```
+  [STABILITY] Hook rewrites missing on critical scripts: <list>.
+  Hooks on these scripts will NOT fire this session
+  (likely cache-pinning fallback failure).
+  ```
+- **Everything OK** -> info summary line with per-bucket counts:
+  ```
+  [STABILITY] COMPILE-PROOF summary: N/M rewrites active (K pinned-fallback), X deferred to lazy-compile
+  ```
+
+**Why it matters**: the activation flow has a fallback path (`CACHE_MODE_IGNORE + take_over_path`) for PCK-pre-compiled scripts. If that fallback fails, this canary is the only signal that hooks won't fire for those scripts -- `hook()` calls still succeed, dispatch machinery still runs, it just never intercepts anything.
+
+## Canary B: GDSC tokenizer version
+
+**Location**: [hook_pack.gd:50-60](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L50) + [gdsc_detokenizer.gd:437 `_probe_gdsc_version`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/gdsc_detokenizer.gd#L437)
+
+**Probes**: reads the first 4 bytes of a known-readable vanilla `.gd`/`.gdc` (Camera, Controller, Audio, AI), confirms `"GDSC"` magic, and returns the version byte.
+
+**Alarm levels**:
+
+- Not 100 or 101 (and not -1 for "file not tokenized") -> critical:
+  ```
+  [STABILITY] Unsupported GDSC tokenizer vN on Godot <version>.
+  This ModLoader supports v100 (Godot 4.0-4.4) and v101 (Godot 4.5-4.6).
+  Hook pack generation disabled -- script hooks will not fire.
+  See README for supported Godot versions.
+  ```
+- Supported -> info: `[STABILITY] Detokenizer compatible: GDSC vN on Godot <version>`.
+
+**Why it matters**: if Godot ships a v102 tokenizer in a future release, the detokenizer would cascade "Empty detokenized source" warnings through every hookable script and silently fall back to vanilla. Canary B short-circuits at the start of hook pack generation with one actionable message.
+
+## Canary C: VFS mount precedence
+
+**Location**: write at [hook_pack.gd:366-374](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L366), readback at [hook_pack.gd:404-412](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L404)
+
+**Probes**: adds a tiny known-content file `__modloader_canary__.txt` to the hook pack zip, with content `"MODLOADER-VFS-CANARY-" + MODLOADER_VERSION`. After mounting the pack, reads the file back via `FileAccess.get_file_as_string("res://__modloader_canary__.txt")`.
+
+**Alarm levels**:
+
+- Canary content missing or wrong -> critical:
+  ```
+  [STABILITY] VFS canary FAILED (got '<prefix>', expected MODLOADER-VFS-CANARY-*)
+  -- hook pack mounted but files aren't served. Rewrites will not take effect this session.
+  ```
+- Canary readable -> info: `[STABILITY] VFS canary OK: hook pack mount precedence verified (<content>)`.
+
+**Why it matters**: `ProjectSettings.load_resource_pack` can return true while the resulting mount doesn't actually serve files (stale handles, format mismatch, etc.). Canary C verifies mount precedence independently of the rewrite pipeline. If the canary fails, no script rewrite will take effect regardless of anything downstream.
+
+## Escape hatches
+
+### modloader_disabled sentinel
+
+**Path**: `<exe_dir>/modloader_disabled` (in the game folder, not `user://`)
+
+**Effect**: the loader's static init detects this file and skips everything -- no mounts, no UI, no autoloads. The game runs as if the loader weren't installed. Also force-resets persistent state (override.cfg, pass state, hook pack) for the NEXT launch.
+
+**Check**: [boot.gd:8 `_is_modloader_disabled`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L8), handled at [boot.gd:41-44](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L41).
+
+**When to use**: the loader itself is broken and the UI can't load. User creates this file manually, then removes it to re-enable.
+
+### modloader_safe_mode sentinel
+
+**Path**: `<exe_dir>/modloader_safe_mode`
+
+**Effect**: on next boot, wipes pass state + resets `override.cfg` to clean baseline + deletes heartbeat + removes the sentinel file. Then normal Pass 1 proceeds, so the UI appears.
+
+**Check**: [boot.gd:596 `_check_safe_mode`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L596), runs from within Pass 1.
+
+**When to use**: mods are broken but the loader itself works. User removes misbehaving mods via the UI on next launch.
+
+### UI Reset-to-Vanilla button
+
+**Location**: bottom bar of the launcher UI, left of Launch Game.
+
+**Effect**: unchecks every mod in memory, saves config, calls `_static_force_vanilla_state` (same cleanup as the disabled sentinel), strips `--modloader-restart` from cmdline args, and restarts the game clean.
+
+**Source**: [ui.gd:48 `_reset_to_vanilla_and_restart`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L48).
+
+**When to use**: mods loaded but the game crashes or behaves badly. User clicks the button, gets a guaranteed vanilla next launch.
+
+## Crash recovery
+
+### Heartbeat
+
+**File**: `user://modloader_heartbeat.txt`
+
+**Lifecycle**:
+- Written just before the Pass-1-to-Pass-2 restart ([boot.gd:571 `_write_heartbeat`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L571))
+- Deleted at the end of Pass 2 cleanup ([boot.gd:577 `_delete_heartbeat`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L577))
+
+**Detection**: next launch's Pass 1 checks for the file at [boot.gd:581 `_check_crash_recovery`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L581). Presence means the previous launch didn't complete.
+
+### Restart counter
+
+**Key**: `[state] restart_count` in `user://mod_pass_state.cfg`
+
+**Increment**: `_write_pass_state` ([boot.gd:519](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L519)) bumps on each write.
+
+**Force-reset**: when `restart_count >= MAX_RESTART_COUNT` (2), `_check_crash_recovery` logs `"Restart loop (N crashes) -- resetting to clean state"`, restores clean `override.cfg`, deletes pass state, deletes heartbeat.
+
+**Reset to zero**: Pass 2 cleanup calls `_clear_restart_counter` ([boot.gd:649](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L649)) on successful completion.
+
+### Pass 2 dirty marker
+
+**File**: `user://modloader_pass2_dirty`
+
+**Lifecycle**:
+- Written first thing in `_run_pass_2` ([lifecycle.gd:164-167](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L164)) with current timestamp
+- Deleted after Pass 2 reaches its cleanup block ([lifecycle.gd:232-233](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L232))
+
+**Detection**: static init at `_mount_previous_session` checks for the file at [boot.gd:50-53](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L50). Presence means Pass 2 was interrupted (force-quit, crash, power loss) -- hook pack may be half-written, pass state + override.cfg reference untrustworthy state. Full wipe via `_static_force_vanilla_state("pass 2 crashed mid-run", ...)`.
+
+## Combined recovery flow
+
+If something goes wrong mid-run, the order of defenses is:
+
+1. **Crash during Pass 2** -> `modloader_pass2_dirty` survives -> static init wipes on next boot, user gets clean Pass 1.
+2. **Crash during Pass 1 before restart** -> heartbeat survives but pass state wasn't written -> next boot sees heartbeat + no restart mismatch, just deletes heartbeat and continues normally.
+3. **Two Pass 2 crashes in a row** -> `restart_count >= 2` + heartbeat -> `_check_crash_recovery` force-resets, user gets clean Pass 1.
+4. **User created `modloader_safe_mode`** -> Pass 1 `_check_safe_mode` wipes state, continues to UI.
+5. **User created `modloader_disabled`** -> static init skips everything, loader is idle for this session. User removes the file to re-enable.
+
+Nothing asks Godot to "just try again" without resetting state -- compounding retries across a persistent fault is how you get a game that won't boot without a manual reinstall.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,17 @@
+### Metro Mod Loader
+
+**Wiki**
+- [Home](Home)
+- [Architecture](Architecture)
+- [Modules](Modules)
+- [Hooks](Hooks)
+- [Mod-Format](Mod-Format)
+- [GDSC-Detokenizer](GDSC-Detokenizer)
+- [Stability-Canaries](Stability-Canaries)
+- [Build](Build)
+- [Developer-Mode](Developer-Mode)
+- [Limitations](Limitations)
+
+**Repo**
+- [README](https://github.com/ametrocavich/vostok-mod-loader/blob/development/README.md)
+- [CONTRIBUTING](https://github.com/ametrocavich/vostok-mod-loader/blob/development/CONTRIBUTING.md)


### PR DESCRIPTION
## Summary

- Adds `docs/wiki/` with 11 markdown pages covering loader internals: architecture, modules, hooks, mod format, GDSC detokenizer, stability canaries, build flow, developer mode, limitations (plus Home and _Sidebar).
- Every non-trivial claim cites `src/<file>.gd#L<line>`. All function line numbers, const values, log strings, and list counts were grep-verified against source during a fact-check pass; 2 errors caught and fixed (`RTV_RESOURCE_DATA_SKIP` count 27->25, hardcoded class map 60->58).
- Adds `.github/workflows/wiki-sync.yml` to mirror `docs/wiki/` into the GitHub Wiki git repo on push to `development` or `master`. Uses the default `GITHUB_TOKEN` scoped to `contents: write` -- no PAT needed since the wiki is considered part of the repo's content scope.

Contributors edit `docs/wiki/*.md` via normal PR flow; wiki updates itself on merge.

## Test plan

- [ ] Merge this PR to `development`.
- [ ] Confirm the `wiki-sync` action run appears under Actions and completes successfully.
- [ ] Open the Wiki tab and verify `Home`, `Architecture`, `Hooks`, `Mod-Format`, `Limitations` etc. appear with correct content.
- [ ] Verify the sidebar renders (from `_Sidebar.md`).
- [ ] Click a few `src/<file>.gd#L<n>` citations and confirm they land on the correct source line.
- [ ] Edit a page in `docs/wiki/` via a follow-up PR and confirm the wiki updates on merge.