### PR TITLE
feat(ui): add mod profiles

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Road to Vostok - Community Mod Loader
+# Road to Vostok -- Community Mod Loader
 
 Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods, load order, and updates.
+
+**Developer docs**: [Wiki](https://github.com/ametrocavich/vostok-mod-loader/wiki) -- architecture, hook internals, mod format schema, stability canaries, limitations.
 
 ## Requirements
 
 - Road to Vostok (PC, Steam)
-- Mods packaged as `.vmz` or `.pck`. Unpacked folders are also accepted in Developer Mode.
+- Mods packaged as `.vmz` or `.pck`. Unpacked folders work in Developer Mode.
 
 ## Installation
 
@@ -13,40 +15,22 @@ Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods,
    ```
    C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\
    ```
-
-2. Create a `mods` folder if it doesn't exist:
-   ```
-   C:\Program Files (x86)\Steam\steamapps\common\Road to Vostok\mods\
-   ```
-
-3. Drop `.vmz` mod files into `mods/`.
-
+2. Create a `mods` folder there if it doesn't exist.
+3. Drop `.vmz` files into `mods/`.
 4. Launch the game. The mod loader UI appears before the main menu.
-
-## Installing Mods
-
-Drop `.vmz` files into the `mods` folder. They show up automatically on next launch.
-
-`.pck` files also work but have no mod.txt metadata, autoloads, or update checking. If a mod was distributed as a `.zip`, rename it to `.vmz`.
-
-| Format | Notes |
-|--------|-------|
-| `.vmz` | Road to Vostok's native mod format (renamed zip) |
-| `.pck` | Godot PCK - mount only, no mod.txt or autoloads |
 
 ## Launcher UI
 
-The mod loader opens with two tabs:
+Two tabs:
 
-**Mods** - Lists detected mods with checkboxes and a priority spinbox. Higher priority loads later and wins file conflicts. The load order panel on the right updates in real time.
-
-**Updates** - If mods include ModWorkshop info in `mod.txt`, you can check for and download updates here.
+- **Mods** -- detected mods with checkboxes and a priority spinbox. Higher priority loads later and wins file conflicts. Load-order preview on the right updates in real time.
+- **Updates** -- for mods with `[updates] modworkshop=<id>` in `mod.txt`, check for and download updates from ModWorkshop.
 
 Click **Launch Game** or close the window to start.
 
-## mod.txt
+## Authoring a Mod
 
-Mods can include a `mod.txt` at the root of their archive. All string values need to be quoted.
+Package your mod as a `.vmz` archive (rename a `.zip` to `.vmz`) with a `mod.txt` at the root. All string values must be quoted.
 
 ```ini
 [mod]
@@ -56,7 +40,7 @@ version="1.0.0"
 priority=0
 
 [autoload]
-MyModMain="res://MyModMain/Main.gd"
+MyModMain="res://MyMod/Main.gd"
 
 [updates]
 modworkshop=12345
@@ -65,115 +49,19 @@ modworkshop=12345
 | Field | Description |
 |---|---|
 | `name` | Display name in the UI |
-| `id` | Unique ID. Duplicates are skipped. |
-| `version` | Version string for update comparison |
-| `priority` | Load order weight. Higher = loads later = wins conflicts. Default 0. |
-| `[autoload]` | `Name="res://path.gd"` (or `"res://path.tscn"`) -- instantiated as a Node after mods mount. Prefix with `!` for [early autoloads](#early-autoloads). |
-| `[updates] modworkshop` | ModWorkshop ID for update checking |
+| `id` | Unique ID. Duplicate IDs after the first loaded mod are skipped |
+| `version` | Used by the Updates tab to compare against ModWorkshop |
+| `priority` | Higher loads later, wins file conflicts. Default 0 |
+| `[autoload]` | `Name="res://path.gd"` (or `.tscn`). Prefix value with `!` to load before the game's own autoloads |
+| `[updates] modworkshop` | ModWorkshop mod ID |
 
-Mods without `mod.txt` still mount as resource packs. Their files override vanilla resources, but no autoloads run.
+Mods without `mod.txt` still mount as resource packs -- their files override vanilla resources, but no autoloads run.
+
+Full schema (including `[script_overrides]`, `[rtvmodlib] needs=`, the `!` prefix semantics, and packaging gotchas): see the [Mod-Format wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Mod-Format).
 
 ## Hooks
 
-The hook system preserves tetrahydroc's exact RTVModLib API surface -- `hook()` / `unhook()` / `_caller` / `skip_super()` / `frameworks_ready`, hook-name format, callback signatures. Mod code written against RTVModLib runs unchanged here.
-
-The implementation under the hood is different. Rather than generating `Framework<Name>.gd` subclasses of vanilla and applying them via `take_over_path`, the loader rewrites vanilla source directly and ships it AT the vanilla `res://` path. Mod scripts that subclass vanilla get the same rewrite treatment shipped at their own path. Both rewrites land in a single hook pack mounted with `replace_files=true`. The pack itself is written to `user://modloader_hooks/`, but no game files or mod archives are modified.
-
-Mods that don't use RTVModLib at all also work unchanged. Because dispatch lives inside the vanilla script, a mod that just does `extends Camera` (or uses `take_over_path`, `[script_overrides]`, etc.) inherits hook dispatch for free -- the mod author doesn't need to know the loader exists.
-
-### Why source-rewrite instead of extends-wrapper
-
-Both approaches aim at the same end state: hooks fire reliably regardless of whether an overhaul mod calls `super()`. They get there differently.
-
-**The extends-wrapper approach** (tetrahydroc's RTVModLib standalone, and this loader's earlier generations) builds a subclass `FrameworkController extends Controller`, puts hook dispatch in the wrapper's method overrides, then `take_over_path`s the wrapper onto `res://Scripts/Controller.gd`. When a mod like ImmersiveXP also `take_over_path`s the same vanilla path, the framework wrapper gets applied AFTER the mod and ends up on top of the chain. Wrapper's `Movement(delta)` dispatches, then `super()` calls into the mod's `Movement`, which may or may not call `super()` to vanilla. Hooks fire regardless of the mod's super() call because the wrapper's dispatch is above both.
-
-That works in theory. In practice it trips [Godot bug #83542](https://github.com/godotengine/godot/issues/83542) for class_name scripts that a mod has already taken over: `Resource::set_path(take_over=true)` clears `ResourceCache` but not `ScriptServer::global_classes`, so `extends "res://Scripts/Controller.gd"` compiles against the orphaned class-name registration and emits `Could not find class "Controller"`. ImmersiveXP `overrideScript()`s 21 vanilla scripts; six of those target `class_name`'d vanillas (Controller, Camera, Door, WeaponRig, Item, Mine), and those six are the ones that trip #83542 under the extends-wrapper approach. Hooks on those scripts stop working.
-
-**This loader's source-rewrite approach** avoids ever triggering #83542 by not using `extends "res://Scripts/X.gd"` at the loader level. The rewritten vanilla ships at the vanilla path itself, with `class_name` intact, so the class registry stays consistent with what's actually at the path. The class_name-swap crash path (`Resource::set_path` not clearing `global_name`) is also moot because nothing is being moved off its canonical path by the loader.
-
-Mod-subclass rewriting plays the same role as "apply framework wrapper on top of mod via `take_over_path`": it puts hook dispatch above the mod's body so hooks fire whether or not the mod calls `super()`. The difference is that it's achieved by rewriting the mod's source file in the hook pack rather than by a runtime `take_over_path`, which keeps #83542 out of the picture even when the mod IS a class_name script.
-
-### Scope of this approach
-
-- **Every vanilla method gets dispatch.** No `[rtvmodlib] needs=` opt-in. The rewrite generator ships wrappers for every hookable vanilla script under `res://Scripts/`. In the current RTV build that's 161 scripts (5,776 hook points) out of 176 total -- 15 are skipped: 7 runtime-sensitive (`MuzzleFlash`, `Hit`, `Explosion`, etc., where dispatch-wrapper overhead breaks short-lived effects or coroutine timing), 7 data/save resource scripts (whose path is embedded in saved files, so wrapping would break save-load), and 1 zero-byte PCK stub the game ships (`CasettePlayer.gd`). Exact counts for your install appear in the boot log: `[RTVCodegen] parsed RTV.pck -- N total file(s), M .gd script(s) under res://Scripts/`, `[RTVCodegen] Skip lists: ...`, and `[RTVCodegen] Generated K rewritten vanilla script(s), L hook points`.
-- **Mods that subclass vanilla get rewritten too.** Any `.gd` file in an enabled mod's archive whose first non-trivial line is `extends "res://Scripts/<X>.gd"` (where `<X>` is a vanilla we hook) gets the same rename+dispatch transform shipped at the mod's own path.
-- **Timing.** The hook pack is mounted with `replace_files=true` at ModLoader's class-level static init, before any game autoload runs. Mod autoloads that do `load(...).take_over_path(...)` on our rewritten files inherit our wrappers via their `extends` chain.
-- **Scene-preloaded vanilla deferred to lazy-compile.** Some vanilla scripts (e.g. `AISpawner.gd`) have module-scope `preload()` of PackedScenes whose `ext_resource` references other vanilla scripts (e.g. `AI_Bandit.tscn` referencing `AI.gd`). Compiling those vanillas eagerly would fire their scene preloads before mod autoloads run, baking ext_resource Script references against the pre-override cache. `take_over_path` then clears those references' paths to empty (per `Resource::set_path`), and scene instances spawn with orphan scripts. To avoid this, vanilla scripts with module-scope scene preloads are skipped from eager compile. They lazy-compile via VFS mount precedence after mod overrides have run, so scenes resolve ext_resources against the post-override cache.
-- **Legacy-GDScript autofix.** Mod sibling scripts (non-subclass `.gd` files in the archive, typically preloaded from subclasses) are scanned for Godot-3-era patterns -- bodyless `if`/`elif`/`else` blocks, `tool` / `onready var` / `export var` -- and rewritten to strict-parser-compatible Godot 4 form. The fixed source lands in the hook pack overlay; the mod's `.vmz` stays untouched. Necessary because `script.reload()` inside a mod's `overrideScript` cascades strict re-parse through preloaded siblings, rejecting patterns that Godot's lenient first-compile would have tolerated.
-- **Post-ready `take_over_path` not covered.** If a mod does `take_over_path` on a vanilla script AFTER `frameworks_ready` has emitted (rather than during its autoload), we rely on the incoming script's own `extends` chain to route through our rewrite. If the mod's replacement script is a file-backed subclass of the vanilla we hook, it's already been rewritten in the hook pack. If it's a fully runtime-constructed script, it won't have dispatch.
-- **`RTVModLib.vmz` coexistence.** If tetrahydroc's standalone RTVModLib mod is also enabled, both systems will try to wrap the same vanilla scripts -- this isn't supported, pick one. (`_register_rtv_modlib_meta` refuses to overwrite an existing `Engine.get_meta("RTVModLib")` and logs a warning, but the rest of the loader still runs.) The `Engine.get_meta("RTVModLib")` API surface (`hook` / `unhook` / `_caller` / `skip_super` / `frameworks_ready`, etc.) is identical between the two, so mod code is portable across whichever ends up registered first.
-
-### How it works
-
-At launch the loader walks `RTV.pck`'s file table, detokenizes every `res://Scripts/*.gd` from its compiled bytecode, and rewrites each one. Vanilla `Controller.Movement(delta)` (a void method) ends up looking like the following in the hook pack. Diagnostic instrumentation emitted by the generator (per-hook firing counters in `Engine.meta` for runtime tracking) is omitted here for readability; see `_rtv_dispatch_inline_src` in modloader.gd for the full output.
-
-```gdscript
-# Vanilla Controller.gd (body simplified)
-func Movement(delta):
-    velocity.x = move_x * walkSpeed
-    move_and_slide()
-
-# Rewritten Controller.gd shipped in the hook pack
-func _rtv_vanilla_Movement(delta):    # original body, renamed
-    velocity.x = move_x * walkSpeed
-    move_and_slide()
-
-func Movement(delta):                 # new dispatch wrapper
-    var _lib = Engine.get_meta("RTVModLib") if Engine.has_meta("RTVModLib") else null
-    if !_lib:
-        _rtv_vanilla_Movement(delta)
-        return
-    # Fast path: no mod has called hook() this session.
-    if not _lib._any_mod_hooked:
-        _rtv_vanilla_Movement(delta)
-        return
-    # Re-entry guard: a mod's wrapper called super() into here. Run vanilla and bail.
-    if _lib._wrapper_active.has("controller-movement"):
-        _rtv_vanilla_Movement(delta)
-        return
-    _lib._wrapper_active["controller-movement"] = true
-    _lib._caller = self
-    _lib._dispatch("controller-movement-pre", [delta])
-    var _repl = _lib._get_hooks("controller-movement")
-    if _repl.size() > 0:
-        var _prev_skip = _lib._skip_super
-        _lib._skip_super = false
-        _repl[0].callv([delta])
-        var _did_skip = _lib._skip_super
-        _lib._skip_super = _prev_skip
-        if !_did_skip:
-            _rtv_vanilla_Movement(delta)
-    else:
-        _rtv_vanilla_Movement(delta)
-    _lib._dispatch("controller-movement-post", [delta])
-    _lib._dispatch_deferred("controller-movement-callback", [delta])
-    _lib._wrapper_active.erase("controller-movement")
-```
-
-Each rewritten script ships as THREE zip entries in `user://modloader_hooks/framework_pack.zip`:
-
-| Entry | Purpose |
-|-------|---------|
-| `Scripts/Name.gd` | The rewritten source. `class_name` preserved. |
-| `Scripts/Name.gd.remap` | Self-referencing `[remap]\npath="res://Scripts/Name.gd"`. Overrides the PCK's `.gd.remap -> .gdc` redirect so Godot loads our source. |
-| `Scripts/Name.gdc` | Zero bytes. Shadows the PCK's compiled bytecode so Godot's GDScript loader falls back to our `.gd`. |
-
-The pack is mounted via `ProjectSettings.load_resource_pack(zip, replace_files=true)` at ModLoader's class-level static init -- before any game autoload runs. Godot's VFS layering plus the three-entry recipe make our `res://Scripts/Camera.gd` win over the PCK's without modifying `RTV.pck` or any `.vmz` on disk.
-
-### Mod subclass rewriting
-
-Mods like IXP ship scripts that `extends "res://Scripts/Camera.gd"` and override a subset of methods. The loader also rewrites those at codegen time:
-
-- Scan every enabled mod's `.vmz`. Find `.gd` files whose first non-trivial line is `extends "res://Scripts/<X>.gd"` where `<X>` is a vanilla we hook.
-- Apply the same rename+dispatch transform, but with the prefix `_rtv_mod_` (literal, not per-mod) instead of `_rtv_vanilla_` so the mod body doesn't shadow vanilla's via virtual dispatch.
-- Ship the rewritten mod script at its own path (e.g. `ImmersiveXP/Camera.gd`) in the same hook pack with `replace_files=true`. The mod's `.vmz` is never modified.
-- When IXP's autoload calls `load("res://ImmersiveXP/Camera.gd")`, mount precedence returns our rewritten version. IXP's existing `overrideScript()` logic then `take_over_path`s our rewritten IXP Camera onto the vanilla path. Dispatch fires from IXP's wrapper regardless of whether IXP's body calls `super()`.
-
-A re-entry guard (`_wrapper_active[hook_base]`) prevents double dispatch when the mod body DOES call `super()` into vanilla's wrapper -- vanilla sees the guard set, skips dispatch, and just runs the vanilla body. One dispatch per logical call regardless of chain depth.
-
-### Registering hooks
-
-`Engine.get_meta("RTVModLib")` returns the hook registry once the modloader has registered itself. The wrappers aren't applied until later in the same frame, so connect to `frameworks_ready` (or call your handler directly if `_is_ready` is already true):
+Mods intercept vanilla methods via the meta API. Minimal example:
 
 ```gdscript
 extends Node
@@ -193,295 +81,48 @@ func _on_lib_ready():
     _lib.hook("controller-jump-pre", _on_jump_pre)
 
 func _on_jump_pre(_delta):
-    # Callback signature must match the wrapped method.
-    # Controller.Jump(_delta) takes one arg, so the dispatcher calls
-    # callv([delta]) -- a zero-arg callback would raise CALL_ERROR.
+    # Callback args match the wrapped method.
     _lib._caller.jumpVelocity = 20.0
 ```
 
-### Hook names
+Hook name format: `<scriptname>-<methodname>[-pre|-post|-callback]` lowercase. Bare name (no suffix) is a replace hook -- first registration wins.
 
-Format: `<scriptname>-<methodname>[-suffix]`, all lowercase. The script name is the filename without `.gd`. The method name is the original, lowercased, including any leading underscore.
+The API is drop-in compatible with [tetrahydroc's RTVModLib mod](https://github.com/tetrahydroc/rtv-mod-lib) (`hook` / `unhook` / `_caller` / `skip_super` / `frameworks_ready`, same signatures). Mod code written against RTVModLib runs unchanged here.
 
-| Suffix | Behavior |
-|--------|----------|
-| `-pre` | Before the original. Stackable across mods. |
-| `-post` | After the original. Stackable. |
-| `-callback` | After the original via `call_deferred`. Stackable. |
-| (none) | Replace. First-registered owns it; later registrations return `-1`. |
-
-Examples: `pickup-_ready-post`, `controller-jump-pre`, `door-interact-callback`, `hitbox-applydamage` (replace).
-
-### API
-
-All members live on the meta object returned by `Engine.get_meta("RTVModLib")`.
-
-| Member | Type | Purpose |
-|--------|------|---------|
-| `frameworks_ready` | signal | Emitted once after wrappers are mounted and applied. |
-| `_is_ready` | bool | True once `frameworks_ready` has emitted. |
-| `_caller` | Node | Instance whose method triggered dispatch. Set before each callback, never reset -- outside a callback it's the last dispatched instance (stale, possibly freed). Snapshot synchronously if you need it later. |
-| `_skip_super` | bool | Set by `skip_super()` during a replace hook. |
-| `hook(name, callback, priority=100)` | int | Register. Returns hook id, or `-1` if a replace hook is already owned. Lower priority runs first (default 100). |
-| `unhook(id)` | void | Remove by id. |
-| `has_hooks(name)` | bool | Any registrations at this name. |
-| `has_replace(name)` | bool | True if any hook is registered at this name. To detect a replace owner specifically, pass the bare name -- presence at a bare key implies a replace, since `hook()` only allows one. (Implementation is currently identical to `has_hooks()`.) |
-| `get_replace_owner(name)` | int | Owner id, or `-1` if none. Lets a mod detect a conflict and fall back to `-pre` / `-post`. |
-| `skip_super()` | void | Inside a replace hook, prevents the original method from running. |
-| `seq()` | int | Monotonic dispatch counter (debug). |
-
-### Callback signatures
-
-Callbacks receive the same argument list as the wrapped method. The source instance is in `_caller`:
-
-```gdscript
-func _on_movement_pre(delta: float) -> void:
-    var ctrl = Engine.get_meta("RTVModLib")._caller
-    ctrl.walkSpeed = 10.0
-```
-
-For zero-arg methods (like `_ready`), the callback takes no arguments:
-
-```gdscript
-func _on_ready_post() -> void:
-    var pickup = Engine.get_meta("RTVModLib")._caller
-    pickup.gravity_scale = 0.5
-```
-
-### Replace hooks
-
-```gdscript
-_lib.hook("hitbox-applydamage", _god_mode)
-
-func _god_mode(damage):
-    _lib.skip_super()  # original ApplyDamage won't run
-```
-
-Only one replace per name. `hook()` returns `-1` if another mod already owns the slot. Use `get_replace_owner()` or check the return value and fall back to a `-pre` or `-post` hook so two mods can coexist.
-
-### Examples
-
-The three examples below are adapted from tetrahydroc's RTVModLib README.
-
-#### AI Kill Tracker
-
-```gdscript
-extends Node
-
-# Tracks AI kills and prints a summary
-
-var _lib = null
-var _kills: Dictionary = {}  # ai_type -> count
-
-func _ready():
-    if Engine.has_meta("RTVModLib"):
-        var lib = Engine.get_meta("RTVModLib")
-        if lib._is_ready:
-            _on_lib_ready()
-        else:
-            lib.frameworks_ready.connect(_on_lib_ready)
-
-func _on_lib_ready():
-    _lib = Engine.get_meta("RTVModLib")
-    _lib.hook("ai-death-post", _on_ai_death, 50)
-    print("Kill Tracker: Loaded")
-
-func _on_ai_death(direction = null, force = null):
-    # AI.Death(direction, force) was called -- an AI just died
-    _kills["total"] = _kills.get("total", 0) + 1
-    print("Kills: " + str(_kills["total"]))
-```
-
-`mod.txt`:
-
-```ini
-[mod]
-name="Kill Tracker"
-id="kill-tracker"
-version="1.0.0"
-
-[autoload]
-KillTracker="res://KillTracker/Main.gd"
-```
-
-#### Custom Trader Prices
-
-```gdscript
-extends Node
-
-# Doubles all trader prices
-
-var _lib = null
-
-func _ready():
-    if Engine.has_meta("RTVModLib"):
-        var lib = Engine.get_meta("RTVModLib")
-        if lib._is_ready:
-            _on_lib_ready()
-        else:
-            lib.frameworks_ready.connect(_on_lib_ready)
-
-func _on_lib_ready():
-    _lib = Engine.get_meta("RTVModLib")
-    _lib.hook("interface-calculatedeal-post", _modify_prices)
-
-func _modify_prices():
-    # Runs after CalculateDeal -- modify the displayed values
-    var scene = get_tree().current_scene
-    var interface = scene.get_node_or_null("Core/UI/Interface")
-    if interface and interface.requestValue:
-        var current = int(interface.requestValue.text)
-        interface.requestValue.text = str(current * 2)
-```
-
-#### Replace Hook with Fallback
-
-```gdscript
-extends Node
-
-# Custom loot generation that falls back to vanilla if conditions aren't met
-
-var _lib = null
-
-func _ready():
-    if Engine.has_meta("RTVModLib"):
-        var lib = Engine.get_meta("RTVModLib")
-        if lib._is_ready:
-            _on_lib_ready()
-        else:
-            lib.frameworks_ready.connect(_on_lib_ready)
-
-func _on_lib_ready():
-    _lib = Engine.get_meta("RTVModLib")
-    var id = _lib.hook("lootcontainer-generateloot", _custom_loot)
-    if id == -1:
-        # Another mod already owns this replace hook
-        print("MyMod: GenerateLoot replace hook rejected, using pre/post instead")
-        _lib.hook("lootcontainer-generateloot-post", _modify_loot_after)
-
-func _custom_loot():
-    if some_condition:
-        _lib.skip_super()  # Skip vanilla loot gen
-        # Generate custom loot...
-    # If skip_super() not called, vanilla GenerateLoot runs normally
-```
-
-### Limitations
-
-- **Wrappers only over methods the script defines**. Inherited methods aren't wrapped.
-- **Static methods aren't wrapped**.
-- **Source reconstruction**: scripts are detokenized from binary tokens. Comments and exact formatting are not preserved. Covers Godot 4.0-4.6.
-- **Resource / data scripts skipped**: `*Data.gd` files (SlotData, ItemData, etc) and serialized resources aren't wrapped to avoid breaking save files.
-- **Mod rewriting is literal `extends` only**: a mod's `.gd` file gets rewritten only if its first non-trivial line is `extends "res://Scripts/X.gd"`. Computed / class-name extends aren't detected.
-- **Autofix scope is narrow**: legacy-GDScript autofix handles bodyless `if`/`elif`/`else` blocks and `tool` / `onready var` / `export var` annotations. Not handled: `setget`, typed `export(Type) var`, and other Godot 3 specifics. Mods using those patterns in preloaded sibling scripts may still hit strict-reload failures.
-
-### Hook troubleshooting
-
-- **`hook()` returns `-1`**: another mod owns the replace slot. Use `get_replace_owner()` to detect, then fall back to `-pre` or `-post`.
-- **Callback never fires**: you registered before `frameworks_ready` emitted. Always `await lib.frameworks_ready` if `_is_ready` is false. All hookable scripts are wrapped by default, so no opt-in is needed.
-- **`_caller` is wrong or invalid**: the loader sets `_caller` before each dispatch and never clears it. Reading outside your hook (or from a `-callback` deferred handler) returns either the LAST dispatched instance (stale) or, if that source was freed, an invalid reference. Snapshot `_caller` synchronously inside your hook and reference the snapshot afterward.
-- **Hook name doesn't match anything**: format is `<scriptname>-<methodname>[-suffix]` lowercase. Underscore-prefixed methods keep the underscore: `pickup-_ready-post`, not `pickup-ready-post`.
-- **`[RTVCodegen] <path> is rewritten and also overridden by <mod> -- override displaces the rewrite, hooks won't fire for that path`**: another mod ships a `[script_overrides]` entry for the same vanilla script. The override displaces our rewrite at that path, so dispatch never fires for nodes that use it.
-
-Hook cache: `%APPDATA%\Road to Vostok\modloader_hooks\`
-The cache is regenerated every launch. To force a clean state, delete the `modloader_hooks` folder.
-
-## Early Autoloads
-
-Prefix an autoload with `!` to load it before the game's own autoloads:
-
-```ini
-[autoload]
-EarlySetup="!res://MyMod/EarlySetup.gd"
-```
-
-This works via the loader's two-pass restart sequence: on Pass 1 the mod loader writes the autoload into `override.cfg`'s `[autoload_prepend]` section, then restarts; on Pass 2 your node is in the scene tree before the game's autoloads run. (The two-pass restart fires whenever any enabled mod changes the persisted state, not specifically because of the `!` prefix -- the early autoload just takes effect on the second pass.)
-
-Regular autoloads (without `!`) load after all mods mount. Only use `!` when your mod genuinely needs to run before game autoloads.
+Full API reference, dispatch semantics, three-entry pack recipe, mod subclass rewriting, and worked examples: [Hooks wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Hooks).
 
 ## Troubleshooting
 
-**From the mod loader UI:** click **Reset to Vanilla** in the pre-launch window. Wipes the hook pack, pass state, override.cfg mod entries, and unchecks every mod; restarts into a clean vanilla run. Your mods stay in `mods/`.
+**From the UI**: click **Reset to Vanilla** in the pre-launch window. Wipes mod state (hook pack, override.cfg, pass state), unchecks every mod, restarts clean. Your mods stay in `mods/`.
 
-**If the game crashes or gets stuck:**
+**If the game crashes or won't launch**:
 
-- **Wait it out.** After 2 failed launches, the mod loader automatically resets to a clean state.
-- **Disable ModLoader entirely:** Create an empty file named `modloader_disabled` (no extension) in the game folder. On next launch, the mod loader skips all work -- no archives mount, no UI shows, no autoloads run. Delete the file to re-enable. Use this when ModLoader itself is broken and you can't reach the UI.
-- **Manual safe-mode reset:** Create an empty file named `modloader_safe_mode` (no extension) in the game folder. On next launch, the mod loader resets `override.cfg`, deletes pass state, clears the heartbeat, then deletes the safe-mode file. Note: this does NOT wipe the hook pack -- use **Reset to Vanilla** or `modloader_disabled` for a full reset.
-- **Full reset:** Delete `override.cfg` from the game folder and replace it with a fresh copy from the mod loader release.
+- **Wait it out** -- after 2 failed launches, the loader auto-resets to clean state.
+- **Force-disable**: create an empty file named `modloader_disabled` (no extension) in the game folder. On next launch, the loader sits idle (no mounts, no UI, no autoloads). Delete the file to re-enable. Use when the loader itself is broken and you can't reach the UI.
+- **Safe-mode reset**: create an empty file named `modloader_safe_mode` (no extension) in the game folder. On next launch, the loader resets `override.cfg`, deletes pass state, clears the heartbeat, then deletes the safe-mode file.
 
-**Crash-safe recovery:** If the game is killed during the two-pass restart phase (before Pass 2 finishes applying the hook pack), ModLoader leaves a `user://modloader_pass2_dirty` marker. Next cold boot detects it and force-wipes hook pack + override.cfg + pass state before retrying -- so a half-written hook pack can't poison the next launch.
+More recovery detail (heartbeat, restart counter, crashed-Pass-2 dirty marker): [Stability-Canaries wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Stability-Canaries).
 
-## Conflict Report
+## Best Practices (for mod authors)
 
-With Developer Mode enabled, the modloader's own log buffer (everything emitted via `[ModLoader]` lines) is written to `%APPDATA%\Road to Vostok\modloader_conflicts.txt` after each launch. Look for these markers:
-
-| Message | Meaning |
-|---------|---------|
-| **CONFLICT: `<path>`** | Two or more mods ship the same `res://` path. Later loader wins. Adjust priorities to pick a winner. |
-| **CONFLICT: re-declares class_name** | Two scripts share a `class_name`. Usually a mod bundled its own `.godot/global_script_class_cache.cfg`. |
-| **DATABASE OVERRIDE** | A mod replaced `Scripts/Database.gd`. Normal for overhauls, may block other mods' scene overrides. |
-| **BAD ZIP** | Backslash file paths in the archive. Re-pack with 7-Zip. |
-
-The summary block also lists which hooks had registrations. (Under source-rewrite the "Framework Overrides Active" section in the summary stays silent -- that section is for the dormant `[rtvmodlib] needs=` -> `Framework<Name>.gd` path, which doesn't populate `_hook_swap_map` under the current source-rewrite mechanism.)
-
-## Best Practices
-
-- **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes).
+- **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes, breaks mounting).
 - **Include a `mod.txt`** at the archive root. Without it, autoloads won't run.
-- **Use `super()` in lifecycle methods.** Skipping it breaks other mods that override the same class.
-- **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't. All vanilla scripts are hooked automatically, just register callbacks through `Engine.get_meta("RTVModLib")`.
-- **If you replace Database.gd**, every `preload()` path must exist or the game breaks.
-- **`UpdateTooltip()` is the world-item tooltip path.** Each interactable (`Pickup`, `Door`, `Bed`, `Fire`, `LootContainer`, `Trader`, `Furniture`, etc.) implements `UpdateTooltip()`, which writes to `gameData.tooltip`; `HUD._physics_process` polls and renders. To change a world tooltip, hook the relevant class's `UpdateTooltip` (e.g. `lootcontainer-updatetooltip-post`).
-- **Test with other mods installed** and check the conflict report.
+- **Use `super()` in lifecycle methods** (`_ready`, `_process`, etc.) when overriding vanilla scripts. Skipping it breaks other mods that override the same class.
+- **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't. Every vanilla script is hooked automatically -- just register callbacks.
+- **Test with other mods installed** and check the conflict report (Developer Mode).
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch model, Conventional Commit format, and build instructions. The short version: edit files in `src/`, run `./build.sh`, open PRs against the `development` branch with titles like `feat: ...` or `fix: ...`.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Short version: edit files in `src/`, run `./build.sh`, open PRs against `development` with Conventional Commit titles (`feat:`, `fix:`, `docs:`, etc.). Release-please handles version bumps automatically from the commit history.
 
 ## Uninstalling
 
-Delete `override.cfg` and `modloader.gd` from the game folder. The `mods` folder and its contents can be removed separately.
+Delete `override.cfg` and `modloader.gd` from the game folder. The `mods/` folder can be removed separately.
 
-Settings: `%APPDATA%\Road to Vostok\mod_config.cfg`
-Conflict log: `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
-
----
-
-## Recovery (Technical Details)
-
-- **Heartbeat file:** `user://modloader_heartbeat.txt` is written at launch and deleted on success. The restart counter (stored in pass state) is incremented every time the loader writes pass state for a Pass 2 restart -- so it ticks on every modloader-triggered restart, not on heartbeat detection. If the next launch finds a leftover heartbeat AND the counter is at or above `MAX_RESTART_COUNT` (2), the loader wipes `override.cfg` and all two-pass state to break the loop. Otherwise it logs a warning and clears the heartbeat.
-- **Pass 2 dirty marker:** `user://modloader_pass2_dirty` is written at the start of Pass 2 and deleted when Pass 2 finishes. If present on next cold boot, Pass 2 was interrupted (force-quit, crash, power loss) and the hook pack may be half-written. Static init detects the marker and force-wipes state before ModLoader runs.
-- **Disabled flag:** An empty `modloader_disabled` file in the game folder makes ModLoader sit idle for that session. Static init resets `override.cfg`, deletes pass state, clears the pass-2 dirty marker, and wipes the hook pack, then returns immediately. The UI never shows. Delete the file to re-enable.
-- **Safe mode flag:** An empty `modloader_safe_mode` file triggers a one-shot full reset on next launch, then is deleted.
-- **State files:** `user://mod_pass_state.cfg` stores archive paths + hook pack path for the two-pass restart. Cleared by the Reset button, the disabled flag, by entering zero-mod state via the UI, or by a Pass 2 crash.
-
----
-
-## Engine Compatibility
-
-Tested against Godot 4.6.1 (the version Road to Vostok ships with -- verifiable in the boot banner: `Godot Engine v4.6.1.stable.official.14d19694e`). Reviewed against the Godot 4.7 milestone -- no breaking changes identified within Road to Vostok's first-party mod support window.
-
-If a future Godot version changes how `res://` paths resolve inside mounted resource packs, the hook pack's mount-precedence recipe (`.gd` + `.gd.remap` + empty `.gdc`) will stop winning over the PCK. The `[STABILITY] VFS canary FAILED` alarm trips on first launch and the loader logs a critical error. Users can fall back to tetrahydroc's standalone `RTVModLib` mod, which uses the extends-wrapper approach (`Framework<Name>.gd` subclasses applied at runtime via `take_over_path`). The fallback handles the typical case, but trips Godot [#83542](https://github.com/godotengine/godot/issues/83542) on overhaul mods that `take_over_path` on `class_name`'d vanilla scripts: the take-over orphans vanilla's `class_name` registration in `ScriptServer`, after which extends-by-path resolution against that vanilla fails with `Could not find class`. ImmersiveXP triggers this on Controller, Camera, Door, WeaponRig, Item, and Mine (the six vanilla scripts in IXP's `overrideScript()` list that declare `class_name`). Our source-rewrite sidesteps the bug by never calling `take_over_path` on a `class_name`'d vanilla.
-
-The three specific engine behaviors that would trigger the fallback:
-
-1. **`load_resource_pack(replace_files=true)`** stops letting later mounts override earlier ones at the same `res://` path.
-2. **`.gd.remap`** resolution order changes so a self-referencing remap no longer preempts the PCK's redirect to compiled `.gdc`.
-3. **Empty `.gdc`** stops silently falling back to compiling the sibling `.gd`.
-
-Everything else in the loader -- mod discovery, autoload ordering via `[autoload_prepend]`, the hook API, crash recovery, the pre-game UI -- is unaffected by either scenario.
-
----
+- Settings file: `%APPDATA%\Road to Vostok\mod_config.cfg`
+- Conflict log (Developer Mode only): `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
+- Hook pack cache: `%APPDATA%\Road to Vostok\modloader_hooks\` (regenerated on each launch)
 
 ## License
 
-MIT License
-
-Copyright (c) 2025
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+MIT. See [LICENSE](LICENSE).

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -210,6 +210,113 @@ Why the fallback matters ([hook_pack.gd:538-545](https://github.com/ametrocavich
 
 Scripts with module-scope `preload("res://...tscn|.scn")` are deferred from eager compile (the `_scripts_with_scene_preloads` set). VFS mount precedence still serves the rewrite when game code lazy-loads these paths after mod overrides have run -- this avoids baking Script ext_resources in scenes to the pre-override vanilla. See [Limitations](Limitations).
 
+## Worked examples
+
+The three examples below are adapted from tetrahydroc's RTVModLib README.
+
+### AI Kill Tracker
+
+```gdscript
+extends Node
+
+# Tracks AI kills and prints a summary
+
+var _lib = null
+var _kills: Dictionary = {}  # ai_type -> count
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready:
+            _on_lib_ready()
+        else:
+            lib.frameworks_ready.connect(_on_lib_ready)
+
+func _on_lib_ready():
+    _lib = Engine.get_meta("RTVModLib")
+    _lib.hook("ai-death-post", _on_ai_death, 50)
+    print("Kill Tracker: Loaded")
+
+func _on_ai_death(direction = null, force = null):
+    # AI.Death(direction, force) was called -- an AI just died.
+    _kills["total"] = _kills.get("total", 0) + 1
+    print("Kills: " + str(_kills["total"]))
+```
+
+`mod.txt`:
+
+```ini
+[mod]
+name="Kill Tracker"
+id="kill-tracker"
+version="1.0.0"
+
+[autoload]
+KillTracker="res://KillTracker/Main.gd"
+```
+
+### Custom Trader Prices
+
+```gdscript
+extends Node
+
+# Doubles all trader prices
+
+var _lib = null
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready:
+            _on_lib_ready()
+        else:
+            lib.frameworks_ready.connect(_on_lib_ready)
+
+func _on_lib_ready():
+    _lib = Engine.get_meta("RTVModLib")
+    _lib.hook("interface-calculatedeal-post", _modify_prices)
+
+func _modify_prices():
+    # Runs after CalculateDeal -- modify the displayed values.
+    var scene = get_tree().current_scene
+    var interface = scene.get_node_or_null("Core/UI/Interface")
+    if interface and interface.requestValue:
+        var current = int(interface.requestValue.text)
+        interface.requestValue.text = str(current * 2)
+```
+
+### Replace hook with fallback
+
+```gdscript
+extends Node
+
+# Custom loot generation that falls back to vanilla if conditions aren't met
+
+var _lib = null
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready:
+            _on_lib_ready()
+        else:
+            lib.frameworks_ready.connect(_on_lib_ready)
+
+func _on_lib_ready():
+    _lib = Engine.get_meta("RTVModLib")
+    var id = _lib.hook("lootcontainer-generateloot", _custom_loot)
+    if id == -1:
+        # Another mod already owns this replace hook.
+        print("MyMod: GenerateLoot replace hook rejected, using pre/post instead")
+        _lib.hook("lootcontainer-generateloot-post", _modify_loot_after)
+
+func _custom_loot():
+    if some_condition:
+        _lib.skip_super()  # Skip vanilla loot gen
+        # Generate custom loot...
+    # If skip_super() not called, vanilla GenerateLoot runs normally.
+```
+
 ## Related
 
 - [Stability-Canaries](Stability-Canaries) -- runtime probes that alarm when the dispatch chain breaks

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -17,6 +17,9 @@ const MODLOADER_RES_PATH := "res://modloader.gd"
 const MOD_DIR := "mods"
 const TMP_DIR := "user://vmz_mount_cache"
 const UI_CONFIG_PATH := "user://mod_config.cfg"
+# Sentinel value for `[settings] active_profile` written by Reset to Vanilla.
+# Has no stored sections -- `_apply_profile_to_entries` treats it as "all off".
+const VANILLA_PROFILE := "__vanilla__"
 const CONFLICT_REPORT_PATH := "user://modloader_conflicts.txt"
 const PASS_STATE_PATH := "user://mod_pass_state.cfg"
 const HEARTBEAT_PATH := "user://modloader_heartbeat.txt"
@@ -86,6 +89,11 @@ const RTV_ENGINE_VOID_METHODS: Array[String] = [
 
 var _mods_dir: String = ""
 var _developer_mode := false
+var _active_profile := "Default"
+var _ui_window: Window = null
+# Bottom-bar label used as a makeshift status hint because Godot's native
+# tooltips get layered behind our always_on_top launcher and aren't visible.
+var _ui_hint_label: Label = null
 var _has_loaded := false
 var _last_mod_txt_status := "none"
 var _database_replaced_by := ""

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1190,6 +1190,38 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			order_list.add_child(lbl)
 
+	# -- Missing from this profile --------------------------------------------
+	# Mods the active profile references but that aren't on disk. Shown at the
+	# top of the list so they get attention before the regular mod rows; each
+	# has a Remove button to strip the orphaned keys from the profile. Future:
+	# offer to download via modworkshop if an id is stored.
+	var missing_files := _missing_mods_in_active_profile()
+	if not missing_files.is_empty():
+		var missing_hdr := Label.new()
+		missing_hdr.text = "Missing from this profile"
+		missing_hdr.modulate = Color(1.0, 0.55, 0.55)
+		missing_hdr.add_theme_font_size_override("font_size", 11)
+		list.add_child(missing_hdr)
+		list.add_child(HSeparator.new())
+		for fn: String in missing_files:
+			var miss_row := HBoxContainer.new()
+			list.add_child(miss_row)
+			var miss_lbl := Label.new()
+			miss_lbl.text = fn + "  --  not installed"
+			miss_lbl.modulate = Color(1.0, 0.45, 0.45)
+			miss_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			miss_row.add_child(miss_lbl)
+			var remove_btn := Button.new()
+			remove_btn.text = "Remove"
+			remove_btn.tooltip_text = "Strip this entry from the active profile"
+			miss_row.add_child(remove_btn)
+			var captured := fn
+			remove_btn.pressed.connect(func():
+				_remove_missing_entry_from_profile(captured)
+				_rebuild_mods_tab(tabs)
+			)
+			list.add_child(HSeparator.new())
+
 	# -- Column headers --------------------------------------------------------
 
 	var header_row := HBoxContainer.new()
@@ -1296,37 +1328,6 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			refresh_order.call()
 			_save_ui_config()
 		)
-
-	# -- Missing from this profile --------------------------------------------
-	# Mods the active profile references but that aren't on disk. Shown as red
-	# stub rows with a Remove button to strip the orphaned entry from the
-	# profile. Future: offer to download via modworkshop if an id is stored.
-	var missing_files := _missing_mods_in_active_profile()
-	if not missing_files.is_empty():
-		var missing_hdr := Label.new()
-		missing_hdr.text = "Missing from this profile"
-		missing_hdr.modulate = Color(1.0, 0.55, 0.55)
-		missing_hdr.add_theme_font_size_override("font_size", 11)
-		list.add_child(missing_hdr)
-		list.add_child(HSeparator.new())
-		for fn: String in missing_files:
-			var row := HBoxContainer.new()
-			list.add_child(row)
-			var miss_lbl := Label.new()
-			miss_lbl.text = fn + "  --  not installed"
-			miss_lbl.modulate = Color(1.0, 0.45, 0.45)
-			miss_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-			row.add_child(miss_lbl)
-			var remove_btn := Button.new()
-			remove_btn.text = "Remove"
-			remove_btn.tooltip_text = "Strip this entry from the active profile"
-			row.add_child(remove_btn)
-			var captured := fn
-			remove_btn.pressed.connect(func():
-				_remove_missing_entry_from_profile(captured)
-				_rebuild_mods_tab(tabs)
-			)
-			list.add_child(HSeparator.new())
 
 	refresh_order.call()
 	return outer

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1,8 +1,15 @@
 ## ----- ui.gd -----
-## The launcher window shown before the game starts: mods tab (list +
-## checkboxes + priority), updates tab (ModWorkshop version checking +
-## downloads), theme, and the reset-to-vanilla action. Closing the window
-## (or clicking Launch Game) hands control back to _run_pass_1.
+## The launcher window shown before the game starts.
+##   - Mods tab: per-mod enable checkbox + load-order spin, profile selector
+##     (switch / create / delete) with a Vanilla entry that confirms then
+##     resets + restarts, and a live load-order preview.
+##   - Updates tab: ModWorkshop version checking + downloads.
+##   - Profiles live in UI_CONFIG_PATH under `profile.<name>.enabled` and
+##     `profile.<name>.priority`; the active profile is stored in
+##     `[settings] active_profile`. VANILLA_PROFILE is a sentinel meaning
+##     "all mods off" and keeps stored profiles untouched on reset.
+## Closing the window (or clicking Launch Game) hands control back to
+## _run_pass_1.
 
 func _load_developer_mode_setting() -> void:
 	var cfg := ConfigFile.new()
@@ -13,43 +20,339 @@ func _load_developer_mode_setting() -> void:
 		_log_info("Developer mode: ON")
 
 func _load_ui_config() -> void:
+	_active_profile = "Default"
 	var cfg := ConfigFile.new()
 	if cfg.load(UI_CONFIG_PATH) != OK:
 		return
+
+	# Migrate legacy flat [enabled]/[priority] layout into profile.Default.* on
+	# the first post-upgrade load. The next _save_ui_config writes the file back
+	# without the flat sections, so the migration only runs once per install.
+	var has_any_profile := false
+	for sec: String in cfg.get_sections():
+		if sec.begins_with("profile."):
+			has_any_profile = true
+			break
+	if not has_any_profile:
+		if cfg.has_section("enabled"):
+			for key: String in cfg.get_section_keys("enabled"):
+				cfg.set_value("profile.Default.enabled", key, cfg.get_value("enabled", key))
+		if cfg.has_section("priority"):
+			for key: String in cfg.get_section_keys("priority"):
+				cfg.set_value("profile.Default.priority", key, cfg.get_value("priority", key))
+
+	var stored := str(cfg.get_value("settings", "active_profile", "Default"))
+	var profiles := _list_profiles_in_cfg(cfg)
+	if stored == VANILLA_PROFILE:
+		_active_profile = VANILLA_PROFILE
+	elif stored in profiles:
+		_active_profile = stored
+	elif not profiles.is_empty():
+		_active_profile = profiles[0]
+	else:
+		_active_profile = "Default"
+
+	_apply_profile_to_entries(cfg, _active_profile)
+
+func _apply_profile_to_entries(cfg: ConfigFile, profile: String) -> void:
+	# VANILLA_PROFILE has no stored sections -- treating it as "all mods off"
+	# lets Reset to Vanilla avoid touching the user's other profiles.
+	var is_vanilla := profile == VANILLA_PROFILE
+	var en_sec := "profile." + profile + ".enabled"
+	var pr_sec := "profile." + profile + ".priority"
 	for entry in _ui_mod_entries:
 		var fn: String = entry["file_name"]
-		entry["enabled"] = bool(cfg.get_value("enabled", fn, true))
+		if is_vanilla:
+			entry["enabled"] = false
+		elif cfg.has_section_key(en_sec, fn):
+			entry["enabled"] = bool(cfg.get_value(en_sec, fn))
+		else:
+			entry["enabled"] = true
 		if entry["ext"] == "zip":
 			entry["enabled"] = false
-		if cfg.has_section_key("priority", fn):
-			entry["priority"] = int(str(cfg.get_value("priority", fn)))
+		if cfg.has_section_key(pr_sec, fn):
+			entry["priority"] = int(str(cfg.get_value(pr_sec, fn)))
+
+func _list_profiles_in_cfg(cfg: ConfigFile) -> Array[String]:
+	var names: Array[String] = []
+	var prefix := "profile."
+	var suffix := ".enabled"
+	for sec: String in cfg.get_sections():
+		if sec.begins_with(prefix) and sec.ends_with(suffix):
+			var name: String = sec.substr(prefix.length(), sec.length() - prefix.length() - suffix.length())
+			# Skip VANILLA_PROFILE -- it's a sentinel, not a real profile, and
+			# leaked ghost sections (e.g. from pre-guard auto-save bugs) must
+			# not appear in the dropdown.
+			if name != "" and name != VANILLA_PROFILE and not (name in names):
+				names.append(name)
+	# Also include profiles that only have a priority section (shouldn't happen
+	# in practice, but guards against partial state).
+	var pr_suffix := ".priority"
+	for sec: String in cfg.get_sections():
+		if sec.begins_with(prefix) and sec.ends_with(pr_suffix):
+			var name: String = sec.substr(prefix.length(), sec.length() - prefix.length() - pr_suffix.length())
+			if name != "" and name != VANILLA_PROFILE and not (name in names):
+				names.append(name)
+	names.sort()
+	return names
+
+func _list_profiles() -> Array[String]:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return []
+	return _list_profiles_in_cfg(cfg)
 
 func _save_ui_config() -> void:
 	var cfg := ConfigFile.new()
-	# Load existing to preserve any custom [settings] keys (e.g. test flags).
 	cfg.load(UI_CONFIG_PATH)
-	# Clear mod-specific sections so removed mods don't linger.
+
+	# Drop legacy flat sections if they linger after migration.
 	if cfg.has_section("enabled"):
 		cfg.erase_section("enabled")
 	if cfg.has_section("priority"):
 		cfg.erase_section("priority")
-	for entry in _ui_mod_entries:
-		var fn: String = entry["file_name"]
-		cfg.set_value("enabled", fn, entry["enabled"])
-		cfg.set_value("priority", fn, entry["priority"])
+
+	# Skip profile-section writes while the Vanilla sentinel is active -- it's
+	# not a real profile and must not materialize stored sections, even from
+	# the Launch-time save in lifecycle.gd.
+	if _active_profile != VANILLA_PROFILE:
+		# Rewrite the active profile's sections fresh so removed mods don't linger.
+		var en_sec := "profile." + _active_profile + ".enabled"
+		var pr_sec := "profile." + _active_profile + ".priority"
+		if cfg.has_section(en_sec):
+			cfg.erase_section(en_sec)
+		if cfg.has_section(pr_sec):
+			cfg.erase_section(pr_sec)
+		for entry in _ui_mod_entries:
+			var fn: String = entry["file_name"]
+			cfg.set_value(en_sec, fn, entry["enabled"])
+			cfg.set_value(pr_sec, fn, entry["priority"])
+
 	cfg.set_value("settings", "developer_mode", _developer_mode)
+	cfg.set_value("settings", "active_profile", _active_profile)
 	cfg.save(UI_CONFIG_PATH)
 
-# UI Reset-to-Vanilla action: wipe all persistent mod state and restart. Used
-# by the "Reset to Vanilla" button. Uncheck all mods in memory so mod_config.cfg
-# loses the enabled flags, then call the shared static cleanup helper. Restart
-# the game so the clean slate actually takes effect.
+# Profile management: snapshot the current in-memory state to a new profile
+# and switch to it. Caller is responsible for validating `name` (unique,
+# non-empty, not "Vanilla").
+func _create_profile(name: String) -> void:
+	_active_profile = name
+	_save_ui_config()
+
+# Delete the active profile's sections and switch to whichever profile remains
+# first in alphabetical order. Caller must ensure at least one other profile
+# exists before calling this.
+func _delete_active_profile() -> void:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return
+	var target := _active_profile
+	for suffix: String in [".enabled", ".priority"]:
+		var sec := "profile." + target + suffix
+		if cfg.has_section(sec):
+			cfg.erase_section(sec)
+	var remaining := _list_profiles_in_cfg(cfg)
+	if remaining.is_empty():
+		_active_profile = "Default"
+	else:
+		_active_profile = remaining[0]
+	cfg.set_value("settings", "active_profile", _active_profile)
+	cfg.save(UI_CONFIG_PATH)
+	_apply_profile_to_entries(cfg, _active_profile)
+
+# Swap in-memory mod state to an existing profile. Does not write to disk
+# beyond updating the active_profile pointer -- mod enabled/priority values
+# already live in the profile sections.
+func _switch_profile(name: String) -> void:
+	_active_profile = name
+	var cfg := ConfigFile.new()
+	cfg.load(UI_CONFIG_PATH)
+	cfg.set_value("settings", "active_profile", _active_profile)
+	cfg.save(UI_CONFIG_PATH)
+	_apply_profile_to_entries(cfg, _active_profile)
+
+# Rename the active profile. We just save under the new name (which materializes
+# the sections from current in-memory state, matching what the old profile
+# held), then erase the old sections. Handles fresh-install placeholder cleanly
+# since _save_ui_config doesn't care whether sections existed previously.
+func _rename_profile(new_name: String) -> void:
+	var old := _active_profile
+	if old == new_name:
+		return
+	_active_profile = new_name
+	_save_ui_config()
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return
+	for suffix: String in [".enabled", ".priority"]:
+		var sec := "profile." + old + suffix
+		if cfg.has_section(sec):
+			cfg.erase_section(sec)
+	cfg.save(UI_CONFIG_PATH)
+
+# Parse a shared payload back into the fields needed to reconstruct a profile.
+# Returns either {"error": "..."} on failure or the parsed metroprofile dict
+# on success. Validates the MTRPRF1 magic, checksum, and JSON shape.
+func _parse_profile_payload(raw: String) -> Dictionary:
+	var parts := raw.strip_edges().split(".")
+	if parts.size() != 3:
+		return {"error": "Invalid format -- expected MTRPRF1.<body>.<checksum>"}
+	if parts[0] != "MTRPRF1":
+		return {"error": "Unknown payload type \"" + parts[0] + "\""}
+	var body: String = parts[1]
+	var check: String = parts[2]
+	var ctx := HashingContext.new()
+	ctx.start(HashingContext.HASH_SHA256)
+	ctx.update(body.to_utf8_buffer())
+	if check != ctx.finish().hex_encode().substr(0, 8):
+		return {"error": "Payload is corrupted -- checksum mismatch"}
+	var json_str := Marshalls.base64_to_utf8(body)
+	if json_str == "":
+		return {"error": "Payload body is not valid base64"}
+	var obj = JSON.parse_string(json_str)
+	if typeof(obj) != TYPE_DICTIONARY:
+		return {"error": "Payload JSON is not an object"}
+	var d: Dictionary = obj
+	if int(d.get("metroprofile", 0)) != 1:
+		return {"error": "Unsupported metroprofile schema version"}
+	if not (d.get("name") is String):
+		return {"error": "Payload missing name"}
+	if not (d.get("enabled") is Dictionary):
+		return {"error": "Payload missing enabled data"}
+	return d
+
+# Apply a parsed payload as a profile. Overwrites any existing profile with
+# the same name (caller is expected to have confirmed), switches to it, and
+# syncs in-memory entries.
+func _import_profile_from_parsed(parsed: Dictionary) -> void:
+	var name := _sanitize_profile_name(parsed["name"])
+	if name == "" or name.to_lower() == "vanilla" or name == VANILLA_PROFILE:
+		return
+	var cfg := ConfigFile.new()
+	cfg.load(UI_CONFIG_PATH)
+	var en_sec := "profile." + name + ".enabled"
+	var pr_sec := "profile." + name + ".priority"
+	if cfg.has_section(en_sec):
+		cfg.erase_section(en_sec)
+	if cfg.has_section(pr_sec):
+		cfg.erase_section(pr_sec)
+	var enabled_dict: Dictionary = parsed["enabled"]
+	for key in enabled_dict.keys():
+		cfg.set_value(en_sec, str(key), bool(enabled_dict[key]))
+	var priority_dict: Dictionary = parsed.get("priority", {})
+	for key in priority_dict.keys():
+		cfg.set_value(pr_sec, str(key), int(priority_dict[key]))
+	_active_profile = name
+	cfg.set_value("settings", "active_profile", _active_profile)
+	cfg.save(UI_CONFIG_PATH)
+	_apply_profile_to_entries(cfg, _active_profile)
+
+# Build the shareable opaque payload for the given profile. Shape:
+#     MTRPRF1.<base64-encoded JSON>.<first 8 hex chars of SHA-256(body)>
+# The magic prefix identifies the schema version, the body is the profile's
+# JSON, and the suffix lets a future import path detect copy/paste corruption
+# without full cryptographic verification. Empty string if the profile has
+# nothing to export.
+func _profile_to_payload(profile_name: String) -> String:
+	var json := _profile_to_json_string(profile_name)
+	if json == "":
+		return ""
+	var body := Marshalls.utf8_to_base64(json)
+	var ctx := HashingContext.new()
+	ctx.start(HashingContext.HASH_SHA256)
+	ctx.update(body.to_utf8_buffer())
+	var check := ctx.finish().hex_encode().substr(0, 8)
+	return "MTRPRF1." + body + "." + check
+
+# Serialize the named profile to a JSON string. Used as the inner layer of
+# _profile_to_payload; exposed separately in case we need it for debugging
+# or tests. Empty string if the profile has no stored sections.
+func _profile_to_json_string(profile_name: String) -> String:
+	var src := ConfigFile.new()
+	if src.load(UI_CONFIG_PATH) != OK:
+		return ""
+	var en_sec := "profile." + profile_name + ".enabled"
+	var pr_sec := "profile." + profile_name + ".priority"
+	if not src.has_section(en_sec):
+		return ""
+	var enabled: Dictionary = {}
+	for key: String in src.get_section_keys(en_sec):
+		enabled[key] = bool(src.get_value(en_sec, key))
+	var priority: Dictionary = {}
+	if src.has_section(pr_sec):
+		for key: String in src.get_section_keys(pr_sec):
+			priority[key] = int(str(src.get_value(pr_sec, key)))
+	return JSON.stringify({
+		"metroprofile":      1,
+		"name":              profile_name,
+		"modloader_version": MODLOADER_VERSION,
+		"exported_at":       Time.get_datetime_string_from_system(),
+		"enabled":           enabled,
+		"priority":          priority,
+	}, "  ")
+
+# File_names that the active profile references but which aren't present in
+# _ui_mod_entries (mod archives that were deleted or renamed since the profile
+# was saved). Rendered as red stub rows in the Mods list.
+func _missing_mods_in_active_profile() -> Array[String]:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return []
+	var en_sec := "profile." + _active_profile + ".enabled"
+	if not cfg.has_section(en_sec):
+		return []
+	var present: Dictionary = {}
+	for entry in _ui_mod_entries:
+		present[entry["file_name"]] = true
+	var missing: Array[String] = []
+	for key: String in cfg.get_section_keys(en_sec):
+		if not present.has(key):
+			missing.append(key)
+	missing.sort()
+	return missing
+
+# Strip an orphaned entry (file_name) from the active profile's sections.
+# Called from the "Remove" button on a missing-mod stub row.
+func _remove_missing_entry_from_profile(file_name: String) -> void:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return
+	for suffix: String in [".enabled", ".priority"]:
+		var sec := "profile." + _active_profile + suffix
+		if cfg.has_section(sec) and cfg.has_section_key(sec, file_name):
+			cfg.erase_section_key(sec, file_name)
+	cfg.save(UI_CONFIG_PATH)
+
+# Keep only letters, digits, space, underscore, hyphen. Strip edges. Reject
+# dots (they would collide with the `profile.<name>.enabled` section path).
+func _sanitize_profile_name(raw: String) -> String:
+	var trimmed := raw.strip_edges()
+	var out := ""
+	for i in trimmed.length():
+		var c := trimmed.substr(i, 1)
+		var u := trimmed.unicode_at(i)
+		var is_alpha := (u >= 65 and u <= 90) or (u >= 97 and u <= 122)
+		var is_digit := u >= 48 and u <= 57
+		if is_alpha or is_digit or c == " " or c == "-" or c == "_":
+			out += c
+	return out
+
+# Reset to Vanilla: switch the active profile to VANILLA_PROFILE, wipe the
+# hook pack + override.cfg, and restart the game clean. The active profile
+# pointer is the ONLY thing we touch in the config -- stored profiles survive
+# so the user can switch back and restore their selection.
+#
+# Important: we do NOT call _save_ui_config here. That would rewrite the
+# currently-active profile's sections from the in-memory _ui_mod_entries
+# state, which callers often set to all-disabled before invoking us.
 
 func _reset_to_vanilla_and_restart(win: Window) -> void:
 	_log_info("[Reset] User triggered Reset to Vanilla")
-	for entry in _ui_mod_entries:
-		entry["enabled"] = false
-	_save_ui_config()
+	var cfg := ConfigFile.new()
+	cfg.load(UI_CONFIG_PATH)
+	cfg.set_value("settings", "active_profile", VANILLA_PROFILE)
+	cfg.set_value("settings", "developer_mode", _developer_mode)
+	cfg.save(UI_CONFIG_PATH)
 	var log_lines := PackedStringArray()
 	_static_force_vanilla_state("UI reset button", log_lines)
 	for line in log_lines:
@@ -65,6 +368,299 @@ func _reset_to_vanilla_and_restart(win: Window) -> void:
 	OS.set_restart_on_exit(true, restart_args)
 	get_tree().quit()
 
+# Tear down and rebuild the Mods tab in place. Called whenever profile state
+# changes (switch, create, delete) or Developer Mode toggles, so rows and the
+# profile bar reflect fresh _ui_mod_entries + _active_profile state.
+func _rebuild_mods_tab(tabs: TabContainer) -> void:
+	var old := tabs.get_node_or_null("Mods")
+	if old == null:
+		return
+	var idx := old.get_index()
+	tabs.remove_child(old)
+	old.queue_free()
+	var new_tab := build_mods_tab(tabs)
+	new_tab.name = "Mods"
+	tabs.add_child(new_tab)
+	tabs.move_child(new_tab, idx)
+	tabs.current_tab = idx
+
+# Parent a dialog on the launcher window (fallback: tree root) so it layers
+# over our always_on_top Window, and copy our dark theme onto it since theme
+# lookup doesn't cross Window boundaries reliably.
+func _attach_ui_dialog(d: Window) -> void:
+	var parent: Node = _ui_window if _ui_window != null else get_tree().root
+	parent.add_child(d)
+	if _ui_window != null and _ui_window.theme != null:
+		d.theme = _ui_window.theme
+
+# Connect the same handler to both signals and a shared free-and-forget exit
+# path. ConfirmationDialog fires `canceled` on Cancel and `close_requested` on
+# ESC / window-X -- callers want both to behave the same.
+func _connect_dialog_exits(d: ConfirmationDialog, on_confirm: Callable, on_dismiss: Callable) -> void:
+	d.confirmed.connect(on_confirm)
+	d.canceled.connect(on_dismiss)
+	d.close_requested.connect(on_dismiss)
+
+# Make a Control swap the bottom-bar hint label to `text` while hovered and
+# restore the original on exit. Stand-in for Godot tooltips, which are popups
+# that render behind our always_on_top launcher window.
+func _wire_hint(c: Control, text: String) -> void:
+	if _ui_hint_label == null:
+		return
+	var default_text := _ui_hint_label.text
+	c.mouse_entered.connect(func():
+		if is_instance_valid(_ui_hint_label):
+			_ui_hint_label.text = text
+	)
+	c.mouse_exited.connect(func():
+		if is_instance_valid(_ui_hint_label):
+			_ui_hint_label.text = default_text
+	)
+
+# Vanilla dropdown entry: confirm, then run the full reset-and-restart flow.
+# Cancel rebuilds the Mods tab so the dropdown reverts from "Vanilla" back to
+# the currently-active profile.
+func _show_vanilla_confirm(tabs: TabContainer) -> void:
+	var d := ConfirmationDialog.new()
+	d.title = "Reset to Vanilla"
+	d.dialog_text = "This will disable all mods, wipe the hook cache and override.cfg, and restart the game clean.\n\nYour saved profiles are kept -- switch back to any of them later to re-enable those mods.\n\nContinue?"
+	d.ok_button_text = "Reset and Restart"
+	_attach_ui_dialog(d)
+	# Red text on the destructive button. theme_color_override on the OK
+	# button didn't take effect for reasons I haven't chased; modulate works
+	# because dark bg (~0.06) tints imperceptibly while light text (~0.84)
+	# multiplies into a clear red.
+	d.get_ok_button().modulate = Color(1.0, 0.55, 0.55)
+	var win_ref := _ui_window
+	_connect_dialog_exits(d,
+		func():
+			d.queue_free()
+			_reset_to_vanilla_and_restart(win_ref),
+		func():
+			d.queue_free()
+			_rebuild_mods_tab(tabs))
+	d.popup_centered()
+
+# New Profile dialog: prompt for a name, validate, snapshot current state
+# into the new profile, switch to it. Cancel leaves everything unchanged.
+func _show_new_profile_dialog(tabs: TabContainer) -> void:
+	var d := ConfirmationDialog.new()
+	d.title = "New Profile"
+	d.ok_button_text = "Create"
+	d.dialog_hide_on_ok = false  # keep open until we validate the name
+
+	var form := VBoxContainer.new()
+	form.custom_minimum_size = Vector2(320, 0)
+	form.add_theme_constant_override("separation", 6)
+	d.add_child(form)
+
+	var prompt := Label.new()
+	prompt.text = "Profile name (letters, digits, spaces, _-):"
+	form.add_child(prompt)
+
+	var name_edit := LineEdit.new()
+	name_edit.custom_minimum_size.x = 280
+	form.add_child(name_edit)
+
+	var err_lbl := Label.new()
+	err_lbl.modulate = Color(1.0, 0.5, 0.5)
+	err_lbl.add_theme_font_size_override("font_size", 11)
+	form.add_child(err_lbl)
+
+	_attach_ui_dialog(d)
+
+	var existing := _list_profiles()
+	var try_create := func():
+		var name := _sanitize_profile_name(name_edit.text)
+		if name == "":
+			err_lbl.text = "Name cannot be empty or all invalid characters."
+		elif name.to_lower() == "vanilla" or name == VANILLA_PROFILE:
+			err_lbl.text = "That name is reserved."
+		elif name in existing:
+			err_lbl.text = "Profile \"" + name + "\" already exists."
+		else:
+			d.queue_free()
+			_create_profile(name)
+			_rebuild_mods_tab(tabs)
+
+	name_edit.text_submitted.connect(func(_t): try_create.call())
+	_connect_dialog_exits(d, try_create, func(): d.queue_free())
+	d.popup_centered()
+	name_edit.grab_focus()
+
+# Rename dialog. Same validation rules as New (letters/digits/space/_-, not
+# empty, not "Vanilla", not colliding with another profile). Renaming to the
+# same name is a silent no-op.
+func _show_rename_profile_dialog(tabs: TabContainer) -> void:
+	var current := _active_profile
+	var d := ConfirmationDialog.new()
+	d.title = "Rename Profile"
+	d.ok_button_text = "Rename"
+	d.dialog_hide_on_ok = false
+
+	var form := VBoxContainer.new()
+	form.custom_minimum_size = Vector2(320, 0)
+	form.add_theme_constant_override("separation", 6)
+	d.add_child(form)
+
+	var prompt := Label.new()
+	prompt.text = "New name for \"" + current + "\":"
+	form.add_child(prompt)
+
+	var name_edit := LineEdit.new()
+	name_edit.custom_minimum_size.x = 280
+	name_edit.text = current
+	form.add_child(name_edit)
+
+	var err_lbl := Label.new()
+	err_lbl.modulate = Color(1.0, 0.5, 0.5)
+	err_lbl.add_theme_font_size_override("font_size", 11)
+	form.add_child(err_lbl)
+
+	_attach_ui_dialog(d)
+
+	var existing := _list_profiles()
+	var try_rename := func():
+		var name := _sanitize_profile_name(name_edit.text)
+		if name == "":
+			err_lbl.text = "Name cannot be empty or all invalid characters."
+		elif name.to_lower() == "vanilla" or name == VANILLA_PROFILE:
+			err_lbl.text = "That name is reserved."
+		elif name == current:
+			d.queue_free()  # no-op
+		elif name in existing:
+			err_lbl.text = "Profile \"" + name + "\" already exists."
+		else:
+			d.queue_free()
+			_rename_profile(name)
+			_rebuild_mods_tab(tabs)
+
+	name_edit.text_submitted.connect(func(_t): try_rename.call())
+	_connect_dialog_exits(d, try_rename, func(): d.queue_free())
+	d.popup_centered()
+	name_edit.select_all()
+	name_edit.grab_focus()
+
+# Combined Import / Export dialog. Top half shows the active profile's
+# checksummed payload with a Copy button; bottom half is a paste area +
+# Import button. Name collisions prompt for an overwrite confirm.
+func _show_share_profile_dialog(tabs: TabContainer) -> void:
+	var current := _active_profile
+	var payload := _profile_to_payload(current)
+
+	var d := AcceptDialog.new()
+	d.title = "Import / Export Profile"
+	d.ok_button_text = "Close"
+
+	var box := VBoxContainer.new()
+	box.custom_minimum_size = Vector2(560, 500)
+	box.add_theme_constant_override("separation", 8)
+	d.add_child(box)
+
+	# -- Export half -----------------------------------------------------------
+	var export_lbl := Label.new()
+	if payload != "":
+		export_lbl.text = "Profile \"" + current + "\" -- copy and share this payload:"
+	else:
+		export_lbl.text = "Nothing to export (active profile has no saved data yet)."
+		export_lbl.modulate = Color(0.55, 0.55, 0.55)
+	box.add_child(export_lbl)
+
+	var export_text := TextEdit.new()
+	export_text.text = payload
+	export_text.editable = false
+	export_text.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+	export_text.custom_minimum_size.y = 120
+	box.add_child(export_text)
+
+	var copy_btn := Button.new()
+	copy_btn.text = "Copy to Clipboard"
+	copy_btn.disabled = payload == ""
+	box.add_child(copy_btn)
+	copy_btn.pressed.connect(func():
+		DisplayServer.clipboard_set(payload)
+		copy_btn.text = "Copied!"
+	)
+
+	box.add_child(HSeparator.new())
+
+	# -- Import half -----------------------------------------------------------
+	var import_lbl := Label.new()
+	import_lbl.text = "Or paste someone else's payload to import their profile:"
+	box.add_child(import_lbl)
+
+	var import_text := TextEdit.new()
+	import_text.editable = true
+	import_text.wrap_mode = TextEdit.LINE_WRAPPING_BOUNDARY
+	import_text.custom_minimum_size.y = 100
+	box.add_child(import_text)
+
+	var err_lbl := Label.new()
+	err_lbl.modulate = Color(1.0, 0.5, 0.5)
+	err_lbl.add_theme_font_size_override("font_size", 11)
+	box.add_child(err_lbl)
+
+	var import_btn := Button.new()
+	import_btn.text = "Import"
+	box.add_child(import_btn)
+
+	_attach_ui_dialog(d)
+
+	# Import flow: parse, validate, prompt-to-overwrite if name collides,
+	# otherwise apply + switch + rebuild in one step.
+	var do_import := func():
+		var parsed := _parse_profile_payload(import_text.text)
+		if parsed.has("error"):
+			err_lbl.text = parsed["error"]
+			return
+		var name := _sanitize_profile_name(parsed["name"])
+		if name == "" or name.to_lower() == "vanilla" or name == VANILLA_PROFILE:
+			err_lbl.text = "Payload contains an invalid profile name."
+			return
+		var apply := func():
+			_import_profile_from_parsed(parsed)
+			d.queue_free()
+			_rebuild_mods_tab(tabs)
+		if name in _list_profiles():
+			var cd := ConfirmationDialog.new()
+			cd.title = "Overwrite Profile"
+			cd.dialog_text = "Profile \"" + name + "\" already exists. Overwrite it with the pasted payload?"
+			cd.ok_button_text = "Overwrite"
+			_attach_ui_dialog(cd)
+			_connect_dialog_exits(cd,
+				func():
+					cd.queue_free()
+					apply.call(),
+				func(): cd.queue_free())
+			cd.popup_centered()
+		else:
+			apply.call()
+
+	import_btn.pressed.connect(do_import)
+
+	var dismiss := func(): d.queue_free()
+	d.confirmed.connect(dismiss)
+	d.close_requested.connect(dismiss)
+	d.popup_centered()
+
+# Delete-profile confirmation. The trash button is already disabled when the
+# active profile is Vanilla or the last remaining user profile; the guard in
+# _delete_active_profile is belt-and-suspenders.
+func _show_delete_confirm(tabs: TabContainer) -> void:
+	var target := _active_profile
+	var d := ConfirmationDialog.new()
+	d.title = "Delete Profile"
+	d.dialog_text = "Delete profile \"" + target + "\"?\n\nThe mod selection stored in this profile will be discarded. Your other profiles are not affected."
+	d.ok_button_text = "Delete"
+	_attach_ui_dialog(d)
+	_connect_dialog_exits(d,
+		func():
+			d.queue_free()
+			_delete_active_profile()
+			_rebuild_mods_tab(tabs),
+		func(): d.queue_free())
+	d.popup_centered()
+
 # UI
 
 func show_mod_ui() -> void:
@@ -78,6 +674,8 @@ func show_mod_ui() -> void:
 	win.transparent_bg = true
 	get_tree().root.add_child(win)
 	win.popup_centered()
+	# Stash for dialogs triggered by profile-bar controls. Cleared on close.
+	_ui_window = win
 
 	# Kill the default Godot gray on the Window itself (embedded_border is the
 	# stylebox that paints the window's own background area).
@@ -100,13 +698,19 @@ func show_mod_ui() -> void:
 	bg.add_theme_stylebox_override("panel", bg_s)
 	win.add_child(bg)
 
+	# Assign the dark theme on the Window itself so child Windows (OptionButton
+	# popup + dialogs spawned from the profile bar) inherit it via the scene
+	# tree. Setting it only on the MarginContainer misses sub-Windows.
+	var dark_theme := make_dark_theme()
+	win.theme = dark_theme
+
 	var margin := MarginContainer.new()
 	margin.add_theme_constant_override("margin_left", 10)
 	margin.add_theme_constant_override("margin_right", 10)
 	margin.add_theme_constant_override("margin_top", 8)
 	margin.add_theme_constant_override("margin_bottom", 10)
 	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	margin.theme = make_dark_theme()
+	margin.theme = dark_theme
 	win.add_child(margin)
 
 	var root := VBoxContainer.new()
@@ -132,11 +736,10 @@ func show_mod_ui() -> void:
 	hint.add_theme_font_size_override("font_size", 11)
 	hint.modulate = Color(0.45, 0.45, 0.45)
 	bottom.add_child(hint)
+	# Expose for _wire_hint so toolbar/dropdown hovers can temporarily repurpose
+	# this label as a status-line substitute for broken Godot tooltips.
+	_ui_hint_label = hint
 
-	var reset_btn := Button.new()
-	reset_btn.text = "  Reset to Vanilla  "
-	reset_btn.custom_minimum_size = Vector2(150, 36)
-	reset_btn.tooltip_text = "Wipe all mod state (hook pack, override.cfg, cached archives) and restart the game clean. Use this when mods are stuck or you want a guaranteed vanilla launch."
 	var launch_btn := Button.new()
 	launch_btn.text = "  Launch Game  "
 	launch_btn.custom_minimum_size = Vector2(130, 36)
@@ -147,24 +750,16 @@ func show_mod_ui() -> void:
 	ls_n.border_width_left = 1; ls_n.border_width_right = 1
 	ls_n.content_margin_left = 10; ls_n.content_margin_right = 10
 	launch_btn.add_theme_stylebox_override("normal", ls_n)
-	reset_btn.add_theme_stylebox_override("normal", ls_n.duplicate())
 	var ls_h := ls_n.duplicate()
 	ls_h.bg_color = Color(0.10, 0.10, 0.10)
 	ls_h.border_color = Color(0.55, 0.55, 0.55)
 	launch_btn.add_theme_stylebox_override("hover", ls_h)
-	reset_btn.add_theme_stylebox_override("hover", ls_h.duplicate())
 	var ls_p := ls_n.duplicate()
 	ls_p.bg_color = Color(0.03, 0.03, 0.03)
 	launch_btn.add_theme_stylebox_override("pressed", ls_p)
-	reset_btn.add_theme_stylebox_override("pressed", ls_p.duplicate())
 	launch_btn.add_theme_color_override("font_color", Color(0.88, 0.88, 0.88))
 	launch_btn.add_theme_color_override("font_hover_color", Color(1.0, 1.0, 1.0))
-	reset_btn.add_theme_color_override("font_color", Color(0.70, 0.55, 0.55))
-	reset_btn.add_theme_color_override("font_hover_color", Color(1.0, 0.70, 0.70))
-	bottom.add_child(reset_btn)
 	bottom.add_child(launch_btn)
-
-	reset_btn.pressed.connect(func(): _reset_to_vanilla_and_restart(win))
 
 	# Closing the window with X should behave the same as clicking Launch.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
@@ -178,7 +773,58 @@ func show_mod_ui() -> void:
 	tabs.add_child(updates_tab)
 
 	await launch_btn.pressed
+	_ui_window = null
+	_ui_hint_label = null
 	win.queue_free()
+
+# Runtime-generated 16x16 pencil icon. Monochrome outline in button-text
+# gray so it matches the rest of the UI -- a colored pencil looks like an
+# emoji in this context.
+func _make_pencil_icon() -> ImageTexture:
+	var img := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0, 0, 0, 0))
+	var line := Color(0.84, 0.84, 0.84)  # matches C_TEXT in make_dark_theme
+	# Body outline: rectangle from (1,5) to (12,9).
+	for x in range(1, 13):
+		img.set_pixel(x, 5, line)
+		img.set_pixel(x, 9, line)
+	for y in range(5, 10):
+		img.set_pixel(1, y, line)
+		img.set_pixel(12, y, line)
+	# Divider between eraser compartment and main body.
+	for y in range(5, 10):
+		img.set_pixel(4, y, line)
+	# Triangular tip sticking off the right side.
+	img.set_pixel(13, 6, line)
+	img.set_pixel(13, 7, line)
+	img.set_pixel(13, 8, line)
+	img.set_pixel(14, 7, line)
+	return ImageTexture.create_from_image(img)
+
+# Runtime-generated 16x16 trashcan: lid handle on top, rectangular body with
+# three vertical slots.
+func _make_trashcan_icon() -> ImageTexture:
+	var img := Image.create(16, 16, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0, 0, 0, 0))
+	var line := Color(0.84, 0.84, 0.84)  # matches C_TEXT in make_dark_theme
+	# Lid handle (short bar on top).
+	for x in range(6, 10):
+		img.set_pixel(x, 2, line)
+	# Lid (wider bar).
+	for x in range(3, 13):
+		img.set_pixel(x, 4, line)
+	# Body sides + floor.
+	for y in range(5, 14):
+		img.set_pixel(4, y, line)
+		img.set_pixel(11, y, line)
+	for x in range(5, 11):
+		img.set_pixel(x, 13, line)
+	# Three vertical slots for texture.
+	for y in range(6, 12):
+		img.set_pixel(6, y, line)
+		img.set_pixel(8, y, line)
+		img.set_pixel(10, y, line)
+	return ImageTexture.create_from_image(img)
 
 func make_dark_theme() -> Theme:
 	var t := Theme.new()
@@ -270,11 +916,74 @@ func make_dark_theme() -> Theme:
 	# -- ScrollContainer (transparent, scrollbars inherit) ---------------------
 	t.set_stylebox("panel", "ScrollContainer", StyleBoxEmpty.new())
 
+	# -- PopupMenu (OptionButton dropdown) -------------------------------------
+	var pm_panel := StyleBoxFlat.new()
+	pm_panel.bg_color = Color(0.06, 0.06, 0.06)
+	pm_panel.border_color = C_BORD
+	pm_panel.border_width_top = 1; pm_panel.border_width_bottom = 1
+	pm_panel.border_width_left = 1; pm_panel.border_width_right = 1
+	pm_panel.content_margin_left = 4; pm_panel.content_margin_right = 4
+	pm_panel.content_margin_top = 4;  pm_panel.content_margin_bottom = 4
+	t.set_stylebox("panel", "PopupMenu", pm_panel)
+	var pm_hover := StyleBoxFlat.new()
+	pm_hover.bg_color = Color(0.14, 0.14, 0.14)
+	t.set_stylebox("hover", "PopupMenu", pm_hover)
+	var pm_sep := StyleBoxFlat.new()
+	pm_sep.bg_color = C_BORD
+	pm_sep.content_margin_top = 1; pm_sep.content_margin_bottom = 1
+	t.set_stylebox("separator", "PopupMenu", pm_sep)
+	t.set_color("font_color",           "PopupMenu", C_TEXT)
+	t.set_color("font_hover_color",     "PopupMenu", Color(1.0, 1.0, 1.0))
+	t.set_color("font_disabled_color",  "PopupMenu", C_DIM)
+	t.set_color("font_separator_color", "PopupMenu", C_DIM)
+
+	# -- OptionButton (themed like Button but needs its own panel stylebox
+	#    because OptionButton uses a separate theme type from Button) ----------
+	t.set_stylebox("normal",   "OptionButton", bn.duplicate())
+	t.set_stylebox("hover",    "OptionButton", bh.duplicate())
+	t.set_stylebox("pressed",  "OptionButton", bp.duplicate())
+	t.set_stylebox("disabled", "OptionButton", bd.duplicate())
+	t.set_stylebox("focus",    "OptionButton", StyleBoxEmpty.new())
+	t.set_color("font_color",         "OptionButton", C_TEXT)
+	t.set_color("font_hover_color",   "OptionButton", Color(1.0, 1.0, 1.0))
+	t.set_color("font_pressed_color", "OptionButton", C_TEXT)
+
+	# -- Tooltip (hover hint panel) --------------------------------------------
+	# Without these our tooltips render with the default light theme and get
+	# lost behind the always_on_top launcher window.
+	var tt_panel := StyleBoxFlat.new()
+	tt_panel.bg_color = Color(0.10, 0.10, 0.10)
+	tt_panel.border_color = C_BORD
+	tt_panel.border_width_top = 1; tt_panel.border_width_bottom = 1
+	tt_panel.border_width_left = 1; tt_panel.border_width_right = 1
+	tt_panel.content_margin_left = 8; tt_panel.content_margin_right = 8
+	tt_panel.content_margin_top = 4;  tt_panel.content_margin_bottom = 4
+	t.set_stylebox("panel", "TooltipPanel", tt_panel)
+	t.set_color("font_color", "TooltipLabel", C_TEXT)
+
+	# -- AcceptDialog / ConfirmationDialog -------------------------------------
+	# The dialog's own panel background + embedded-window border styleboxes.
+	var dlg_panel := StyleBoxFlat.new()
+	dlg_panel.bg_color = Color(0.06, 0.06, 0.06)
+	dlg_panel.border_color = C_BORD
+	dlg_panel.border_width_top = 1; dlg_panel.border_width_bottom = 1
+	dlg_panel.border_width_left = 1; dlg_panel.border_width_right = 1
+	dlg_panel.content_margin_left = 10; dlg_panel.content_margin_right = 10
+	dlg_panel.content_margin_top = 8;   dlg_panel.content_margin_bottom = 8
+	t.set_stylebox("panel", "AcceptDialog", dlg_panel)
+	t.set_stylebox("panel", "ConfirmationDialog", dlg_panel.duplicate())
+	t.set_stylebox("embedded_border",           "Window", dlg_panel.duplicate())
+	t.set_stylebox("embedded_unfocused_border", "Window", dlg_panel.duplicate())
+	t.set_color("title_color", "Window", C_HI)
+
 	return t
 
 func build_mods_tab(tabs: TabContainer) -> Control:
 	var outer := VBoxContainer.new()
 	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+	# -- Toolbar (profile selector + folder shortcut + dev toggle) ------------
+	# Single row: Open Mods Folder | Profile: [dropdown] [+] [pencil] [trash] [Share] | ... | Developer Mode
 
 	var toolbar := HBoxContainer.new()
 	toolbar.add_theme_constant_override("separation", 8)
@@ -286,6 +995,88 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	open_btn.pressed.connect(func():
 		OS.shell_open(ProjectSettings.globalize_path(_mods_dir))
 	)
+	_wire_hint(open_btn, "Open the game's mods folder in your file manager.")
+
+	# Small visual gap between folder button and profile controls.
+	var pre_profile_gap := Control.new()
+	pre_profile_gap.custom_minimum_size.x = 12
+	toolbar.add_child(pre_profile_gap)
+
+	var profile_lbl := Label.new()
+	profile_lbl.text = "Profile:"
+	toolbar.add_child(profile_lbl)
+
+	var profile_opt := OptionButton.new()
+	profile_opt.custom_minimum_size.x = 180
+	toolbar.add_child(profile_opt)
+
+	# The dropdown popup is a sub-Window. Our modloader Window is always_on_top,
+	# which leaves the popup stranded behind it (invisible on click). Mark the
+	# popup always_on_top and transient so it layers over us correctly. Theme
+	# assignment is explicit -- theme lookup doesn't always cross Window boundaries.
+	var profile_popup := profile_opt.get_popup()
+	profile_popup.always_on_top = true
+	profile_popup.transient = true
+	if _ui_window != null and _ui_window.theme != null:
+		profile_popup.theme = _ui_window.theme
+
+	# Item 0 is Vanilla; selecting it shows the reset-and-restart confirm.
+	# Godot 4 PopupMenu has no per-item text color, so the danger cue lives
+	# in the confirmation dialog's red OK button rather than on this entry.
+	profile_opt.add_item("Vanilla")
+	profile_opt.set_item_metadata(0, VANILLA_PROFILE)
+
+	# Fresh install has no profile sections yet -- show Default as a placeholder
+	# that gets materialized on the first _save_ui_config (Launch or any toggle).
+	var profiles := _list_profiles()
+	if profiles.is_empty():
+		profiles = ["Default"]
+	var active_idx := 0  # fall back to Vanilla if no user profile matches
+	for name: String in profiles:
+		profile_opt.add_item(name)
+		var idx := profile_opt.item_count - 1
+		profile_opt.set_item_metadata(idx, name)
+		if name == _active_profile:
+			active_idx = idx
+	profile_opt.selected = active_idx
+
+	# Profile-mutation buttons. Rename/Delete guard against Vanilla (sentinel
+	# has no underlying profile); Delete additionally needs at least one
+	# other profile to switch to.
+	var on_vanilla := _active_profile == VANILLA_PROFILE
+
+	var new_profile_btn := Button.new()
+	new_profile_btn.text = "+"
+	new_profile_btn.tooltip_text = "New profile from current mod selection"
+	new_profile_btn.custom_minimum_size.x = 28
+	toolbar.add_child(new_profile_btn)
+	_wire_hint(new_profile_btn, "New profile from current mod selection.")
+
+	var rename_btn := Button.new()
+	rename_btn.icon = _make_pencil_icon()
+	rename_btn.tooltip_text = "Rename the active profile"
+	rename_btn.disabled = on_vanilla
+	rename_btn.custom_minimum_size.x = 28
+	toolbar.add_child(rename_btn)
+	_wire_hint(rename_btn, "Rename the active profile.")
+
+	# Delete is disabled on Vanilla (nothing concrete to delete) and when only
+	# one user profile exists (we always need at least one to switch to).
+	var del_profile_btn := Button.new()
+	del_profile_btn.icon = _make_trashcan_icon()
+	del_profile_btn.tooltip_text = "Delete the active profile"
+	del_profile_btn.disabled = on_vanilla or profiles.size() <= 1
+	del_profile_btn.custom_minimum_size.x = 28
+	toolbar.add_child(del_profile_btn)
+	_wire_hint(del_profile_btn, "Delete the active profile.")
+
+	# Always enabled: even on Vanilla or an empty profile, users may want to
+	# paste in someone else's shared payload.
+	var share_btn := Button.new()
+	share_btn.text = "Share"
+	share_btn.tooltip_text = "Copy this profile to share, or paste one from someone else"
+	toolbar.add_child(share_btn)
+	_wire_hint(share_btn, "Copy this profile to share, or paste one from someone else.")
 
 	var spacer := Control.new()
 	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -298,20 +1089,26 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	dev_check.add_theme_font_size_override("font_size", 11)
 	dev_check.modulate = Color(0.45, 0.45, 0.45)
 	toolbar.add_child(dev_check)
+	_wire_hint(dev_check, "Developer Mode: verbose logging, conflict report, and loose folder loading.")
+
+	profile_opt.item_selected.connect(func(idx: int):
+		var meta = profile_opt.get_item_metadata(idx)
+		if meta == VANILLA_PROFILE:
+			_show_vanilla_confirm(tabs)
+		else:
+			_switch_profile(str(meta))
+			_rebuild_mods_tab(tabs)
+	)
+	new_profile_btn.pressed.connect(func(): _show_new_profile_dialog(tabs))
+	rename_btn.pressed.connect(func(): _show_rename_profile_dialog(tabs))
+	del_profile_btn.pressed.connect(func(): _show_delete_confirm(tabs))
+	share_btn.pressed.connect(func(): _show_share_profile_dialog(tabs))
 
 	dev_check.toggled.connect(func(on: bool):
 		_developer_mode = on
 		_ui_mod_entries = collect_mod_metadata()
 		_load_ui_config()
-		var old := tabs.get_node("Mods")
-		var idx := old.get_index()
-		tabs.remove_child(old)
-		old.queue_free()
-		var new_tab := build_mods_tab(tabs)
-		new_tab.name = "Mods"
-		tabs.add_child(new_tab)
-		tabs.move_child(new_tab, idx)
-		tabs.current_tab = idx
+		_rebuild_mods_tab(tabs)
 	)
 
 	outer.add_child(HSeparator.new())
@@ -328,9 +1125,17 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	left_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	split.add_child(left_scroll)
 
+	# Right padding keeps the load-order SpinBox arrows from sitting flush
+	# against the vertical scrollbar -- users were hitting the spin arrows
+	# while trying to drag the scrollbar handle.
+	var list_pad := MarginContainer.new()
+	list_pad.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	list_pad.add_theme_constant_override("margin_right", 16)
+	left_scroll.add_child(list_pad)
+
 	var list := VBoxContainer.new()
 	list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	left_scroll.add_child(list)
+	list_pad.add_child(list)
 
 	# -- Right: live load order preview ----------------------------------------
 
@@ -410,6 +1215,16 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 	# -- One row per mod -------------------------------------------------------
 
+	# Vanilla has no editable state; hint users to pick a profile before they
+	# try to toggle anything. Controls below are disabled alongside this note.
+	if on_vanilla and not _ui_mod_entries.is_empty():
+		var vanilla_note := Label.new()
+		vanilla_note.text = "Vanilla active -- switch to a profile to edit mods."
+		vanilla_note.modulate = Color(1.0, 0.55, 0.55)
+		vanilla_note.add_theme_font_size_override("font_size", 11)
+		list.add_child(vanilla_note)
+		list.add_child(HSeparator.new())
+
 	if _ui_mod_entries.is_empty():
 		var empty := Label.new()
 		empty.text = "No mods found.\n\nPlace .vmz or .pck files in:\n" \
@@ -451,7 +1266,9 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			warn.add_theme_font_size_override("font_size", 11)
 			name_col.add_child(warn)
 
-		if entry["ext"] == "zip":
+		# Vanilla has no stored profile; disable editing so auto-save can't
+		# create a ghost `profile.__vanilla__.*` section.
+		if entry["ext"] == "zip" or on_vanilla:
 			check.disabled = true
 
 		var spin := SpinBox.new()
@@ -459,7 +1276,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
-		if entry["ext"] == "zip":
+		if entry["ext"] == "zip" or on_vanilla:
 			spin.editable = false
 		row.add_child(spin)
 
@@ -472,11 +1289,44 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			e["enabled"] = on
 			nlbl.modulate = Color(0.58, 0.82, 0.38) if on else Color(0.5, 0.5, 0.5)
 			refresh_order.call()
+			_save_ui_config()
 		)
 		spin.value_changed.connect(func(val: float):
 			e["priority"] = int(val)
 			refresh_order.call()
+			_save_ui_config()
 		)
+
+	# -- Missing from this profile --------------------------------------------
+	# Mods the active profile references but that aren't on disk. Shown as red
+	# stub rows with a Remove button to strip the orphaned entry from the
+	# profile. Future: offer to download via modworkshop if an id is stored.
+	var missing_files := _missing_mods_in_active_profile()
+	if not missing_files.is_empty():
+		var missing_hdr := Label.new()
+		missing_hdr.text = "Missing from this profile"
+		missing_hdr.modulate = Color(1.0, 0.55, 0.55)
+		missing_hdr.add_theme_font_size_override("font_size", 11)
+		list.add_child(missing_hdr)
+		list.add_child(HSeparator.new())
+		for fn: String in missing_files:
+			var row := HBoxContainer.new()
+			list.add_child(row)
+			var miss_lbl := Label.new()
+			miss_lbl.text = fn + "  --  not installed"
+			miss_lbl.modulate = Color(1.0, 0.45, 0.45)
+			miss_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			row.add_child(miss_lbl)
+			var remove_btn := Button.new()
+			remove_btn.text = "Remove"
+			remove_btn.tooltip_text = "Strip this entry from the active profile"
+			row.add_child(remove_btn)
+			var captured := fn
+			remove_btn.pressed.connect(func():
+				_remove_missing_entry_from_profile(captured)
+				_rebuild_mods_tab(tabs)
+			)
+			list.add_child(HSeparator.new())
 
 	refresh_order.call()
 	return outer


### PR DESCRIPTION
## Summary
- Save/restore per-mod enable + load-order state per named profile in `mod_config.cfg`. Legacy flat `[enabled]`/`[priority]` sections migrate into a `Default` profile on first load.
- Profile selector in the Mods tab: switch, new, rename (pencil icon), delete (trashcan icon), share. `Vanilla` is a built-in dropdown entry with a red confirmation that runs the existing reset-and-restart flow; the `VANILLA_PROFILE` sentinel keeps stored profiles untouched and disables mod edits while active so auto-save can't create ghost sections.
- Share dialog copies / imports profiles as opaque `MTRPRF1.<base64 JSON>.<sha256-8>` payloads so paste corruption is catchable. Name collisions prompt to overwrite.
- Profile-referenced mods that aren't on disk render as red stub rows with a `Remove` button that strips the orphaned keys.
- Mod list gets a 16 px right margin so spinner arrows no longer sit flush against the scrollbar — users were accidentally changing load order while dragging the scrollbar.
- Bottom hint label doubles as a hover-driven status strip because Godot's native tooltips layer behind our always_on_top launcher window.

## Test plan
- [ ] Fresh install: `Default` placeholder in dropdown, toggling a mod materializes its sections in `mod_config.cfg`.
- [ ] Create/rename/delete flow: dialogs validate empty names, duplicates, and any case of `vanilla`; `VANILLA_PROFILE` sentinel blocked at all three.
- [ ] Switch profiles mid-session: checkboxes + spin values swap in place, no restart.
- [ ] Reset to Vanilla: red-button confirm, profiles survive, game relaunches clean.
- [ ] Share export: copy payload, paste into another install's Import field. Collision prompts overwrite; non-collision imports + switches.
- [ ] Corrupted payload: mutate any character and confirm the import error message triggers.
- [ ] Missing mods: delete a mod archive while a profile references it, confirm the red stub row and Remove.
- [ ] Scrollbar drag with many mods: spin arrows don't fire on scrollbar interactions.
- [x] Toolbar hover: bottom hint strip updates for each button.