### PR TITLE
chore: prepare 3.0.0 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025-2026 ametrocavich and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -9,7 +9,7 @@ The mod loader runs in two stages:
 
 | Stage | Trigger | Code |
 |---|---|---|
-| Static init | Module-scope var initializer evaluates before `_ready` | `var _filescope_mounted := _mount_previous_session()` at [src/constants.gd:161](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L161) |
+| Static init | Module-scope var initializer evaluates before `_ready` | `var _filescope_mounted := _mount_previous_session()` at [src/constants.gd:175](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L175) |
 | `_ready` | Godot calls it after scene enters tree | [src/lifecycle.gd:7](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/lifecycle.gd#L7) |
 
 The static-init trick works because Godot evaluates `var = <call>()` initializers at script-load time. The mounts land in VFS before any autoload scene graph resolves, so game autoloads can `preload(res://ModPath/Foo.gd)` without the archive being explicitly mounted in `_ready`.

--- a/docs/wiki/Build.md
+++ b/docs/wiki/Build.md
@@ -35,12 +35,12 @@ Dependencies flow top-down -- earlier files may not reference code defined later
 
 ### Invariants enforced by build.sh
 
-Post-concat sanity checks ([build.sh:57-69](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L57)):
+Post-concat sanity checks ([build.sh:58-70](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L58)):
 
 - **Exactly one `extends` line**, and it must be at the very top ([header.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/header.gd)).
 - **At most one `class_name`** declaration (currently there is none -- the loader is ModLoader autoload).
 
-Missing source file aborts before concat ([build.sh:46-48](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L46)).
+Missing source file aborts before concat ([build.sh:46-49](https://github.com/ametrocavich/vostok-mod-loader/blob/development/build.sh#L46)).
 
 ### Running it
 

--- a/docs/wiki/Developer-Mode.md
+++ b/docs/wiki/Developer-Mode.md
@@ -4,17 +4,17 @@ Dev mode is a per-user setting that unlocks folder-mod loading, verbose logging,
 
 ## How to enable
 
-UI toolbar checkbox in the Mods tab: **Developer Mode** ([ui.gd:294-315](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L294)). Toggle persists to `[settings] developer_mode` in `user://mod_config.cfg`.
+UI toolbar checkbox in the Mods tab: **Developer Mode** ([ui.gd:1302-1329](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L1302)). Toggle persists to `[settings] developer_mode` in `user://mod_config.cfg`.
 
-Loading the saved value runs at Pass-1 boot via [ui.gd:7 `_load_developer_mode_setting`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L7). Log line `"Developer mode: ON"` if enabled.
+Loading the saved value runs at Pass-1 boot via [ui.gd:14 `_load_developer_mode_setting`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L14). Log line `"Developer mode: ON"` if enabled.
 
 ## What it unlocks
 
 ### 1. Unpacked folder mods
 
-Subdirectories of `<exe>/mods/` are recognized as mod archives and zipped to `user://vmz_mount_cache/<name>_dev.zip` on the fly. Without dev mode, subdirectories are ignored ([mod_discovery.gd:25](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L25)).
+Subdirectories of `<exe>/mods/` are recognized as mod archives and zipped to `user://vmz_mount_cache/<name>_dev.zip` on the fly. Without dev mode, subdirectories are ignored ([mod_discovery.gd:29](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L29)).
 
-Folder entries show `[dev folder]` label in red in the UI ([ui.gd:441-446](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L441)).
+Folder entries show `[dev folder]` label in red in the UI ([ui.gd:1506-1511](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L1506)).
 
 Use case: in-development mods you haven't packaged yet.
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -41,7 +41,7 @@ if lib.has_replace("weaponrig-shoot"):
 
 ## Hook names
 
-Hook names follow this convention (documented at [constants.gd:102-103](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L102)):
+Hook names follow this convention (documented at [constants.gd:116-117](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L116)):
 
 ```
 <scriptname>-<methodname>[-pre|-post|-callback]
@@ -118,7 +118,7 @@ Void methods, coroutines (`await`), and engine lifecycle methods (`_ready` et al
 Source: [hooks_api.gd:42-65](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L42).
 
 1. Detect replace vs. aspect: `is_replace = not (name ends_with "-pre/-post/-callback")`.
-2. If replace and `_hooks[name]` is non-empty: debug-log the rejection, return `-1`. (Debug-level, not warning -- rejection is normal API behavior per the comment at [hooks_api.gd:49-53](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L49). Promoting to `push_warning` spammed stderr for expected conflicts.)
+2. If replace and `_hooks[name]` is non-empty: debug-log the rejection, return `-1`. (Debug-level, not warning -- rejection is normal API behavior per the comment at [hooks_api.gd:48-52](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd#L48). Promoting to `push_warning` spammed stderr for expected conflicts.)
 3. Create entry `{callback, priority, id}`, append to `_hooks[name]`, sort by priority ascending.
 4. Set `_any_mod_hooked = true` (sticky).
 5. Return `id`, increment `_next_id`.

--- a/docs/wiki/Limitations.md
+++ b/docs/wiki/Limitations.md
@@ -18,7 +18,7 @@ Godot quirks and design constraints the loader works around or can't work around
 
 ## Scripts deliberately not rewritten
 
-Runtime-sensitive scripts in `RTV_SKIP_LIST` at [constants.gd:47-55](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L47). Dispatch wrappers break their runtime semantics:
+Runtime-sensitive scripts in `RTV_SKIP_LIST` at [constants.gd:50-58](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L50). Dispatch wrappers break their runtime semantics:
 
 | Script | Reason |
 |---|---|
@@ -32,9 +32,9 @@ Runtime-sensitive scripts in `RTV_SKIP_LIST` at [constants.gd:47-55](https://git
 
 Hooks on methods in these scripts won't fire. Mods should hook alternative call sites.
 
-Resource-serialized scripts at [constants.gd:59-64](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L59) (save data -- `CharacterSave`, `ContainerSave`, `FurnitureSave`, `ItemSave`, `Preferences`, `ShelterSave`, `SlotData`, `SwitchSave`, `TraderSave`, `Validator`, `WorldSave`) aren't rewritten -- `ResourceSaver` embeds the script path into user save files, and wrapping the script would make saves mod-dependent.
+Resource-serialized scripts at [constants.gd:62-67](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L62) (save data -- `CharacterSave`, `ContainerSave`, `FurnitureSave`, `ItemSave`, `Preferences`, `ShelterSave`, `SlotData`, `SwitchSave`, `TraderSave`, `Validator`, `WorldSave`) aren't rewritten -- `ResourceSaver` embeds the script path into user save files, and wrapping the script would make saves mod-dependent.
 
-Data-resource scripts at [constants.gd:68-77](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L68) (25 entries: `AIWeaponData`, `AttachmentData`, `ItemData`, `LootTable`, `Recipes`, etc.) aren't rewritten -- they're loaded from `res://` only, have no call sites to intercept. Mods should hook the consumers instead.
+Data-resource scripts at [constants.gd:71-80](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L71) (25 entries: `AIWeaponData`, `AttachmentData`, `ItemData`, `LootTable`, `Recipes`, etc.) aren't rewritten -- they're loaded from `res://` only, have no call sites to intercept. Mods should hook the consumers instead.
 
 ## Scene-preload deferred compile
 

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -47,7 +47,7 @@ needs=["Controller", "Camera"]
 | `version` | string | `""` | Used by the Updates tab to compare against ModWorkshop |
 | `priority` | int | 0 (or parsed from filename prefix) | Higher loads later, wins file conflicts. Clamped to `-999..999` |
 
-**VostokMods compat**: if the archive filename matches `^(-?\d+)-(.*)`, the numeric prefix is used as a fallback priority when `[mod] priority` isn't set. Example: `100-BetterAI.vmz` loads with `priority=100`. See [mod_discovery.gd:73-85](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L73).
+**VostokMods compat**: if the archive filename matches `^(-?\d+)-(.*)`, the numeric prefix is used as a fallback priority when `[mod] priority` isn't set. Example: `100-BetterAI.vmz` loads with `priority=100`. See [mod_discovery.gd:119-131](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L119).
 
 ### `[autoload]` section
 
@@ -77,7 +77,7 @@ Duplicate autoload names are logged and skipped (first wins). Paths not present 
 |---|---|---|
 | `modworkshop` | int | ModWorkshop mod id. Enables the Updates tab for this mod |
 
-Version compare uses [mod_discovery.gd:138 `compare_versions`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L138) -- splits on `.`, strips `v`/`V` prefix, pads shorter side with `"0"`, lexicographic int comparison.
+Version compare uses [mod_discovery.gd:195 `compare_versions`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L195) -- splits on `.`, strips `v`/`V` prefix, pads shorter side with `"0"`, lexicographic int comparison.
 
 ### `[script_overrides]` section
 
@@ -156,4 +156,4 @@ CONFLICT: res://Scripts/SomeFile.gd
     [2] ModB via ModB.vmz <-- wins
 ```
 
-Within equal priority, load order is stable: mod_name ascii-lowercase, then filename. See [mod_discovery.gd:127 `_compare_load_order`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L127).
+Within equal priority, load order is stable: mod_name ascii-lowercase, then filename. See [mod_discovery.gd:184 `_compare_load_order`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L184).

--- a/docs/wiki/Modules.md
+++ b/docs/wiki/Modules.md
@@ -14,7 +14,7 @@ All module-scope `const`, `var`, and `signal` declarations. Everything has to la
 
 - `MODLOADER_VERSION` at [constants.gd:13](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L13) -- release-please bumps this via Conventional Commits, bracketed by `x-release-please-start/end` markers
 - `RTV_SKIP_LIST` (7 scripts), `RTV_RESOURCE_SERIALIZED_SKIP` (11), `RTV_RESOURCE_DATA_SKIP` (25) -- scripts the rewriter refuses to touch, each with inline rationale
-- `_filescope_mounted := _mount_previous_session()` at [constants.gd:161](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L161) -- a module-scope var with a function-call initializer. This is what triggers the static-init mount before `_ready`
+- `_filescope_mounted := _mount_previous_session()` at [constants.gd:175](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/constants.gd#L175) -- a module-scope var with a function-call initializer. This is what triggers the static-init mount before `_ready`
 
 ### [logging.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/logging.gd)
 
@@ -34,7 +34,7 @@ Includes both static functions (callable from static init before instance state 
 
 The largest domain. Owns:
 
-- `_mount_previous_session` at [boot.gd:32](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L32) -- the static-init entry point triggered by `constants.gd:161`
+- `_mount_previous_session` at [boot.gd:32](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L32) -- the static-init entry point triggered by `constants.gd:175`
 - Sentinel handling (disabled, safe mode, Pass 2 dirty marker)
 - `override.cfg` reading + writing (`_write_override_cfg`, `_restore_clean_override_cfg`)
 - Pass state persistence (`_write_pass_state`, `_compute_state_hash`)
@@ -95,7 +95,7 @@ Two-layer override verification:
 
 Pre-game launcher window. Two tabs (Mods, Updates), dark theme, Reset-to-Vanilla action. Closing the window equals clicking Launch Game.
 
-- `show_mod_ui` at [ui.gd:70](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L70)
+- `show_mod_ui` at [ui.gd:871](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L871)
 - `build_mods_tab` / `build_updates_tab` -- tab content
 - `make_dark_theme` -- Theme resource with pure-black backgrounds
 - `_reset_to_vanilla_and_restart` -- unchecks every mod, calls `_static_force_vanilla_state`, strips `--modloader-restart` from cmdline so the relaunch is a clean Pass 1

--- a/docs/wiki/Stability-Canaries.md
+++ b/docs/wiki/Stability-Canaries.md
@@ -93,7 +93,7 @@ Boot-time probes that alarm loudly when something the loader depends on silently
 
 **Effect**: unchecks every mod in memory, saves config, calls `_static_force_vanilla_state` (same cleanup as the disabled sentinel), strips `--modloader-restart` from cmdline args, and restarts the game clean.
 
-**Source**: [ui.gd:48 `_reset_to_vanilla_and_restart`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L48).
+**Source**: [ui.gd:418 `_reset_to_vanilla_and_restart`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L418).
 
 **When to use**: mods loaded but the game crashes or behaves badly. User clicks the button, gets a guaranteed vanilla next launch.
 


### PR DESCRIPTION
## Summary

Release-prep polish pass plus a `Release-As: 3.0.0` trailer so release-please cuts exactly `v3.0.0` instead of the default minor bump from `2.3.1`.

- `LICENSE`: add copyright attribution + 2025-2026 year range (was bare template)
- `docs/wiki/*.md`: fix 17 drifted line-number references across 8 pages -- every cited symbol (`constants.gd`, `ui.gd`, `mod_discovery.gd`, `build.sh`, `hooks_api.gd`, etc.) verified against current `src/` lines

No code changes. No `src/*.gd` or `modloader.gd` touched.

## Why 3.0.0

The `2.1.0 -> current` gap is a meaningful architecture step (src/ split + build pipeline, source-rewrite hook system, release-please automation, mod profiles, security scanner, developer wiki). Users upgrading will notice -- the version should too.

## Release mechanics

Once this PR squash-merges into `development`, the squashed commit carries the `Release-As: 3.0.0` footer forward. When `development` rebase-merges into `master`, release-please reads it and opens a release PR titled "chore(main): release 3.0.0". Merging that PR creates the `v3.0.0` tag and uploads `modloader.gd` + `override.cfg` as release assets.

## Test plan

- [ ] Link check: spot-click a few wiki-edited links on the rendered GitHub Wiki post-merge
- [ ] Release-As pickup: confirm release-please opens a `release 3.0.0` PR (not `2.4.0`) after the `development -> master` PR lands
- [ ] Release assets: confirm `modloader.gd` + `override.cfg` attach to the `v3.0.0` release on tag creation

Release-As: 3.0.0