### PR TITLE
feat: opt-in hook declarations, cutover from inference-based wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,35 @@ modworkshop=12345
 
 Mods without `mod.txt` still mount as resource packs -- their files override vanilla resources, but no autoloads run.
 
-Full schema (including `[script_overrides]`, `[rtvmodlib] needs=`, the `!` prefix semantics, and packaging gotchas): see the [Mod-Format wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Mod-Format).
+### Opt-in hook declarations
+
+v2.4.0 uses an opt-in model: a modlist that declares nothing loads byte-identical to a vanilla setup (no wrap, no rewrite, no hook pack). Declarations turn on specific parts of the system.
+
+```ini
+[hooks]
+res://Scripts/Interface.gd = _ready, update_tooltip
+res://Scripts/Controller.gd = Movement
+
+[script_extend]
+res://Scripts/Camera.gd = res://MyMod/MyCamera.gd
+
+[registry]
+; declaring this section is enough to enable lib.register() / lib.override()
+```
+
+- **`[hooks]`** -- list methods by vanilla script path. Those methods get dispatch wrappers at runtime so your `.hook(...)` callbacks fire. Only declared methods are wrapped; everything else in the script stays vanilla. Scanning `.hook(...)` calls in your source also enrolls the corresponding method.
+- **`[script_extend]`** -- a full-script replacement that chains via Godot's `extends` resolution. Multiple mods can extend the same vanilla script; take_over_path runs in priority order, each override's `extends` resolves to the prior chain tip. `[script_overrides]` is kept as a legacy alias.
+- **`[registry]`** -- declaring this section enables `lib.register()` / `lib.override()` on Database.gd. Without it, the registry helpers never get injected and those calls return `false`.
+
+Full schema (including `[rtvmodlib] needs=`, the `!` prefix semantics, and packaging gotchas): see the [Mod-Format wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Mod-Format).
+
+### Migrating from v3.0.0
+
+v3.0.0 inferred the wrap surface from `extends`, `take_over_path`, and a pinned list, then rewrote mod source to auto-fire hooks even when mods replaced a method without calling `super()`. v2.4.0 removes the inference and the mod-source rewrite. If your mod relied on either, you need to declare intent:
+
+- If your mod calls `.hook(...)` but never declared a `[hooks]` section: no change needed -- scanner picks up the `.hook()` call.
+- If your mod's override replaced a vanilla method fully and expected hooks to fire via the old rewrite: add `super.method(...)` at the start of the override, OR add a `[hooks]` entry for that method.
+- If your mod used `lib.register()` / `lib.override()` without declaring `[registry]`: add the `[registry]` section.
 
 ## Hooks
 
@@ -95,7 +123,7 @@ Hook name format: `<scriptname>-<methodname>[-pre|-post|-callback]` lowercase. B
 
 The API is drop-in compatible with [tetrahydroc's RTVModLib mod](https://github.com/tetrahydroc/rtv-mod-lib) (`hook` / `unhook` / `_caller` / `skip_super` / `frameworks_ready`, same signatures). Mod code written against RTVModLib runs unchanged here.
 
-Full API reference, dispatch semantics, three-entry pack recipe, mod subclass rewriting, and worked examples: [Hooks wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Hooks).
+Full API reference, dispatch semantics, and three-entry pack recipe: [Hooks wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Hooks).
 
 ## Troubleshooting
 
@@ -113,8 +141,9 @@ More recovery detail (heartbeat, restart counter, crashed-Pass-2 dirty marker): 
 
 - **Package as `.vmz`** with forward-slash paths. Use 7-Zip, not .NET `ZipFile.CreateFromDirectory()` (writes backslashes, breaks mounting).
 - **Include a `mod.txt`** at the archive root. Without it, autoloads won't run.
-- **Use `super()` in lifecycle methods** (`_ready`, `_process`, etc.) when overriding vanilla scripts. Skipping it breaks other mods that override the same class.
-- **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't. Every vanilla script is hooked automatically -- just register callbacks.
+- **Use `super()` in lifecycle methods** (`_ready`, `_process`, etc.) when overriding vanilla scripts. Skipping it breaks hook composition for other mods that hooked that method.
+- **Declare `[hooks]` or call `.hook(...)`** on the vanilla methods you care about. In v2.4.0, only declared methods get dispatch wrappers -- there's no auto-wrap surface anymore.
+- **Prefer hooks over file replacement** when you only need to modify a few methods. Hooks compose across mods; file replacement doesn't.
 - **Test with other mods installed** and check the conflict report (Developer Mode).
 
 ## Contributing

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -217,14 +217,16 @@ static func _mount_previous_session() -> Dictionary:
 	# First-ever session: no pass_state entry, skip. Pass 1 will generate
 	# and activate this session -- Camera/WeaponRig fall back to PCK
 	# bytecode that first run. Second session onward: pre-mount works.
-	# Fallback to HOOK_PACK_ZIP constant if pass_state lost the key
-	# (e.g. after a version-mismatch wipe). The zip survives on disk.
+	# No fallback by filename: per-session filenames mean a lost pass_state
+	# entry leaves us with orphan files we can't distinguish. Let Pass 1
+	# regenerate from scratch; the orphan-cleanup pass below sweeps them.
 	var hook_pack: String = cfg.get_value("state", "hook_pack_path", "") as String
-	if hook_pack == "":
-		var fallback_abs := ProjectSettings.globalize_path(HOOK_PACK_ZIP)
-		if FileAccess.file_exists(fallback_abs):
-			hook_pack = HOOK_PACK_ZIP
-			log_lines.append("[FileScope] HOOK PACK path missing from pass_state -- using fallback: " + HOOK_PACK_ZIP)
+	# Orphan cleanup: previous sessions may have left framework_pack_*.zip
+	# files behind (Windows can't delete the currently-mounted one mid-session).
+	# At static-init the engine has mounted nothing yet, so deleting every pack
+	# EXCEPT the one pass_state points at is safe. Prevents unbounded growth
+	# for users cycling large mod sets over many sessions.
+	_static_cleanup_orphan_hook_packs(hook_pack, log_lines)
 	if hook_pack != "":
 		var hook_abs: String = hook_pack if not hook_pack.begins_with("user://") \
 				else ProjectSettings.globalize_path(hook_pack)
@@ -318,8 +320,42 @@ static func _static_reset_override_cfg(log_lines: PackedStringArray) -> void:
 	f.close()
 	log_lines.append("[FileScope] override.cfg reset to clean [autoload_prepend] state")
 
+static func _static_cleanup_orphan_hook_packs(keep_path: String, log_lines: PackedStringArray) -> void:
+	# Delete every framework_pack_*.zip in HOOK_PACK_DIR except keep_path.
+	# Called at static-init BEFORE any hook-pack mount, so the VFS holds no
+	# handles to these files. Safe to delete them on every platform. If
+	# keep_path is empty (no pass_state entry, or no hook pack yet) every
+	# file matching the pattern is treated as orphan.
+	var pack_dir := ProjectSettings.globalize_path(HOOK_PACK_DIR)
+	if not DirAccess.dir_exists_absolute(pack_dir):
+		return
+	var keep_abs := ProjectSettings.globalize_path(keep_path) if keep_path != "" else ""
+	var dir := DirAccess.open(pack_dir)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var removed := 0
+	while true:
+		var fname := dir.get_next()
+		if fname == "":
+			break
+		if not fname.begins_with(HOOK_PACK_PREFIX) or not fname.ends_with(".zip"):
+			continue
+		var full := pack_dir.path_join(fname)
+		if keep_abs != "" and full == keep_abs:
+			continue
+		DirAccess.remove_absolute(full)
+		removed += 1
+	dir.list_dir_end()
+	if removed > 0:
+		log_lines.append("[FileScope] Cleaned %d orphan hook pack(s) from prior session(s)" % removed)
+
 static func _static_wipe_hook_cache() -> void:
-	# Wipe every Framework*.gd we previously generated (cheap to regenerate).
+	# Wipe every Framework*.gd we previously generated (cheap to regenerate)
+	# and every framework_pack_*.zip (per-session hook packs). On Windows,
+	# a zip currently mounted by Godot's VFS may refuse deletion (open handle);
+	# the orphan-cleanup pass in _mount_previous_session catches stragglers
+	# on the next fresh-engine launch.
 	var pack_dir := ProjectSettings.globalize_path(HOOK_PACK_DIR)
 	if DirAccess.dir_exists_absolute(pack_dir):
 		var pdir := DirAccess.open(pack_dir)
@@ -330,6 +366,8 @@ static func _static_wipe_hook_cache() -> void:
 				if pname == "":
 					break
 				if pname.begins_with("Framework") and pname.ends_with(".gd"):
+					DirAccess.remove_absolute(pack_dir.path_join(pname))
+				elif pname.begins_with(HOOK_PACK_PREFIX) and pname.ends_with(".zip"):
 					DirAccess.remove_absolute(pack_dir.path_join(pname))
 			pdir.list_dir_end()
 	var cache_dir := ProjectSettings.globalize_path(VANILLA_CACHE_DIR)
@@ -497,20 +535,20 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 		DirAccess.remove_absolute(tmp)
 	return err
 
-func _persist_hook_pack_state() -> void:
+func _persist_hook_pack_state(pack_path: String) -> void:
 	# Write hook_pack_path to pass_state so _mount_previous_session() can
 	# mount it at static init in the next session. Piggybacks on the
 	# existing pass_state ConfigFile -- doesn't overwrite other keys.
 	var cfg := ConfigFile.new()
 	cfg.load(PASS_STATE_PATH)  # OK if missing; we populate below
-	cfg.set_value("state", "hook_pack_path", HOOK_PACK_ZIP)
+	cfg.set_value("state", "hook_pack_path", pack_path)
 	# Store exe mtime alongside so _mount_previous_session's existing
 	# exe-mtime check also invalidates the hook pack on game updates.
 	cfg.set_value("state", "hook_pack_exe_mtime", FileAccess.get_modified_time(OS.get_executable_path()))
 	if cfg.get_value("state", "modloader_version", "") == "":
 		cfg.set_value("state", "modloader_version", MODLOADER_VERSION)
 	if cfg.save(PASS_STATE_PATH) == OK:
-		_log_info("[RTVCodegen] Persisted hook pack path for next-session static-init mount")
+		_log_info("[RTVCodegen] Persisted hook pack path for next-session static-init mount: " + pack_path.get_file())
 
 func _write_pass_state(archive_paths: PackedStringArray, state_hash: String = "") -> Error:
 	var cfg := ConfigFile.new()

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -52,62 +52,12 @@ static func _mount_previous_session() -> Dictionary:
 		_write_filescope_log(log_lines)
 		return mounted
 
-	# PRE-INIT cache snapshot + preempt list: class_name scripts that Godot
-	# boot-compiles (via autoload imports or initial scene graph references)
-	# get their PCK .gdc bytecode pinned in ScriptServer.class_cache before
-	# any ModLoader code runs. Once pinned, runtime rewire can't displace
-	# them. Preempt these at static init with CACHE_MODE_IGNORE to force our
-	# rewrite into the cache first.
-	#
-	# Not on the list:
-	#  - class_name scripts NOT referenced at boot (Inspect, Item, Slot,
-	#    Surface, Area, Mine, MuzzleFlash). Godot lazy-loads them on first
-	#    reference, hitting our VFS overlay. No preempt needed.
-	#  - Scripts without class_name (Bed, Cat, Menu, Loader, Database, etc.).
-	#    Same VFS-lazy-load path; our rewrite wins at first compile.
-	#
-	# Reduced from 43 entries (2026-04-18): 27 non-class_name entries cut
-	# after empirical verification that VFS lazy-load handles them.
-	var pinned_probes: Array[String] = [
-		"res://Scripts/Camera.gd",        # class_name Camera
-		"res://Scripts/Controller.gd",    # class_name Controller
-		"res://Scripts/Door.gd",          # class_name Door
-		"res://Scripts/Fish.gd",          # class_name Fish
-		"res://Scripts/Furniture.gd",     # class_name Furniture
-		"res://Scripts/GameData.gd",      # class_name GameData
-		"res://Scripts/Grenade.gd",       # class_name Grenade
-		"res://Scripts/Grid.gd",          # class_name Grid
-		"res://Scripts/Hitbox.gd",        # class_name Hitbox
-		"res://Scripts/KnifeRig.gd",      # class_name Knife
-		"res://Scripts/LootContainer.gd", # class_name LootContainer
-		"res://Scripts/Lure.gd",          # class_name Lure
-		"res://Scripts/Pickup.gd",        # class_name Pickup
-		"res://Scripts/Settings.gd",      # class_name Settings
-		"res://Scripts/Trader.gd",        # class_name Trader
-		"res://Scripts/WeaponRig.gd",     # class_name WeaponRig
-	]
-	var pre_cached_count := 0
-	var pre_cached_tokenized: PackedStringArray = []
-	var pre_cached_source: PackedStringArray = []
-	var pre_notloaded: PackedStringArray = []
-	for path in pinned_probes:
-		if ResourceLoader.has_cached(path):
-			pre_cached_count += 1
-			var s := load(path) as GDScript
-			if s != null and s.source_code.length() > 0:
-				pre_cached_source.append(path.get_file())
-			else:
-				pre_cached_tokenized.append(path.get_file())
-		else:
-			pre_notloaded.append(path.get_file())
-	log_lines.append("[FileScope] PRE-INIT cache: %d/%d probes already cached at static init" \
-			% [pre_cached_count, pinned_probes.size()])
-	if pre_cached_tokenized.size() > 0:
-		log_lines.append("[FileScope]   tokenized (PCK-compiled already): " + ", ".join(pre_cached_tokenized))
-	if pre_cached_source.size() > 0:
-		log_lines.append("[FileScope]   source-loaded (our take_over_path from prev session): " + ", ".join(pre_cached_source))
-	if pre_notloaded.size() > 0:
-		log_lines.append("[FileScope]   NOT YET LOADED (preempt window open): " + ", ".join(pre_notloaded))
+	# Pinned probes narrowed (v2.4.0): previously a hardcoded list of 16
+	# class_name scripts the game pre-compiles at boot. Now read from the
+	# pass_state's hook_pack_wrapped_paths key -- only scripts this modlist
+	# actually wrapped get CACHE_MODE_IGNORE preempt. Populated further
+	# down after pass_state loads; the cache-snapshot diagnostic now logs
+	# whatever the prior session wrapped.
 
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) != OK:
@@ -221,45 +171,58 @@ static func _mount_previous_session() -> Dictionary:
 	# entry leaves us with orphan files we can't distinguish. Let Pass 1
 	# regenerate from scratch; the orphan-cleanup pass below sweeps them.
 	var hook_pack: String = cfg.get_value("state", "hook_pack_path", "") as String
+	var wrapped_paths: PackedStringArray = cfg.get_value("state", "hook_pack_wrapped_paths", PackedStringArray())
 	# Orphan cleanup: previous sessions may have left framework_pack_*.zip
 	# files behind (Windows can't delete the currently-mounted one mid-session).
 	# At static-init the engine has mounted nothing yet, so deleting every pack
 	# EXCEPT the one pass_state points at is safe. Prevents unbounded growth
 	# for users cycling large mod sets over many sessions.
 	_static_cleanup_orphan_hook_packs(hook_pack, log_lines)
+	# Cache-snapshot diagnostic -- shows which wrapped scripts were already
+	# loaded into ResourceLoader by Godot's eager class_cache pass before
+	# we get a chance to preempt them. Useful for diagnosing "why didn't
+	# my hook fire" on pinned paths. Skipped when no wrapped_paths exist.
+	if wrapped_paths.size() > 0:
+		var pre_cached_count := 0
+		var pre_cached_tokenized: PackedStringArray = []
+		var pre_cached_source: PackedStringArray = []
+		var pre_notloaded: PackedStringArray = []
+		for path in wrapped_paths:
+			if ResourceLoader.has_cached(path):
+				pre_cached_count += 1
+				var s := load(path) as GDScript
+				if s != null and s.source_code.length() > 0:
+					pre_cached_source.append(path.get_file())
+				else:
+					pre_cached_tokenized.append(path.get_file())
+			else:
+				pre_notloaded.append(path.get_file())
+		log_lines.append("[FileScope] PRE-INIT cache: %d/%d wrapped scripts already cached at static init" \
+				% [pre_cached_count, wrapped_paths.size()])
+		if pre_cached_tokenized.size() > 0:
+			log_lines.append("[FileScope]   tokenized (PCK-compiled already): " + ", ".join(pre_cached_tokenized))
+		if pre_cached_source.size() > 0:
+			log_lines.append("[FileScope]   source-loaded (our take_over_path from prev session): " + ", ".join(pre_cached_source))
+		if pre_notloaded.size() > 0:
+			log_lines.append("[FileScope]   NOT YET LOADED (preempt window open): " + ", ".join(pre_notloaded))
 	if hook_pack != "":
 		var hook_abs: String = hook_pack if not hook_pack.begins_with("user://") \
 				else ProjectSettings.globalize_path(hook_pack)
 		if FileAccess.file_exists(hook_abs):
 			if ProjectSettings.load_resource_pack(hook_abs, true):
 				log_lines.append("[FileScope] HOOK PACK mounted at static init: " + hook_pack)
-				# CRITICAL: mounting alone isn't enough. Godot pre-compiles
-				# class_name scripts referenced by the initial scene graph
-				# (Camera, WeaponRig) BEFORE ModLoader._ready. Once they land
-				# in ScriptServer.class_cache as PCK-bytecode, no runtime
-				# rewire works. Force a fresh source-compile of every
-				# rewritten script RIGHT NOW while we're still at static
-				# init -- before game autoloads run, before any scene
-				# instantiates. take_over_path claims the canonical path
-				# in the cache so downstream load()s return our version.
+				# Preempt ONLY the scripts this modlist declared + wrapped
+				# (v2.4.0). Previous behavior was to preempt a hardcoded list
+				# of 16 class_name scripts regardless of whether a mod
+				# touched them. Narrowing to wrapped_paths ensures legacy
+				# modlists (zero declarations) never see static-init
+				# preemption at all -- Godot's native lazy-compile runs
+				# unmodified, byte-identical to v2.1.0 behavior.
 				var hzr := ZIPReader.new()
 				if hzr.open(hook_abs) == OK:
-					# Build fast-lookup set of "pinned probe" paths. Only these
-					# scripts are known to be pre-compiled by Godot during
-					# class_cache population (Camera/WeaponRig/Door/etc. in the
-					# initial scene graph + engine-class autoloads). Those
-					# genuinely need strict preempt to beat PCK .gdc pinning.
-					# Every OTHER vanilla script should be left to Godot's
-					# normal lenient lazy-compile path. Preempting them all
-					# with CACHE_MODE_IGNORE cascades strict mode through
-					# `extends "res://Scripts/X.gd"` into mod subclass scripts
-					# and their preloaded siblings, rejecting GDScript that
-					# lenient first-compile would have tolerated (e.g. AI
-					# Overhaul's AwarenessSystem.gd with bodyless `if` blocks
-					# -- Gotcha #5 in gdscript_rewrite_gotchas).
-					var probe_set: Dictionary = {}
-					for pp in pinned_probes:
-						probe_set[pp] = true
+					var wrapped_set: Dictionary = {}
+					for wp in wrapped_paths:
+						wrapped_set[wp] = true
 					var preloaded := 0
 					var preload_failed := 0
 					var skipped_lenient := 0
@@ -267,11 +230,11 @@ static func _mount_previous_session() -> Dictionary:
 						if not f.begins_with("Scripts/") or not f.ends_with(".gd"):
 							continue
 						var rpath := "res://" + f
-						if not probe_set.has(rpath):
-							# Not pre-compiled by Godot at class_cache init --
-							# skip strict preempt. VFS mount (replace_files=true)
-							# still serves our rewrite to Godot's lenient
-							# lazy-compile when game code first loads the path.
+						if not wrapped_set.has(rpath):
+							# Not declared as a wrapped target -- skip strict
+							# preempt. VFS mount (replace_files=true) still
+							# serves our rewrite to Godot's lenient lazy-
+							# compile when game code first loads the path.
 							skipped_lenient += 1
 							continue
 						var scr := ResourceLoader.load(rpath, "", ResourceLoader.CACHE_MODE_IGNORE) as GDScript
@@ -281,7 +244,7 @@ static func _mount_previous_session() -> Dictionary:
 						scr.take_over_path(rpath)
 						preloaded += 1
 					hzr.close()
-					log_lines.append("[FileScope] HOOK PACK preempted %d pinned script(s) at static init (%d failed, %d other vanilla left to lenient lazy-compile)" \
+					log_lines.append("[FileScope] HOOK PACK preempted %d wrapped script(s) at static init (%d failed, %d other vanilla left to lenient lazy-compile)" \
 							% [preloaded, preload_failed, skipped_lenient])
 			else:
 				log_lines.append("[FileScope] HOOK PACK mount FAILED: " + hook_pack)
@@ -535,20 +498,24 @@ func _write_override_cfg(prepend_autoloads: Array[Dictionary]) -> Error:
 		DirAccess.remove_absolute(tmp)
 	return err
 
-func _persist_hook_pack_state(pack_path: String) -> void:
-	# Write hook_pack_path to pass_state so _mount_previous_session() can
-	# mount it at static init in the next session. Piggybacks on the
-	# existing pass_state ConfigFile -- doesn't overwrite other keys.
+func _persist_hook_pack_state(pack_path: String, wrapped_paths: PackedStringArray = PackedStringArray()) -> void:
+	# Write hook_pack_path + wrapped_paths to pass_state so the next session
+	# (1) mounts the pack at static init and (2) preempts ONLY the declared
+	# scripts in _mount_previous_session's class_cache-pinning path.
+	# Piggybacks on the existing pass_state ConfigFile -- doesn't overwrite
+	# other keys.
 	var cfg := ConfigFile.new()
 	cfg.load(PASS_STATE_PATH)  # OK if missing; we populate below
 	cfg.set_value("state", "hook_pack_path", pack_path)
+	cfg.set_value("state", "hook_pack_wrapped_paths", wrapped_paths)
 	# Store exe mtime alongside so _mount_previous_session's existing
 	# exe-mtime check also invalidates the hook pack on game updates.
 	cfg.set_value("state", "hook_pack_exe_mtime", FileAccess.get_modified_time(OS.get_executable_path()))
 	if cfg.get_value("state", "modloader_version", "") == "":
 		cfg.set_value("state", "modloader_version", MODLOADER_VERSION)
 	if cfg.save(PASS_STATE_PATH) == OK:
-		_log_info("[RTVCodegen] Persisted hook pack path for next-session static-init mount: " + pack_path.get_file())
+		_log_info("[RTVCodegen] Persisted hook pack path for next-session static-init mount: %s (%d wrapped path(s))" \
+				% [pack_path.get_file(), wrapped_paths.size()])
 
 func _write_pass_state(archive_paths: PackedStringArray, state_hash: String = "") -> Error:
 	var cfg := ConfigFile.new()

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -3,6 +3,12 @@
 ## scene tree for mismatches, log override timing issues, and produce the
 ## conflict report written to user://. Loaded alongside the normal loading
 ## path but only runs when developer_mode=true.
+##
+## v2.4.0 cutover note: mod subclass scripts are no longer rewritten (old
+## Step C removed), so the _rtv_mod_ method-prefix signal is gone. Detection
+## now classifies by "does the instance's script extend the wrapped vanilla"
+## rather than "does it carry a _rtv_mod_ prefix." Script path + extends-
+## chain walk are the reliable signals for override-took-effect.
 
 # Log which mods use overrideScript() -- overrides apply after scene reload.
 func _log_override_timing_warnings() -> void:
@@ -17,44 +23,16 @@ func _log_override_timing_warnings() -> void:
 		_log_debug(mod_name + " uses overrideScript() on: " + target_list
 				+ " -- applies after scene reload")
 
-# [OverrideVerify]: diagnose silent override failures. Runs once after
-# frameworks_ready (all mod autoloads finished their overrideScript calls).
+# [OverrideVerify]: Post-frameworks_ready sanity check on dynamic overrides.
 #
-# There are TWO failure modes we need to distinguish:
-#
-#   MODE 1 (cache miss): mod's autoload ran AFTER vanilla's preload chain
-#     already resolved the scripts, so when mod.Main.gd's `overrideScript`
-#     does `load(vanilla_path)` + `take_over_path`, vanilla is already
-#     cached and the mod's take_over_path DOES replace the cache entry,
-#     BUT any PackedScene / preload reference resolved earlier still points
-#     at the vanilla script object.
-#
-#   MODE 2 (cache ok, instance stale): take_over_path updated the cache
-#     entry but pre-loaded PackedScenes captured the vanilla script at
-#     ext_resource resolution time -- those PackedScenes won't see the
-#     update, so `instantiate()` creates nodes with the vanilla script.
-#
-# We need to SEE both to pick a fix. Probe in two layers:
-#   Layer A (this function): load(vanilla_path) post-frameworks_ready and
-#     check for `_rtv_mod_*` methods on the cached script. Presence = mod's
-#     script object is what the cache serves.
-#   Layer B (node_added): catch the first instance of each overridden class
-#     to enter the tree, check its get_script().get_script_method_list()
-#     for _rtv_mod_*. Absence = PackedScene ext_resource staleness.
-#
-# Distinguishing feature: our codegen renames the mod's body methods to
-# `_rtv_mod_<name>` and the vanilla's to `_rtv_vanilla_<name>`. Both
-# scripts have dispatch wrappers at the original names, so the rename
-# prefix is the only reliable signal of which script is in use.
-var _override_probe_sampled: Dictionary = {}
-var _override_probe_active: bool = false
-var _override_probe_expected: Dictionary = {}  # vanilla_path -> mod_name
+# v2.4.0: classification is path-based, not method-prefix-based. For each
+# mod that calls take_over_path() dynamically, load() the declared target
+# path and log its resource_path + source head. Operators can eyeball
+# whether the take_over_path took effect. Full STALE/BROKEN diagnosis
+# that v3.0.0's _rtv_mod_ prefix enabled is gone with Step C -- without
+# rewriting mod sources there is no reliable in-source signal to test.
 
 func _verify_script_overrides() -> void:
-	# Layer A: cache-level check. For each declared override target, load
-	# it and classify by renamed-method prefix. Build a path-to-expected-mod
-	# map that Layer B will use to classify instance scripts.
-	var expected_map: Dictionary = {}  # vanilla_path -> mod_name (first declared wins)
 	var printed_header: bool = false
 	for mod_name: String in _mod_script_analysis:
 		var analysis: Dictionary = _mod_script_analysis[mod_name]
@@ -68,337 +46,14 @@ func _verify_script_overrides() -> void:
 			printed_header = true
 		for vanilla_path in targets:
 			var vp: String = String(vanilla_path)
-			if not expected_map.has(vp):
-				expected_map[vp] = mod_name
 			var scr := load(vp) as Script
 			if scr == null:
-				_log_warning("[OverrideVerify] %s | %s | FAIL: load() returned null -- cache is empty or mismatched" \
-						% [mod_name, vp])
+				_log_warning("[OverrideVerify] %s | %s | FAIL: load() returned null" % [mod_name, vp])
 				continue
-			var has_mod_rename: bool = false
-			var has_vanilla_rename: bool = false
-			for m in scr.get_script_method_list():
-				var n: String = str(m["name"])
-				if n.begins_with("_rtv_mod_"):
-					has_mod_rename = true
-				elif n.begins_with("_rtv_vanilla_"):
-					has_vanilla_rename = true
-				if has_mod_rename and has_vanilla_rename:
-					break
 			var src: String = scr.source_code
 			var src_head: String = src.substr(0, 60).replace("\n", " | ").replace("\t", " ")
-			# Mod subclass without any method overrides (e.g. CustomItemTest's
-			# Database.gd just adds a const, no funcs) gets skipped by the
-			# Step C rewrite because hookable_count == 0 -- so it ships with
-			# no _rtv_mod_* methods, only _rtv_vanilla_* inherited from the
-			# rewritten parent. Distinguish from actual cache-stale vanilla
-			# by looking for "extends \"res://Scripts/..." in the source.
-			var is_mod_subclass: bool = src.contains("extends \"res://Scripts/")
-			# Skip-listed vanilla scripts (RTV_SKIP_LIST: Explosion, Hit, Mine,
-			# Message, MuzzleFlash, ParticleInstance, TreeRenderer) are NOT
-			# rewritten by our hook pipeline because dispatch wrappers would
-			# break their runtime semantics (short-lived instances, coroutine
-			# lifetime, GPUParticles draw_pass corruption). Mod subclasses
-			# that extend these aren't rewritten either -- they rely on
-			# Godot's standard class-inheritance virtual dispatch. So
-			# "no _rtv_* methods" is the CORRECT state for these, not an
-			# error. Classify separately.
-			var is_skip_listed: bool = vp.get_file() in RTV_SKIP_LIST
-			var status: String
-			if has_mod_rename:
-				status = "OK: mod's script serves this path (has _rtv_mod_* methods)"
-			elif has_vanilla_rename and is_mod_subclass:
-				status = "OK: mod's subclass serves this path (no method overrides -- inherits vanilla dispatch)"
-			elif is_skip_listed and is_mod_subclass:
-				status = "OK: skip-listed vanilla (%s) -- mod subclass inherits unrewritten vanilla via Godot virtual dispatch (no hooks for runtime-sensitive classes)" % vp.get_file()
-			elif has_vanilla_rename:
-				status = "STALE: cache still serves vanilla -- overrideScript take_over_path did not win"
-			else:
-				status = "UNKNOWN: neither _rtv_mod_ nor _rtv_vanilla_ methods -- rewrite likely did not run"
-			_log_info("[OverrideVerify] %s | %s | %s | src_head=[%s]" % [mod_name, vp, status, src_head])
-
-	# Post-override autoload instance check. If any vanilla we hooked is also
-	# a game autoload, the autoload instance was created BEFORE any mod
-	# autoload ran overrideScript. take_over_path updates ResourceCache but
-	# NOT live instances (Resource::set_path only touches the cache; it does
-	# not walk the scene tree). So /root/<AutoloadName>.get_script() may
-	# still point at the rewritten vanilla (now orphaned after take_over_path
-	# cleared its path_cache), even though load(vanilla_path) returns mod's
-	# script. Report which autoloads actually got their instance script
-	# updated, and auto-swap the stale ones. Relevant for RTVCoop and any
-	# mod that overrides autoload scripts like Loader.gd, Settings.gd, etc.
-	var autoload_names: Array[String] = ["Database", "GameData", "Settings",
-			"Menu", "Loader", "Inputs", "Mode", "Profiler", "Simulation"]
-	var autoload_paths: Dictionary = {}  # autoload_name -> res://Scripts/<Name>.gd
-	for an: String in autoload_names:
-		autoload_paths[an] = "res://Scripts/" + an + ".gd"
-	var any_overridden_autoload := false
-	for an: String in autoload_names:
-		if expected_map.has(autoload_paths[an]):
-			any_overridden_autoload = true
-			break
-	if any_overridden_autoload:
-		_log_info("[AutoloadInstanceProbe] === Post-override autoload instance check ===")
-		var root := get_tree().root
-		var swap_count: int = 0
-		for an: String in autoload_names:
-			var ap: String = autoload_paths[an]
-			if not expected_map.has(ap):
-				continue
-			var node: Node = root.get_node_or_null(an)
-			if node == null:
-				_log_info("[AutoloadInstanceProbe] %s | node NOT in tree (not a live autoload)" % an)
-				continue
-			var iscr := node.get_script() as GDScript
-			if iscr == null:
-				_log_info("[AutoloadInstanceProbe] %s | node has no script attached" % an)
-				continue
-			var cur_has_mod: bool = false
-			for m0 in iscr.get_script_method_list():
-				if str(m0["name"]).begins_with("_rtv_mod_"):
-					cur_has_mod = true
-					break
-			# Auto-swap: game autoload was instantiated BEFORE any mod ran
-			# overrideScript, so its ScriptInstance still holds the pre-override
-			# rewritten vanilla (orphaned by take_over_path -- resource.cpp:92
-			# clears old path_cache entry but never walks the scene tree).
-			# load(ap) now returns the mod subclass from the remapped cache;
-			# set_script swaps the instance script in place. Inherited property
-			# slots (mod extends rewritten vanilla) survive via type overlap;
-			# any state built into vanilla-only slots by _ready is lost --
-			# unavoidable without engine-level refresh. Matches RTVCoop's manual
-			# set_script pattern for Loader, and Godot's own reload_scripts
-			# pattern at gdscript.cpp:2419.
-			var swapped: bool = false
-			if not cur_has_mod:
-				var new_scr: GDScript = load(ap) as GDScript
-				if new_scr != null and new_scr != iscr:
-					node.set_script(new_scr)
-					swapped = true
-					swap_count += 1
-					iscr = node.get_script() as GDScript
-			var ipath: String = iscr.resource_path if iscr != null else ""
-			var ihas_mod: bool = false
-			var ihas_vanilla: bool = false
-			if iscr != null:
-				for m in iscr.get_script_method_list():
-					var mn: String = str(m["name"])
-					if mn.begins_with("_rtv_mod_"): ihas_mod = true
-					elif mn.begins_with("_rtv_vanilla_"): ihas_vanilla = true
-					if ihas_mod and ihas_vanilla: break
-			var expected_mod: String = expected_map[ap]
-			var istatus: String
-			if ihas_mod:
-				istatus = "OK: instance runs mod's body (has _rtv_mod_* methods)"
-				if swapped:
-					istatus = "FIXED via set_script swap -- " + istatus
-			elif ipath == "" and ihas_vanilla:
-				istatus = "BROKEN: instance holds ORPHAN script (empty resource_path, _rtv_vanilla_* only) -- swap attempted but did not resolve"
-			elif ihas_vanilla:
-				istatus = "BROKEN: instance runs vanilla body (has _rtv_vanilla_* only; resource_path=%s)" % ipath
-			else:
-				istatus = "UNKNOWN: instance script has no _rtv_* methods"
-			_log_info("[AutoloadInstanceProbe] %s | expected mod=%s | instance_path=%s | %s" \
-					% [an, expected_mod, ipath if ipath != "" else "<empty>", istatus])
-		if swap_count > 0:
-			_log_info("[AutoloadInstanceProbe] Auto-swapped %d stale autoload instance(s) to mod body" % swap_count)
-
-	# Layer B: arm the node_added probe. One-shot per vanilla_path.
-	if expected_map.is_empty():
-		return
-	_override_probe_expected = expected_map
-	_override_probe_sampled.clear()
-	for vp in expected_map:
-		_override_probe_sampled[vp] = false  # false = not yet sampled
-	if not _override_probe_active:
-		_override_probe_active = true
-		get_tree().node_added.connect(_on_override_probe_node_added)
-		_log_info("[OverrideVerify] Instance probe armed for %d path(s): %s" \
-				% [expected_map.size(), ", ".join(expected_map.keys())])
-	# Schedule a tree-walk fallback 12s after frameworks_ready. node_added
-	# should catch instances but can miss cases where scripts are assigned
-	# via set_script() after tree entry, or where the initial script ref
-	# wasn't the one we expected. The walk reports every scripted node
-	# whose script resource_path OR any ancestor-script path hits our
-	# expected_map. One-shot; logs "TREEWALK" so it's grep-distinct from
-	# the node_added InstanceProbe entries. Developer-mode only -- the walk
-	# visits the full tree (~20k nodes) and prints a 30-entry histogram;
-	# useful for debugging override staleness, noisy for release builds.
-	if _developer_mode:
-		get_tree().create_timer(12.0).timeout.connect(_probe_tree_walk)
-
-# One-shot-per-class instance probe. Fired on every node_added; checks if
-# the node's script is one of the overridden paths and classifies by method
-# rename prefix. Once we've sampled every expected path we disconnect.
-func _on_override_probe_node_added(node: Node) -> void:
-	var scr := node.get_script() as Script
-	if scr == null:
-		return
-	var sp: String = scr.resource_path
-	if not _override_probe_expected.has(sp):
-		return
-	# Always attempt the stale-script swap. Scene instances (UI panels,
-	# HUD, Interface, etc.) can be re-created on scene reloads and the
-	# fresh instance is bound to the baked ext_resource (= our rewritten
-	# vanilla, pre-override) rather than the chain tip. Sampled-once
-	# gating only suppresses the InstanceProbe LOG line; the swap check
-	# below runs every time so late instances get fixed.
-	var first_time: bool = not _override_probe_sampled.get(sp, false)
-	_override_probe_sampled[sp] = true
-	var has_mod_rename: bool = false
-	var has_vanilla_rename: bool = false
-	for m in scr.get_script_method_list():
-		var n: String = str(m["name"])
-		if n.begins_with("_rtv_mod_"):
-			has_mod_rename = true
-		elif n.begins_with("_rtv_vanilla_"):
-			has_vanilla_rename = true
-		if has_mod_rename and has_vanilla_rename:
-			break
-	var expected_mod: String = _override_probe_expected[sp]
-	# Skip-listed vanillas (RTV_SKIP_LIST) aren't rewritten; mod subclasses
-	# that extend them ride Godot's normal virtual dispatch and thus have
-	# neither _rtv_mod_ nor _rtv_vanilla_ method prefixes. Classify
-	# separately so we don't flag correct pass-through as STALE/UNKNOWN.
-	var is_skip_listed: bool = sp.get_file() in RTV_SKIP_LIST
-	var status: String
-	if has_mod_rename:
-		status = "OK: instance uses mod's script"
-	elif is_skip_listed:
-		# Verify pass-through: instance script should be a subclass of vanilla
-		# (mod's Override.gd extending res://Scripts/<SkipListed>.gd).
-		var src: String = (scr as GDScript).source_code if scr is GDScript else ""
-		if src.contains("extends \"res://Scripts/") or src.contains("extends\"res://Scripts/"):
-			status = "OK: skip-listed pass-through (instance is mod subclass extending unrewritten vanilla; methods resolve via Godot virtual dispatch)"
-		else:
-			status = "UNKNOWN: skip-listed vanilla but instance source doesn't extend res://Scripts/ -- possible bare vanilla (override did not take)"
-	elif has_vanilla_rename:
-		# STALE SCENE: PackedScene captured the pre-override script binding,
-		# so this instance is running vanilla-rewrite code instead of the mod
-		# chain's code. Attempt the same set_script swap AutoloadInstanceProbe
-		# does for autoloads -- load() the current script at the vanilla path
-		# (which is the take_over_path'd chain tip or single-mod winner) and
-		# replace the instance's script pointer. Inherited property slots
-		# survive via type overlap; state built in vanilla-only slots is lost
-		# (unavoidable without engine-level refresh, matches the RTVCoop
-		# set_script pattern and Godot reload_scripts behavior).
-		var new_scr: GDScript = load(sp) as GDScript
-		if new_scr != null and new_scr != scr:
-			# Sanity check: does the new script have _rtv_mod_* methods? If
-			# not, swapping wouldn't help.
-			var new_has_mod: bool = false
-			for m2 in new_scr.get_script_method_list():
-				if str(m2["name"]).begins_with("_rtv_mod_"):
-					new_has_mod = true
-					break
-			if new_has_mod:
-				node.set_script(new_scr)
-				status = "FIXED via set_script swap -- OK: instance now runs mod's body"
-			else:
-				status = "STALE SCENE: instance uses vanilla -- swap target also has no _rtv_mod_ methods, skipping"
-		else:
-			status = "STALE SCENE: instance uses vanilla -- could not resolve swap target (load returned null or same script)"
-	else:
-		status = "UNKNOWN: no renamed methods on instance script"
-	# Only log once per path to keep the log readable, but the swap above
-	# runs every time so newly-created scene instances (e.g. UI panels
-	# respawned on scene reload) get fixed too. No disconnect -- we need
-	# to keep catching stale instances for the lifetime of the session.
-	if first_time:
-		_log_info("[InstanceProbe] %s | node=%s (%s) | expected mod=%s | %s" \
-				% [sp, node.name, node.get_class(), expected_mod, status])
-
-# Tree-walk fallback for InstanceProbe. Covers cases where node_added
-# signal missed a node (e.g. script assigned after tree entry, or script
-# resource_path differs from what we expected). Walks the full scene tree,
-# logs every node whose ATTACHED script OR any parent-in-extends-chain
-# script matches one of our expected override paths.
-func _probe_tree_walk() -> void:
-	if _override_probe_expected.is_empty():
-		return
-	var hits: Dictionary = {}  # vanilla_path -> {sample info, count}
-	# all_scripts: Every scripted node's top-level script.resource_path -> count.
-	# Surfaces the case where AI instances exist but their scripts report a
-	# path we didn't expect (e.g. sub-resource path from scene baking).
-	var all_scripts: Dictionary = {}
-	var total_nodes: int = 0
-	var scripted_nodes: int = 0
-	_probe_tree_walk_recursive(get_tree().root, hits, all_scripts, 0, [total_nodes, scripted_nodes])
-	var stats: Array = [0, 0]
-	_probe_tree_walk_stats(get_tree().root, stats, 0)
-	total_nodes = stats[0]
-	scripted_nodes = stats[1]
-	_log_info("[TREEWALK] === Post-gameplay tree walk (t+12s) -- %d nodes total, %d scripted ===" \
-			% [total_nodes, scripted_nodes])
-	for vp: String in _override_probe_expected:
-		if hits.has(vp):
-			var info: Dictionary = hits[vp]
-			var mod_name: String = _override_probe_expected[vp]
-			_log_info("[TREEWALK] %s | found %d instance(s); sample: %s (%s) script=%s has_mod_rename=%s chain_depth=%d expected_mod=%s" \
-					% [vp, info.count, info.name, info.cls, info.script_path, info.has_mod, info.depth, mod_name])
-		else:
-			# Not a warning: the probe runs at t+12s (typically still in menu
-			# or loading shelter) while most overrideScript targets only
-			# instantiate in World/Combat scenes loaded later (AI, Door,
-			# Pickup, Helicopter, etc.). An absent instance here is
-			# expected, not broken. InstanceProbe (node_added) verifies
-			# when instances actually spawn. Info-level keeps the signal
-			# without the false alarm.
-			_log_info("[TREEWALK] %s | not instantiated in current scene tree at t+12s (typical for classes that load with World scene; node_added probe will verify on spawn)" \
-					% vp)
-	# Dump top script paths by count. The expected paths above are included.
-	# Anything UNEXPECTED here that matches a class name pattern of something
-	# we DID expect (e.g. "AI" substring in path) is the smoking gun.
-	_log_info("[TREEWALK] All scripted-node resource_paths (top 30 by count):")
-	var pairs: Array = []
-	for k: String in all_scripts:
-		pairs.append([k, int(all_scripts[k])])
-	pairs.sort_custom(func(a, b): return a[1] > b[1])
-	for i in range(min(30, pairs.size())):
-		_log_info("[TREEWALK]   %-8d %s" % [pairs[i][1], pairs[i][0]])
-
-func _probe_tree_walk_stats(node: Node, stats: Array, depth: int) -> void:
-	if depth > 20:
-		return
-	stats[0] += 1
-	if node.get_script() != null:
-		stats[1] += 1
-	for child in node.get_children():
-		_probe_tree_walk_stats(child, stats, depth + 1)
-
-func _probe_tree_walk_recursive(node: Node, hits: Dictionary, all_scripts: Dictionary, depth: int, _counts) -> void:
-	if depth > 20:
-		return
-	var scr := node.get_script() as Script
-	if scr != null:
-		var top_path: String = scr.resource_path
-		if top_path.is_empty():
-			top_path = "<empty-path:" + scr.get_class() + ">"
-		all_scripts[top_path] = int(all_scripts.get(top_path, 0)) + 1
-	var cur: Script = scr
-	var chain_depth := 0
-	while cur != null and chain_depth < 6:
-		var rp: String = cur.resource_path
-		if _override_probe_expected.has(rp) and not hits.has(rp):
-			var has_mod: bool = false
-			for m in cur.get_script_method_list():
-				if str(m["name"]).begins_with("_rtv_mod_"):
-					has_mod = true
-					break
-			hits[rp] = {
-				"name": node.name,
-				"cls": node.get_class(),
-				"script_path": (scr.resource_path if scr != null else "<null>"),
-				"has_mod": has_mod,
-				"depth": chain_depth,
-				"count": 1,
-			}
-		elif _override_probe_expected.has(rp):
-			hits[rp].count += 1
-		cur = cur.get_base_script() as Script
-		chain_depth += 1
-	for child in node.get_children():
-		_probe_tree_walk_recursive(child, hits, all_scripts, depth + 1, _counts)
+			_log_info("[OverrideVerify] %s | %s | resource_path=%s src_head=[%s]" \
+					% [mod_name, vp, scr.resource_path, src_head])
 
 # Two-pass helpers
 

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -237,8 +237,13 @@ func _on_override_probe_node_added(node: Node) -> void:
 	var sp: String = scr.resource_path
 	if not _override_probe_expected.has(sp):
 		return
-	if _override_probe_sampled.get(sp, true):
-		return  # already sampled (true means sampled)
+	# Always attempt the stale-script swap. Scene instances (UI panels,
+	# HUD, Interface, etc.) can be re-created on scene reloads and the
+	# fresh instance is bound to the baked ext_resource (= our rewritten
+	# vanilla, pre-override) rather than the chain tip. Sampled-once
+	# gating only suppresses the InstanceProbe LOG line; the swap check
+	# below runs every time so late instances get fixed.
+	var first_time: bool = not _override_probe_sampled.get(sp, false)
 	_override_probe_sampled[sp] = true
 	var has_mod_rename: bool = false
 	var has_vanilla_rename: bool = false
@@ -268,23 +273,40 @@ func _on_override_probe_node_added(node: Node) -> void:
 		else:
 			status = "UNKNOWN: skip-listed vanilla but instance source doesn't extend res://Scripts/ -- possible bare vanilla (override did not take)"
 	elif has_vanilla_rename:
-		status = "STALE SCENE: instance uses vanilla -- PackedScene captured pre-override script binding (cache may be OK, but scene ext_resource is stale)"
+		# STALE SCENE: PackedScene captured the pre-override script binding,
+		# so this instance is running vanilla-rewrite code instead of the mod
+		# chain's code. Attempt the same set_script swap AutoloadInstanceProbe
+		# does for autoloads -- load() the current script at the vanilla path
+		# (which is the take_over_path'd chain tip or single-mod winner) and
+		# replace the instance's script pointer. Inherited property slots
+		# survive via type overlap; state built in vanilla-only slots is lost
+		# (unavoidable without engine-level refresh, matches the RTVCoop
+		# set_script pattern and Godot reload_scripts behavior).
+		var new_scr: GDScript = load(sp) as GDScript
+		if new_scr != null and new_scr != scr:
+			# Sanity check: does the new script have _rtv_mod_* methods? If
+			# not, swapping wouldn't help.
+			var new_has_mod: bool = false
+			for m2 in new_scr.get_script_method_list():
+				if str(m2["name"]).begins_with("_rtv_mod_"):
+					new_has_mod = true
+					break
+			if new_has_mod:
+				node.set_script(new_scr)
+				status = "FIXED via set_script swap -- OK: instance now runs mod's body"
+			else:
+				status = "STALE SCENE: instance uses vanilla -- swap target also has no _rtv_mod_ methods, skipping"
+		else:
+			status = "STALE SCENE: instance uses vanilla -- could not resolve swap target (load returned null or same script)"
 	else:
 		status = "UNKNOWN: no renamed methods on instance script"
-	_log_info("[InstanceProbe] %s | node=%s (%s) | expected mod=%s | %s" \
-			% [sp, node.name, node.get_class(), expected_mod, status])
-	# Auto-disconnect once all expected paths have been sampled.
-	var all_sampled: bool = true
-	for v in _override_probe_sampled.values():
-		if not v:
-			all_sampled = false
-			break
-	if all_sampled and _override_probe_active:
-		_override_probe_active = false
-		if get_tree().node_added.is_connected(_on_override_probe_node_added):
-			get_tree().node_added.disconnect(_on_override_probe_node_added)
-		_log_info("[InstanceProbe] All %d path(s) sampled -- probe disconnected" \
-				% _override_probe_sampled.size())
+	# Only log once per path to keep the log readable, but the swap above
+	# runs every time so newly-created scene instances (e.g. UI panels
+	# respawned on scene reload) get fixed too. No disconnect -- we need
+	# to keep catching stale instances for the lifetime of the session.
+	if first_time:
+		_log_info("[InstanceProbe] %s | node=%s (%s) | expected mod=%s | %s" \
+				% [sp, node.name, node.get_class(), expected_mod, status])
 
 # Tree-walk fallback for InstanceProbe. Covers cases where node_added
 # signal missed a node (e.g. script assigned after tree entry, or script

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -29,7 +29,14 @@ const DISABLED_FILE := "modloader_disabled"
 const MAX_RESTART_COUNT := 2
 
 const HOOK_PACK_DIR := "user://modloader_hooks"
-const HOOK_PACK_ZIP := "user://modloader_hooks/framework_pack.zip"
+# Hook pack filename: "<prefix>_<timestamp_ms>.zip". A fresh filename per
+# _generate_hook_pack call sidesteps ProjectSettings.load_resource_pack's
+# path-dedup (a same-path re-mount is a no-op and the VFS keeps stale file
+# offsets from the original mount -- FileAccess reads return prior-session
+# bytes even though ZIPPacker rewrote the file on disk). Different filename
+# = new mount = fresh offsets. Orphan files from prior sessions are cleaned
+# up at static-init in _mount_previous_session before any mount happens.
+const HOOK_PACK_PREFIX := "framework_pack"
 const HOOK_PACK_MOUNT_BASE := "res://modloader_hooks"
 const VANILLA_CACHE_DIR := "user://modloader_hooks/vanilla"
 const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -10,7 +10,7 @@
 # The major/minor/patch accessors parse this single source of truth so mods can
 # compare against it without hand-maintaining a second set of constants.
 # x-release-please-start-version
-const MODLOADER_VERSION := "2.3.1"
+const MODLOADER_VERSION := "2.4.0"
 # x-release-please-end
 
 const MODLOADER_RES_PATH := "res://modloader.gd"
@@ -164,6 +164,14 @@ var _ready_is_coroutine_by_path: Dictionary = {}  # res_path -> bool. Sync (fals
 # Script overrides
 var _pending_script_overrides: Array[Dictionary] = []  # {vanilla_path, mod_script_path, mod_name, priority}
 var _applied_script_overrides: Dictionary = {}         # vanilla_path -> true
+
+# Opt-in declarations (v2.4.0 cutover). Populated by the [hooks] parser in
+# mod_loading.gd and by .hook() call scanning. Drives the wrap surface in
+# _generate_hook_pack. If both are empty AND _any_mod_declared_registry is
+# false, _generate_hook_pack early-returns and no hook pack is produced --
+# the modlist behaves byte-identical to pre-hook-system (v2.1.0) behavior.
+var _hooked_methods: Dictionary = {}             # res_path -> {method_name: true}
+var _any_mod_declared_registry: bool = false     # set by [registry] parser
 
 var _re_take_over: RegEx
 var _re_extends: RegEx

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -124,6 +124,12 @@ var _archive_file_sets: Dictionary = {}
 # lowercase. A bare name (no suffix) is a replace hook (first-wins).
 signal frameworks_ready
 var _hooks: Dictionary = {}              # hook_name -> Array of {callback, priority, id}
+# Dev-mode-only: per-hook_base dispatch counter. Incremented inside each
+# wrapper AFTER the _any_mod_hooked short-circuit when _developer_mode is
+# true. Summary at 30s timer in _activate_rewritten_scripts pinpoints
+# runaway method calls (e.g. connect-already-connected error spam from a
+# _ready firing thousands of times).
+var _dispatch_counts: Dictionary = {}
 # Fast-path short-circuit: flipped true the first time any mod calls hook().
 # Dispatch wrappers skip the full _wrapper_active/_caller/_dispatch path
 # when no mod has hooked anything at all. Sticky -- stays true once set.

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -166,6 +166,7 @@ var _re_class_name: RegEx
 var _re_func: RegEx
 var _re_preload: RegEx
 var _re_filename_priority: RegEx
+var _re_hook_call: RegEx
 
 # Rewriter regex (compiled in _rtv_compile_codegen_regex)
 var _rtv_re_extends: RegEx

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -308,6 +308,11 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	var _step_b_allowlist: Array[String] = []
 	var zero_byte_skipped: int = 0
 	var surface_skipped: int = 0
+	# Capture {source, parsed} per wrapped vanilla. Needed later to pack
+	# pristine copies for chain-via-extends: chain-bottom mods extend
+	# res://_rtv_pristine_/Scripts/<X>.gd so their super() doesn't loop
+	# back through the take_over_path'd tip.
+	var vanilla_rewrites: Dictionary = {}
 	for script_path: String in script_paths:
 		var filename := script_path.get_file()
 
@@ -420,6 +425,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		script_count += 1
 		hook_count += hookable_count * 4  # pre/post/callback/replace per method
 		packed_filenames.append(filename)
+		vanilla_rewrites[filename] = { "source": source, "parsed": parsed }
 		_log_debug("[RTVCodegen] Rewrote Scripts/%s (%d hooks)" % [filename, hookable_count * 4])
 
 	# Step C: rewrite mod scripts that subclass a vanilla script we just
@@ -431,6 +437,67 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	for fn in packed_filenames:
 		vanilla_set[fn] = true
 	var mod_candidates := _scan_mod_extends_targets(vanilla_set)
+	# Chain-via-extends composition. Multiple mods extending the same vanilla
+	# used to be last-wins under take_over_path (9 of 10 Interface.gd mods
+	# orphaned as dead code, dropping their save data). Now we compose them
+	# into a single extends chain so every mod's body runs via Godot virtual
+	# dispatch.
+	#
+	# Chain order = load order ascending (lowest priority = bottom of chain,
+	# highest priority = tip). Tip's take_over_path still wins the vanilla
+	# path via normal mod autoload instantiation order. Tip's script extends
+	# the NEXT mod's script (via rewritten extends), which extends the one
+	# below, ..., down to the bottom mod which extends a PRISTINE vanilla
+	# copy at res://_rtv_pristine_/Scripts/<X>.gd. The pristine path is NOT
+	# touched by take_over_path so the chain never loops back through the
+	# tip. (Without the pristine, chain-bottom's extends "res://Scripts/X.gd"
+	# would resolve to the tip after take_over_path -> infinite recursion.)
+	var chain_groups: Dictionary = {}  # vanilla_filename -> sorted Array of candidates
+	for cand: Dictionary in mod_candidates:
+		var vf: String = cand["vanilla_filename"]
+		if not chain_groups.has(vf):
+			chain_groups[vf] = []
+		(chain_groups[vf] as Array).append(cand)
+	var chained_vanillas: Dictionary = {}  # vanilla_filename -> true (needs pristine copy packed)
+	for vf: String in chain_groups:
+		var arr: Array = chain_groups[vf]
+		if arr.size() < 2:
+			# Single-mod: no chain, standard rewrite (extends unchanged).
+			(arr[0] as Dictionary)["extends_override"] = ""
+			continue
+		arr.sort_custom(func(a, b): return int(a["load_index"]) < int(b["load_index"]))
+		chained_vanillas[vf] = true
+		var pristine_path := "res://_rtv_pristine_/Scripts/" + vf
+		for i in range(arr.size()):
+			var c: Dictionary = arr[i]
+			if i == 0:
+				c["extends_override"] = pristine_path
+			else:
+				c["extends_override"] = (arr[i-1] as Dictionary)["res_path"]
+		var summary: PackedStringArray = []
+		for c in arr:
+			summary.append("%s[p=%d]" % [c["mod_name"], c["load_index"]])
+		_log_info("[RTVCodegen] CHAIN %s composed (bottom -> tip): %s -- pristine at %s" \
+				% [vf, " -> ".join(summary), pristine_path])
+	# Pack pristine vanilla copies for every chained script. Pristine = same
+	# rewrite as res://Scripts/<X>.gd but with class_name stripped (duplicate
+	# class_name registration would conflict with the primary's slot in the
+	# PCK's global_script_class_cache.cfg). Lives at res://_rtv_pristine_/
+	# so take_over_path on res://Scripts/<X>.gd can't displace it; chain-
+	# bottom mod's extends always resolves to genuine vanilla content.
+	for vf: String in chained_vanillas:
+		if not vanilla_rewrites.has(vf):
+			_log_warning("[RTVCodegen] Chain target %s wasn't in vanilla rewrite set -- chain will fail" % vf)
+			continue
+		var info: Dictionary = vanilla_rewrites[vf]
+		var pristine_src := _rtv_rewrite_vanilla_source(info["source"], info["parsed"], "_rtv_vanilla_", "", true)
+		var pristine_zip_entry := "_rtv_pristine_/Scripts/" + vf
+		if zp.start_file(pristine_zip_entry) != OK:
+			_log_warning("[RTVCodegen] Failed to start pristine zip entry %s" % pristine_zip_entry)
+			continue
+		zp.write_file(pristine_src.to_utf8_buffer())
+		zp.close_file()
+		_log_debug("[RTVCodegen] Packed pristine %s for chain bottom" % pristine_zip_entry)
 	var mod_script_count := 0
 	var mod_hook_count := 0
 	var mod_packed: Array[Dictionary] = []  # {res_path, vanilla_filename}
@@ -439,6 +506,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		var vanilla_filename: String = cand["vanilla_filename"]
 		var mod_name: String = cand["mod_name"]
 		var source: String = cand["source"]
+		var ext_override: String = cand.get("extends_override", "")
 		# Parse using the VANILLA filename so hook_base is "controller-*"
 		# not "immersivexp/controller-*" -- single hook namespace per vanilla.
 		var parsed := _rtv_parse_script(vanilla_filename, source)
@@ -452,7 +520,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		# vanilla's _rtv_vanilla_ methods via virtual dispatch. Otherwise
 		# super._ready() -> vanilla wrapper -> _rtv_vanilla__ready() resolves
 		# back to the mod's override -> infinite loop.
-		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, "_rtv_mod_")
+		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, "_rtv_mod_", ext_override)
 		# Pack at the mod's own path. Mount replace_files=true wins over the
 		# mod's .vmz which also serves this path. Script stays a subclass of
 		# rewritten vanilla via extends; its body may or may not call super.

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -921,13 +921,35 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 						% [scene_count, probe_key, type_string(typeof(probe_result))])
 
 	# 30s gives the player time to get into gameplay so controller-level
-	# hooks can fire at least once. HOOK-API summary only; the per-wrapper
-	# dispatch counter was removed 2026-04-20 because its 2 Engine.set_meta
-	# calls per invocation cost ~0.37s CPU/sec on hot paths like
-	# hud-_physics_process and interface-_physics_process (93K calls/sec each).
+	# hooks can fire at least once. HOOK-API summary only by default;
+	# dev-mode adds the per-method dispatch counter printout (fed by
+	# _dispatch_counts incremented inside each wrapper after the
+	# _any_mod_hooked short-circuit -- see _rtv_dispatch_inline_src).
+	_dispatch_counts.clear()
 	get_tree().create_timer(30.0).timeout.connect(func():
 		var pc: Dictionary = Engine.get_meta("_rtv_probe_counts", {})
 		var fa: Dictionary = Engine.get_meta("_rtv_probe_first_args", {})
+		# Dispatch counts (dev mode only). Show top 15 hot methods + flag
+		# any that exceed 10000 calls in 30s -- those are runaway candidates
+		# (e.g. a mod's _ready firing in a loop).
+		if _developer_mode and _dispatch_counts.size() > 0:
+			var pairs: Array = []
+			for k: String in _dispatch_counts:
+				pairs.append([k, int(_dispatch_counts[k])])
+			pairs.sort_custom(func(a, b): return a[1] > b[1])
+			_log_info("[RTVCodegen] DISPATCH-COUNT top %d / %d tracked methods (dev mode, 30s window):" \
+					% [min(15, pairs.size()), pairs.size()])
+			for i in range(min(15, pairs.size())):
+				var warn := "  !!HOT!!" if pairs[i][1] > 10000 else ""
+				_log_info("[RTVCodegen]   %-48s %d%s" % [pairs[i][0], pairs[i][1], warn])
+			# Extra: list any method exceeding the runaway threshold explicitly
+			# so "why is the game laggy" is greppable.
+			var runaway: Array = []
+			for p in pairs:
+				if p[1] > 10000:
+					runaway.append("%s=%d" % [p[0], p[1]])
+			if runaway.size() > 0:
+				_log_critical("[RTVCodegen] RUNAWAY methods (>10000 calls/30s): %s -- a mod is likely calling one of these from a loop or frequent callback" % ", ".join(runaway))
 		# HOOK-API per-probe breakdown across phases:
 		var total := 0
 		for k: String in ["loader_pp", "simulation_proc", "profiler_proc",

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -1,13 +1,22 @@
 ## ----- hook_pack.gd -----
-## Orchestrates the full rewrite pipeline: enumerate game scripts, call the
-## rewriter on each, pack the output into modloader_hooks.zip with the
-## three-entry recipe per script (.gd + .gd.remap + empty .gdc), mount it,
-## and force-activate the rewritten scripts in Godot's ResourceCache.
+## Orchestrates the opt-in rewrite pipeline. Vanilla scripts declared via
+## [hooks] in mod.txt or via runtime .hook(...) calls get their declared
+## methods renamed to _rtv_vanilla_<name> with dispatch wrappers appended.
+## Packed into modloader_hooks.zip with the three-entry recipe per script
+## (.gd + .gd.remap + empty .gdc), mounted at res://, and force-activated
+## via source_code+reload / CACHE_MODE_IGNORE+take_over_path fallback so
+## game code compiles against the wrapped source.
+##
+## v2.4.0 cutover: zero declarations -> zero generation. No more inference
+## from extends/take_over_path; no more mod-source rewriting (old Step C).
+## A modlist that declares nothing behaves byte-identical to v2.1.0.
 
 # Scripts that carry rewriter-injected registry helpers. These MUST be
 # force-activated (bypass the scene-preload deferral) so the injected fields
 # are live on autoload instances when mods call lib.register(). Keep in
-# sync with the match statement in _rtv_registry_injection().
+# sync with the match statement in _rtv_registry_injection(). Enrollment
+# into the wrap surface now REQUIRES at least one mod to declare [registry]
+# in its mod.txt -- see _generate_hook_pack's wrap-surface build.
 const REGISTRY_TARGETS: Array[String] = [
 	"Database.gd",
 ]
@@ -15,16 +24,15 @@ const REGISTRY_TARGETS: Array[String] = [
 func _is_registry_target(filename: String) -> bool:
 	return filename in REGISTRY_TARGETS
 
-# Sum a per-mod analysis field across all scanned mods. Used for the
-# wrap-surface log line so we can see how many mods pushed a given
-# category into needed_paths.
-func _count_mods_field(field: String) -> int:
-	var n := 0
-	for mod_name: String in _mod_script_analysis:
-		var a: Dictionary = _mod_script_analysis[mod_name]
-		if (a.get(field, []) as Array).size() > 0:
-			n += 1
-	return n
+# Convert a list of wrapped filenames ("Controller.gd") into the full
+# res://Scripts/ paths persisted in pass_state. boot.gd's next-session
+# _mount_previous_session uses these to preempt ONLY scripts this
+# session wrapped, instead of a hardcoded pinned list.
+func _wrapped_paths_packed(filenames: Array[String]) -> PackedStringArray:
+	var out := PackedStringArray()
+	for fn in filenames:
+		out.append("res://Scripts/" + fn)
+	return out
 
 # Build the framework pack: enumerate res://Scripts/*.gd, detokenize each via
 # _read_vanilla_source, parse + generate wrappers, zip them, mount the zip.
@@ -77,107 +85,63 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	if _loaded_mod_ids.is_empty():
 		return ""
 
+	# OPT-IN GATE (v2.4.0): if no mod declared [hooks] / .hook() / [registry],
+	# skip hook pack generation entirely. The modlist behaves like v2.1.0 --
+	# no wrap, no rewrite, no pack written, no static-init preemption. This
+	# is the single guard protecting legacy mods: prior versions' inference
+	# triggers (extends_paths, take_over_literal_paths, pinned-always-wrap,
+	# REGISTRY_TARGETS-unconditional) all flowed through this code path, so
+	# returning here short-circuits them all.
+	if _hooked_methods.is_empty() and not _any_mod_declared_registry:
+		_log_info("[RTVCodegen] No opt-in declarations ([hooks] / .hook() / [registry]) -- hook pack generation skipped. Legacy mode: vanilla scripts run unmodified (v2.1.0-equivalent).")
+		return ""
+
 	var script_paths: Array[String] = _enumerate_game_scripts()
 	if script_paths.is_empty():
 		_log_warning("[RTVCodegen] script enumeration failed -- falling back to class_name list (%d)" % _class_name_to_path.size())
 		for path: String in _class_name_to_path.values():
 			script_paths.append(path)
-	# Narrow the wrap surface to vanilla scripts that mods actually touch.
-	# Wrapping every vanilla (180 in RTV) fires dispatch on every method call
-	# of every class_name node, even ones no mod extends or hooks. v2.1.0's
-	# opt-in [hooks] model had ~zero overhead for untouched scripts; v3.0.0
-	# flipped to wrap-everything which burned ~93K calls/sec on hot paths
-	# like hud-_physics_process when 65 mods were loaded. Restore the opt-in
-	# semantics WITHOUT requiring mod-author changes by deriving the set from
-	# what the scan already captured.
+	# Opt-in wrap surface. A vanilla script enters needed_paths ONLY if:
+	#   1. at least one mod declared it in [hooks] in its mod.txt, OR
+	#   2. at least one mod called .hook("<stem>-<method>", ...) in source, OR
+	#   3. it's a REGISTRY_TARGET (Database.gd) and at least one mod has
+	#      a [registry] section in its mod.txt.
 	#
-	# A vanilla script goes into needed_paths if ANY enabled mod:
-	#   1. extends "res://Scripts/<X>.gd"
-	#   2. take_over_path("res://Scripts/<X>.gd", ...)
-	#   3. calls .hook("<x>-<method>...", ...) where <x> is the lowercase stem
-	#
-	# Scripts not in the union run AS-IS (no dispatch wrapper, matches v2.1.0
-	# behavior for those specific paths). Their class_name registrations stay
-	# intact because we never touched them -- Godot's native compile path
-	# serves them with no overhead.
-	var prefix_to_path: Dictionary = {}
-	for sp: String in script_paths:
-		prefix_to_path[sp.get_file().get_basename().to_lower()] = sp
+	# No extends-based inference, no take_over_path-based inference, no
+	# pinned-always-wrap. Mods that extend a vanilla script without declaring
+	# a hook get Godot's native compile (no dispatch overhead, no rewrite
+	# of their own source). When ANOTHER mod declares a hook on the same
+	# path, Godot's extends resolution still threads their mod through the
+	# wrapped vanilla naturally -- no mod-source rewrite required.
 	var needed_paths: Dictionary = {}
-	# Reverse map: vanilla_path -> Array of {mod, reason} entries. Diagnostics
-	# only; used right after to warn about multi-claim conflicts. When N>1
-	# mods override the same script via take_over_path, only the last call
-	# wins -- the others' bodies are orphaned and silently dead. Surfacing
-	# this as a CRITICAL saves hours of "why doesn't my mod work" debugging.
-	var claim_map: Dictionary = {}
-	for mod_name: String in _mod_script_analysis:
-		var analysis: Dictionary = _mod_script_analysis[mod_name]
-		for p: String in (analysis.get("extends_paths", []) as Array):
-			if p.begins_with("res://Scripts/"):
-				needed_paths[p] = true
-				if not claim_map.has(p):
-					claim_map[p] = []
-				(claim_map[p] as Array).append({"mod": mod_name, "reason": "extends"})
-		for p: String in (analysis.get("take_over_literal_paths", []) as Array):
-			if p.begins_with("res://Scripts/"):
-				needed_paths[p] = true
-				if not claim_map.has(p):
-					claim_map[p] = []
-				(claim_map[p] as Array).append({"mod": mod_name, "reason": "take_over_path"})
-		for pref: String in (analysis.get("hooked_script_prefixes", []) as Array):
-			if prefix_to_path.has(pref):
-				needed_paths[prefix_to_path[pref]] = true
-	# Hot-path scripts that game code compiles eagerly at static init
-	# (Camera, Controller, WeaponRig, Door, etc.) must stay wrapped even
-	# when no mod touches them -- they're in the pinned_probes list in
-	# boot.gd because Godot's class_cache pins their .gdc before any mod
-	# code runs. Wrapping them costs a dispatch call that short-circuits
-	# via _any_mod_hooked when no mod hooked them, so it's ~1 meta-read
-	# per call and still correct.
-	var _pinned_always_wrap: Array[String] = [
-		"res://Scripts/Camera.gd", "res://Scripts/Controller.gd",
-		"res://Scripts/Door.gd", "res://Scripts/Fish.gd",
-		"res://Scripts/Furniture.gd", "res://Scripts/GameData.gd",
-		"res://Scripts/Grenade.gd", "res://Scripts/Grid.gd",
-		"res://Scripts/Hitbox.gd", "res://Scripts/KnifeRig.gd",
-		"res://Scripts/LootContainer.gd", "res://Scripts/Lure.gd",
-		"res://Scripts/Pickup.gd", "res://Scripts/Settings.gd",
-		"res://Scripts/Trader.gd", "res://Scripts/WeaponRig.gd",
-	]
-	for pp in _pinned_always_wrap:
-		needed_paths[pp] = true
-	# REGISTRY_TARGETS (currently just Database.gd) carry injected registry
-	# fields that mods rely on via lib.register()/override(). Always wrap.
-	for rt_filename in REGISTRY_TARGETS:
-		needed_paths["res://Scripts/" + rt_filename] = true
-	_log_info("[RTVCodegen] Wrap surface: %d of %d vanilla scripts (extends=%d, take_over=%d, hook=%d, pinned=%d)" % [
-		needed_paths.size(),
-		script_paths.size(),
-		_count_mods_field("extends_paths"),
-		_count_mods_field("take_over_literal_paths"),
-		_count_mods_field("hooked_script_prefixes"),
-		_pinned_always_wrap.size() + REGISTRY_TARGETS.size(),
-	])
-	# Report multi-claim conflicts. take_over_path is last-wins by load order;
-	# claimants other than the last are orphaned -- their method bodies exist
-	# but the script Godot resolves at `res://Scripts/<X>.gd` is the winner's.
-	# If ANY of the 10 Interface.gd claimants in a typical big-mod-set loadout
-	# has the behavior a user cares about and isn't last in load order, that
-	# behavior silently vanishes. This warning gives the user a map.
-	var conflict_count := 0
-	for path: String in claim_map:
-		var claims: Array = claim_map[path]
-		if claims.size() < 2:
+	# Per-path per-method mask. Keyed by res_path -> Dictionary[method_name, true].
+	# Populated from _hooked_methods (static [hooks] section + scanned .hook()).
+	# Empty inner dict = all methods (fallback used only for REGISTRY_TARGETS
+	# where the wrap contract is whole-script, not per-method).
+	var hook_mask: Dictionary = {}
+	for path: String in _hooked_methods:
+		# Normalize + validate the declared path. Reject anything outside
+		# res://Scripts/ -- hooks are only meaningful on vanilla game scripts.
+		# A bad path here is a silent failure mode for mod authors; surface it.
+		if not path.begins_with("res://Scripts/"):
+			_log_warning("[RTVCodegen] [hooks] declared for non-vanilla path '%s' -- only res://Scripts/*.gd is hookable; entry ignored" % path)
 			continue
-		conflict_count += 1
-		var claim_summaries: PackedStringArray = []
-		for c in claims:
-			claim_summaries.append("%s(%s)" % [c["mod"], c["reason"]])
-		_log_critical("[RTVCodegen] CONFLICT %s claimed by %d mods: %s -- take_over_path is last-wins, only one mod's code is live" \
-				% [path, claims.size(), ", ".join(claim_summaries)])
-	if conflict_count > 0:
-		_log_critical("[RTVCodegen] %d vanilla script(s) have overlapping claims -- see CONFLICT lines above. Disable duplicates to get predictable behavior." \
-				% conflict_count)
+		needed_paths[path] = true
+		hook_mask[path] = (_hooked_methods[path] as Dictionary).duplicate()
+	# Gate Database.gd on explicit [registry] opt-in. REGISTRY_TARGETS are
+	# wrapped whole-script (no method mask) so the rewriter can inject the
+	# _get()/_rtv_mod_scenes/_rtv_override_scenes helpers; per-method mask
+	# would defeat that injection.
+	if _any_mod_declared_registry:
+		for rt_filename in REGISTRY_TARGETS:
+			var rt_path := "res://Scripts/" + rt_filename
+			needed_paths[rt_path] = true
+			hook_mask.erase(rt_path)  # whole-script wrap, no mask
+	_log_info("[RTVCodegen] Wrap surface: %d vanilla script(s) declared (%d via [hooks]/.hook(), %d via [registry])" % [
+		needed_paths.size(),
+		_hooked_methods.size(),
+		REGISTRY_TARGETS.size() if _any_mod_declared_registry else 0,
+	])
 	# Skip-list breakdown -- gives the README an evidence trail for "we wrap N
 	# scripts, skip M". The actual rewritten count is logged below by the
 	# "Generated N rewritten" line; this just records the static skip-list sizes.
@@ -226,8 +190,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		# Resolve the archive to a readable zip path. Loose folder mods
 		# and already-zipped .zip/.pck archives use archive_file as-is;
 		# .vmz mods use a cached .zip sibling the loader materialized
-		# during discovery (same pattern the rewriter's extends-scanner
-		# uses in _scan_mod_extends_targets).
+		# during discovery.
 		var zip_path := archive_file
 		var ext := archive_file.get_extension().to_lower()
 		if ext == "vmz":
@@ -355,13 +318,24 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 
 		var parsed := _rtv_parse_script(filename, source)
+		# Per-method wrap mask (v2.4.0). A path with no mask entry wraps every
+		# hookable method (used for REGISTRY_TARGETS where injection needs to
+		# see the whole script). A path WITH a mask wraps ONLY declared methods.
+		var path_mask: Dictionary = hook_mask.get(script_path, {}) as Dictionary
+		var apply_mask: bool = not path_mask.is_empty()
 		var hookable_count := 0
 		for fe in parsed["functions"]:
-			if not fe["is_static"]:
-				hookable_count += 1
-			if fe["name"] == "_ready" and not fe["is_static"]:
+			if fe["is_static"]:
+				continue
+			if apply_mask and not path_mask.has(fe["name"]):
+				continue
+			hookable_count += 1
+			if fe["name"] == "_ready":
 				_ready_is_coroutine_by_path[parsed["path"]] = bool(fe["is_coroutine"])
 		if hookable_count == 0:
+			if apply_mask:
+				_log_warning("[RTVCodegen] %s: declared [hooks] methods %s not found in vanilla -- skipping" \
+						% [filename, str(path_mask.keys())])
 			continue
 
 		# Record scripts whose module-scope preload() pulls in a PackedScene.
@@ -381,7 +355,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		if scene_preloads.size() > 0 and not _is_registry_target(filename):
 			_scripts_with_scene_preloads[filename] = scene_preloads
 
-		var rewritten := _rtv_rewrite_vanilla_source(source, parsed)
+		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, path_mask)
 		# Ship at the ORIGINAL vanilla path so class_name registration in the
 		# PCK's global_script_class_cache.cfg matches our file. Declaring
 		# class_name at a non-registered path triggers "Class X hides a
@@ -422,92 +396,23 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		packed_filenames.append(filename)
 		_log_debug("[RTVCodegen] Rewrote Scripts/%s (%d hooks)" % [filename, hookable_count * 4])
 
-	# Step C: rewrite mod scripts that subclass a vanilla script we just
-	# rewrote. Same rename+dispatch treatment keyed to the vanilla filename,
-	# so hooks fire regardless of whether the mod's body calls super(). The
-	# re-entry guard in the dispatch template prevents double-fire when the
-	# mod's body DOES call super() through to vanilla's wrapper.
-	var vanilla_set: Dictionary = {}
-	for fn in packed_filenames:
-		vanilla_set[fn] = true
-	var mod_candidates := _scan_mod_extends_targets(vanilla_set)
-	var mod_script_count := 0
-	var mod_hook_count := 0
-	var mod_packed: Array[Dictionary] = []  # {res_path, vanilla_filename}
-	for cand: Dictionary in mod_candidates:
-		var cand_filename: String = (cand["res_path"] as String).get_file()
-		var vanilla_filename: String = cand["vanilla_filename"]
-		var mod_name: String = cand["mod_name"]
-		var source: String = cand["source"]
-		# Parse using the VANILLA filename so hook_base is "controller-*"
-		# not "immersivexp/controller-*" -- single hook namespace per vanilla.
-		var parsed := _rtv_parse_script(vanilla_filename, source)
-		var hookable_count := 0
-		for fe in parsed["functions"]:
-			if not fe["is_static"]:
-				hookable_count += 1
-		if hookable_count == 0:
-			continue
-		# Use _rtv_mod_ prefix for mod method renames so they don't shadow
-		# vanilla's _rtv_vanilla_ methods via virtual dispatch. Otherwise
-		# super._ready() -> vanilla wrapper -> _rtv_vanilla__ready() resolves
-		# back to the mod's override -> infinite loop.
-		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, "_rtv_mod_")
-		# Pack at the mod's own path. Mount replace_files=true wins over the
-		# mod's .vmz which also serves this path. Script stays a subclass of
-		# rewritten vanilla via extends; its body may or may not call super.
-		var zip_rel: String = (cand["res_path"] as String).trim_prefix("res://")
-		if zp.start_file(zip_rel) != OK:
-			_log_warning("[RTVCodegen] Failed to start mod zip entry %s" % zip_rel)
-			continue
-		zp.write_file(rewritten.to_utf8_buffer())
-		zp.close_file()
-		# NOTE: do NOT ship a .gd.remap or empty .gdc shadow for mod subclass
-		# scripts. Those tricks exist to defeat the base game PCK's
-		# .gd -> .gdc redirect + bytecode preference. Mod archives ship
-		# source-only (no PCK bytecode at this path), so the shadows only
-		# change Godot's load pathway from (direct .gd compile) to
-		# (bytecode-fail -> .gd fallback compile). The latter triggers a
-		# stricter reload path that cascades strict re-parse into the mod's
-		# sibling preloads -- which breaks mods whose code is valid under
-		# lenient first-compile but sloppy under strict (Gotcha #5, e.g.
-		# AI Overhaul's AwarenessSystem.gd with bodyless `if` blocks).
-		# Replacing just the .gd via load_resource_pack(replace_files=true)
-		# is enough for our rewrite to serve at the mod's path, and matches
-		# the pre-hooks load pathway for mod scripts.
-		mod_script_count += 1
-		mod_hook_count += hookable_count * 4
-		mod_packed.append({"res_path": cand["res_path"], "vanilla_filename": vanilla_filename})
-		_log_debug("[RTVCodegen] Rewrote mod script %s (ext=%s, %d hooks) [%s]" \
-				% [cand["res_path"], vanilla_filename, hookable_count * 4, mod_name])
-
-	# Step E: MAXIMUM-COMPAT autofix of mod SIBLING scripts (non-subclass
-	# mod .gd files). These aren't wrapped for dispatch but they may be
-	# preloaded/extended from subclass scripts (AI Overhaul's Core/AI.gd
-	# does `const AwarenessSystem = preload("Systems/AwarenessSystem.gd")`),
-	# and when strict parse cascades through the preload chain Godot
-	# rejects sloppy GDScript the mod author had been getting away with.
-	# We read each sibling from the mod archive (mounted at res:// but
-	# hook pack not yet mounted), run autofix, and pack the fixed version
-	# into the hook pack overlay when it differs from the original. VFS
-	# replace_files=true precedence then serves the fixed version to
-	# Godot's parser, restoring the pre-hooks compat surface for mods
-	# with bodyless `if` blocks and Godot-3-era annotations.
-	# Write pre-collected sibling autofix results to the hook pack. Reads
-	# happened earlier (before zp.open); here we just emit the fixed bytes.
-	# Skip any sibling whose path was also packed as a mod subclass earlier
-	# in this call -- the mod subclass rewrite is the canonical version,
-	# and double-packing would leave two entries in the zip.
-	var subclass_paths: Dictionary = {}
-	for mp in mod_packed:
-		subclass_paths[mp["res_path"]] = true
+	# Step C (mod-subclass rewrite) removed in v2.4.0. Mods that extend
+	# wrapped vanilla now compose via Godot's native extends resolution:
+	# their script sees the wrapped vanilla as its parent, super.method()
+	# calls land on the dispatch wrapper, hooks fire normally. Mods whose
+	# overrides skip super() lose hook composition on those methods --
+	# that's the opt-in contract (declare your hooks, or call super()).
+	#
+	# Step E (sibling autofix) remains. Mod siblings may still be
+	# preloaded/extended by subclass scripts and rely on our legacy-syntax
+	# autofix (bodyless blocks, Godot-3 annotations) to parse cleanly.
+	# Unlike Step C, autofix preserves the mod author's intent semantically
+	# -- no rename, no super() rewrite, no dispatch injection.
 	var sibling_fixed := 0
 	var sibling_carried := 0
 	var sibling_total_bodyless := 0
 	var sibling_total_reload_stripped := 0
 	for p: String in sibling_fixes:
-		if subclass_paths.has(p):
-			continue
 		var fix: Dictionary = sibling_fixes[p]
 		var fixed_src: String = fix["fixed_src"]
 		var af: Dictionary = fix["af"]
@@ -547,11 +452,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		zp.close_file()
 
 	zp.close()
-	if mod_script_count > 0:
-		_log_info("[RTVCodegen] Rewrote %d mod subclass script(s), %d hook points -- composes with mods that bypass super()" \
-				% [mod_script_count, mod_hook_count])
-		hook_count += mod_hook_count
-		script_count += mod_script_count
 
 	# Mount must happen BEFORE mod autoloads run so [rtvmodlib] needs= resolves
 	# and before any scene compiles against the rewritten class_name scripts.
@@ -575,7 +475,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			# we restart and Pass 2 gets 126/126 inline-live.
 			_log_info("[RTVCodegen] Generated %d rewritten vanilla script(s), %d hook points -- activation deferred to Pass 2 fresh engine" \
 					% [script_count, hook_count])
-			_persist_hook_pack_state(pack_zip_rel)
+			_persist_hook_pack_state(pack_zip_rel, _wrapped_paths_packed(packed_filenames))
 		elif ProjectSettings.load_resource_pack(pack_zip_rel, true):
 			# STABILITY canary C readback: confirm VFS mount precedence works
 			# end-to-end. If the canary file isn't readable with expected
@@ -745,12 +645,15 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 	_log_info("[RTVCodegen] Activated %d/%d rewritten script(s) (%d already live from static-init preload; %d deferred to lazy-compile)" \
 			% [activated, eager_total, preactivated, _scripts_with_scene_preloads.size()])
 
-	# Step D: persist hook pack path to pass_state so the next session's
-	# _mount_previous_session() picks it up at static init -- BEFORE game
-	# autoloads compile class_name scripts from the PCK's .gdc. Only
-	# then can we rewire pre-compiled scripts like Camera and WeaponRig
-	# (ScriptServer.class_cache pins their bytecode once compiled).
-	_persist_hook_pack_state(pack_path)
+	# Step D: persist hook pack path + wrapped-paths list to pass_state so
+	# the next session's _mount_previous_session() picks it up at static
+	# init -- BEFORE game autoloads compile class_name scripts from the
+	# PCK's .gdc. Only then can we rewire pre-compiled scripts like Camera
+	# and WeaponRig (ScriptServer.class_cache pins their bytecode once
+	# compiled). wrapped_paths drives the narrow preempt: only the scripts
+	# we wrapped this session get CACHE_MODE_IGNORE treatment at static
+	# init next session.
+	_persist_hook_pack_state(pack_path, _wrapped_paths_packed(filenames))
 
 	# End-to-end proof: register REAL hooks via the public RTVModLib API
 	# on well-known Controller/Camera/Door methods. If these fire at

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -308,11 +308,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	var _step_b_allowlist: Array[String] = []
 	var zero_byte_skipped: int = 0
 	var surface_skipped: int = 0
-	# Capture {source, parsed} per wrapped vanilla. Needed later to pack
-	# pristine copies for chain-via-extends: chain-bottom mods extend
-	# res://_rtv_pristine_/Scripts/<X>.gd so their super() doesn't loop
-	# back through the take_over_path'd tip.
-	var vanilla_rewrites: Dictionary = {}
 	for script_path: String in script_paths:
 		var filename := script_path.get_file()
 
@@ -425,7 +420,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		script_count += 1
 		hook_count += hookable_count * 4  # pre/post/callback/replace per method
 		packed_filenames.append(filename)
-		vanilla_rewrites[filename] = { "source": source, "parsed": parsed }
 		_log_debug("[RTVCodegen] Rewrote Scripts/%s (%d hooks)" % [filename, hookable_count * 4])
 
 	# Step C: rewrite mod scripts that subclass a vanilla script we just
@@ -437,67 +431,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	for fn in packed_filenames:
 		vanilla_set[fn] = true
 	var mod_candidates := _scan_mod_extends_targets(vanilla_set)
-	# Chain-via-extends composition. Multiple mods extending the same vanilla
-	# used to be last-wins under take_over_path (9 of 10 Interface.gd mods
-	# orphaned as dead code, dropping their save data). Now we compose them
-	# into a single extends chain so every mod's body runs via Godot virtual
-	# dispatch.
-	#
-	# Chain order = load order ascending (lowest priority = bottom of chain,
-	# highest priority = tip). Tip's take_over_path still wins the vanilla
-	# path via normal mod autoload instantiation order. Tip's script extends
-	# the NEXT mod's script (via rewritten extends), which extends the one
-	# below, ..., down to the bottom mod which extends a PRISTINE vanilla
-	# copy at res://_rtv_pristine_/Scripts/<X>.gd. The pristine path is NOT
-	# touched by take_over_path so the chain never loops back through the
-	# tip. (Without the pristine, chain-bottom's extends "res://Scripts/X.gd"
-	# would resolve to the tip after take_over_path -> infinite recursion.)
-	var chain_groups: Dictionary = {}  # vanilla_filename -> sorted Array of candidates
-	for cand: Dictionary in mod_candidates:
-		var vf: String = cand["vanilla_filename"]
-		if not chain_groups.has(vf):
-			chain_groups[vf] = []
-		(chain_groups[vf] as Array).append(cand)
-	var chained_vanillas: Dictionary = {}  # vanilla_filename -> true (needs pristine copy packed)
-	for vf: String in chain_groups:
-		var arr: Array = chain_groups[vf]
-		if arr.size() < 2:
-			# Single-mod: no chain, standard rewrite (extends unchanged).
-			(arr[0] as Dictionary)["extends_override"] = ""
-			continue
-		arr.sort_custom(func(a, b): return int(a["load_index"]) < int(b["load_index"]))
-		chained_vanillas[vf] = true
-		var pristine_path := "res://_rtv_pristine_/Scripts/" + vf
-		for i in range(arr.size()):
-			var c: Dictionary = arr[i]
-			if i == 0:
-				c["extends_override"] = pristine_path
-			else:
-				c["extends_override"] = (arr[i-1] as Dictionary)["res_path"]
-		var summary: PackedStringArray = []
-		for c in arr:
-			summary.append("%s[p=%d]" % [c["mod_name"], c["load_index"]])
-		_log_info("[RTVCodegen] CHAIN %s composed (bottom -> tip): %s -- pristine at %s" \
-				% [vf, " -> ".join(summary), pristine_path])
-	# Pack pristine vanilla copies for every chained script. Pristine = same
-	# rewrite as res://Scripts/<X>.gd but with class_name stripped (duplicate
-	# class_name registration would conflict with the primary's slot in the
-	# PCK's global_script_class_cache.cfg). Lives at res://_rtv_pristine_/
-	# so take_over_path on res://Scripts/<X>.gd can't displace it; chain-
-	# bottom mod's extends always resolves to genuine vanilla content.
-	for vf: String in chained_vanillas:
-		if not vanilla_rewrites.has(vf):
-			_log_warning("[RTVCodegen] Chain target %s wasn't in vanilla rewrite set -- chain will fail" % vf)
-			continue
-		var info: Dictionary = vanilla_rewrites[vf]
-		var pristine_src := _rtv_rewrite_vanilla_source(info["source"], info["parsed"], "_rtv_vanilla_", "", true)
-		var pristine_zip_entry := "_rtv_pristine_/Scripts/" + vf
-		if zp.start_file(pristine_zip_entry) != OK:
-			_log_warning("[RTVCodegen] Failed to start pristine zip entry %s" % pristine_zip_entry)
-			continue
-		zp.write_file(pristine_src.to_utf8_buffer())
-		zp.close_file()
-		_log_debug("[RTVCodegen] Packed pristine %s for chain bottom" % pristine_zip_entry)
 	var mod_script_count := 0
 	var mod_hook_count := 0
 	var mod_packed: Array[Dictionary] = []  # {res_path, vanilla_filename}
@@ -506,7 +439,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		var vanilla_filename: String = cand["vanilla_filename"]
 		var mod_name: String = cand["mod_name"]
 		var source: String = cand["source"]
-		var ext_override: String = cand.get("extends_override", "")
 		# Parse using the VANILLA filename so hook_base is "controller-*"
 		# not "immersivexp/controller-*" -- single hook namespace per vanilla.
 		var parsed := _rtv_parse_script(vanilla_filename, source)
@@ -520,7 +452,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		# vanilla's _rtv_vanilla_ methods via virtual dispatch. Otherwise
 		# super._ready() -> vanilla wrapper -> _rtv_vanilla__ready() resolves
 		# back to the mod's override -> infinite loop.
-		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, "_rtv_mod_", ext_override)
+		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, "_rtv_mod_")
 		# Pack at the mod's own path. Mount replace_files=true wins over the
 		# mod's .vmz which also serves this path. Script stays a subclass of
 		# rewritten vanilla via extends; its body may or may not call super.

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -27,6 +27,10 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# clean.
 	var hook_dir := ProjectSettings.globalize_path(HOOK_PACK_DIR)
 	DirAccess.make_dir_recursive_absolute(hook_dir)
+	# Per-call unique filename. Each _generate_hook_pack invocation writes a
+	# new file at a new path so load_resource_pack mounts fresh (no path-dedup
+	# stale offsets). Old files get cleaned up at next static-init.
+	var pack_zip_rel := HOOK_PACK_DIR.path_join("%s_%d.zip" % [HOOK_PACK_PREFIX, Time.get_ticks_msec()])
 	# Do NOT delete the old hook pack zip here. If a previous session mounted
 	# it via ProjectSettings.load_resource_pack (_mount_previous_session), the
 	# VFS still holds a file handle to the zip. Deleting the file on disk
@@ -180,7 +184,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		if zr != null:
 			zr.close()
 
-	var zip_abs := ProjectSettings.globalize_path(HOOK_PACK_ZIP)
+	var zip_abs := ProjectSettings.globalize_path(pack_zip_rel)
 	var zp := ZIPPacker.new()
 	if zp.open(zip_abs) != OK:
 		_log_critical("[RTVCodegen] Failed to create framework pack zip at %s" % zip_abs)
@@ -452,8 +456,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			# we restart and Pass 2 gets 126/126 inline-live.
 			_log_info("[RTVCodegen] Generated %d rewritten vanilla script(s), %d hook points -- activation deferred to Pass 2 fresh engine" \
 					% [script_count, hook_count])
-			_persist_hook_pack_state()
-		elif ProjectSettings.load_resource_pack(HOOK_PACK_ZIP, true):
+			_persist_hook_pack_state(pack_zip_rel)
+		elif ProjectSettings.load_resource_pack(pack_zip_rel, true):
 			# STABILITY canary C readback: confirm VFS mount precedence works
 			# end-to-end. If the canary file isn't readable with expected
 			# content, the hook pack mounted but isn't serving files -- every
@@ -463,14 +467,14 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 				_log_info("[STABILITY] VFS canary OK: hook pack mount precedence verified (%s)" % canary_got.strip_edges())
 			else:
 				_log_critical("[STABILITY] VFS canary FAILED (got '%s', expected MODLOADER-VFS-CANARY-*) -- hook pack mounted but files aren't served. Rewrites will not take effect this session." % canary_got.substr(0, 40))
-			_log_info("[RTVCodegen] Generated %d rewritten vanilla script(s), %d hook points -- pack mounted at res://" \
-					% [script_count, hook_count])
-			_activate_rewritten_scripts(packed_filenames)
+			_log_info("[RTVCodegen] Generated %d rewritten vanilla script(s), %d hook points -- pack mounted at res:// (%s)" \
+					% [script_count, hook_count, pack_zip_rel.get_file()])
+			_activate_rewritten_scripts(packed_filenames, pack_zip_rel)
 		else:
 			_log_critical("[RTVCodegen] Failed to mount hook pack at %s -- rewrites won't load" % zip_abs)
 	else:
 		_log_info("[RTVCodegen] No scripts rewritten -- no pack mounted")
-	return HOOK_PACK_ZIP
+	return pack_zip_rel
 
 # Force the game's ResourceCache entry for each rewritten vanilla path to use
 # our source. Necessary because:
@@ -488,7 +492,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 # Verified 2026-04-17: 158 wrapper calls in 4s across 5 scripts (physics
 # tick rate on active Camera/Controller nodes).
 
-func _activate_rewritten_scripts(filenames: Array[String]) -> void:
+func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) -> void:
 	# Scripts whose module-scope preload() pulls in a PackedScene are deferred
 	# from eager load+reload. Loading them here would fire their preload()
 	# chain BEFORE mod autoloads call overrideScript(), baking Script
@@ -627,7 +631,7 @@ func _activate_rewritten_scripts(filenames: Array[String]) -> void:
 	# autoloads compile class_name scripts from the PCK's .gdc. Only
 	# then can we rewire pre-compiled scripts like Camera and WeaponRig
 	# (ScriptServer.class_cache pins their bytecode once compiled).
-	_persist_hook_pack_state()
+	_persist_hook_pack_state(pack_path)
 
 	# End-to-end proof: register REAL hooks via the public RTVModLib API
 	# on well-known Controller/Camera/Door methods. If these fire at

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -15,6 +15,17 @@ const REGISTRY_TARGETS: Array[String] = [
 func _is_registry_target(filename: String) -> bool:
 	return filename in REGISTRY_TARGETS
 
+# Sum a per-mod analysis field across all scanned mods. Used for the
+# wrap-surface log line so we can see how many mods pushed a given
+# category into needed_paths.
+func _count_mods_field(field: String) -> int:
+	var n := 0
+	for mod_name: String in _mod_script_analysis:
+		var a: Dictionary = _mod_script_analysis[mod_name]
+		if (a.get(field, []) as Array).size() > 0:
+			n += 1
+	return n
+
 # Build the framework pack: enumerate res://Scripts/*.gd, detokenize each via
 # _read_vanilla_source, parse + generate wrappers, zip them, mount the zip.
 #
@@ -71,6 +82,102 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		_log_warning("[RTVCodegen] script enumeration failed -- falling back to class_name list (%d)" % _class_name_to_path.size())
 		for path: String in _class_name_to_path.values():
 			script_paths.append(path)
+	# Narrow the wrap surface to vanilla scripts that mods actually touch.
+	# Wrapping every vanilla (180 in RTV) fires dispatch on every method call
+	# of every class_name node, even ones no mod extends or hooks. v2.1.0's
+	# opt-in [hooks] model had ~zero overhead for untouched scripts; v3.0.0
+	# flipped to wrap-everything which burned ~93K calls/sec on hot paths
+	# like hud-_physics_process when 65 mods were loaded. Restore the opt-in
+	# semantics WITHOUT requiring mod-author changes by deriving the set from
+	# what the scan already captured.
+	#
+	# A vanilla script goes into needed_paths if ANY enabled mod:
+	#   1. extends "res://Scripts/<X>.gd"
+	#   2. take_over_path("res://Scripts/<X>.gd", ...)
+	#   3. calls .hook("<x>-<method>...", ...) where <x> is the lowercase stem
+	#
+	# Scripts not in the union run AS-IS (no dispatch wrapper, matches v2.1.0
+	# behavior for those specific paths). Their class_name registrations stay
+	# intact because we never touched them -- Godot's native compile path
+	# serves them with no overhead.
+	var prefix_to_path: Dictionary = {}
+	for sp: String in script_paths:
+		prefix_to_path[sp.get_file().get_basename().to_lower()] = sp
+	var needed_paths: Dictionary = {}
+	# Reverse map: vanilla_path -> Array of {mod, reason} entries. Diagnostics
+	# only; used right after to warn about multi-claim conflicts. When N>1
+	# mods override the same script via take_over_path, only the last call
+	# wins -- the others' bodies are orphaned and silently dead. Surfacing
+	# this as a CRITICAL saves hours of "why doesn't my mod work" debugging.
+	var claim_map: Dictionary = {}
+	for mod_name: String in _mod_script_analysis:
+		var analysis: Dictionary = _mod_script_analysis[mod_name]
+		for p: String in (analysis.get("extends_paths", []) as Array):
+			if p.begins_with("res://Scripts/"):
+				needed_paths[p] = true
+				if not claim_map.has(p):
+					claim_map[p] = []
+				(claim_map[p] as Array).append({"mod": mod_name, "reason": "extends"})
+		for p: String in (analysis.get("take_over_literal_paths", []) as Array):
+			if p.begins_with("res://Scripts/"):
+				needed_paths[p] = true
+				if not claim_map.has(p):
+					claim_map[p] = []
+				(claim_map[p] as Array).append({"mod": mod_name, "reason": "take_over_path"})
+		for pref: String in (analysis.get("hooked_script_prefixes", []) as Array):
+			if prefix_to_path.has(pref):
+				needed_paths[prefix_to_path[pref]] = true
+	# Hot-path scripts that game code compiles eagerly at static init
+	# (Camera, Controller, WeaponRig, Door, etc.) must stay wrapped even
+	# when no mod touches them -- they're in the pinned_probes list in
+	# boot.gd because Godot's class_cache pins their .gdc before any mod
+	# code runs. Wrapping them costs a dispatch call that short-circuits
+	# via _any_mod_hooked when no mod hooked them, so it's ~1 meta-read
+	# per call and still correct.
+	var _pinned_always_wrap: Array[String] = [
+		"res://Scripts/Camera.gd", "res://Scripts/Controller.gd",
+		"res://Scripts/Door.gd", "res://Scripts/Fish.gd",
+		"res://Scripts/Furniture.gd", "res://Scripts/GameData.gd",
+		"res://Scripts/Grenade.gd", "res://Scripts/Grid.gd",
+		"res://Scripts/Hitbox.gd", "res://Scripts/KnifeRig.gd",
+		"res://Scripts/LootContainer.gd", "res://Scripts/Lure.gd",
+		"res://Scripts/Pickup.gd", "res://Scripts/Settings.gd",
+		"res://Scripts/Trader.gd", "res://Scripts/WeaponRig.gd",
+	]
+	for pp in _pinned_always_wrap:
+		needed_paths[pp] = true
+	# REGISTRY_TARGETS (currently just Database.gd) carry injected registry
+	# fields that mods rely on via lib.register()/override(). Always wrap.
+	for rt_filename in REGISTRY_TARGETS:
+		needed_paths["res://Scripts/" + rt_filename] = true
+	_log_info("[RTVCodegen] Wrap surface: %d of %d vanilla scripts (extends=%d, take_over=%d, hook=%d, pinned=%d)" % [
+		needed_paths.size(),
+		script_paths.size(),
+		_count_mods_field("extends_paths"),
+		_count_mods_field("take_over_literal_paths"),
+		_count_mods_field("hooked_script_prefixes"),
+		_pinned_always_wrap.size() + REGISTRY_TARGETS.size(),
+	])
+	# Report multi-claim conflicts. take_over_path is last-wins by load order;
+	# claimants other than the last are orphaned -- their method bodies exist
+	# but the script Godot resolves at `res://Scripts/<X>.gd` is the winner's.
+	# If ANY of the 10 Interface.gd claimants in a typical big-mod-set loadout
+	# has the behavior a user cares about and isn't last in load order, that
+	# behavior silently vanishes. This warning gives the user a map.
+	var conflict_count := 0
+	for path: String in claim_map:
+		var claims: Array = claim_map[path]
+		if claims.size() < 2:
+			continue
+		conflict_count += 1
+		var claim_summaries: PackedStringArray = []
+		for c in claims:
+			claim_summaries.append("%s(%s)" % [c["mod"], c["reason"]])
+		_log_critical("[RTVCodegen] CONFLICT %s claimed by %d mods: %s -- take_over_path is last-wins, only one mod's code is live" \
+				% [path, claims.size(), ", ".join(claim_summaries)])
+	if conflict_count > 0:
+		_log_critical("[RTVCodegen] %d vanilla script(s) have overlapping claims -- see CONFLICT lines above. Disable duplicates to get predictable behavior." \
+				% conflict_count)
 	# Skip-list breakdown -- gives the README an evidence trail for "we wrap N
 	# scripts, skip M". The actual rewritten count is logged below by the
 	# "Generated N rewritten" line; this just records the static skip-list sizes.
@@ -200,6 +307,7 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# GDScriptCache-pinned bucket vs the live-inline bucket.
 	var _step_b_allowlist: Array[String] = []
 	var zero_byte_skipped: int = 0
+	var surface_skipped: int = 0
 	for script_path: String in script_paths:
 		var filename := script_path.get_file()
 
@@ -215,6 +323,14 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			zero_byte_skipped += 1
 			continue
 		if not _step_b_allowlist.is_empty() and filename not in _step_b_allowlist:
+			continue
+		# Wrap-surface filter: no mod extends, take_over_paths, or hooks
+		# this script, and it's not a pinned-at-boot class_name. Skipping
+		# means the script stays pure vanilla at runtime -- no dispatch
+		# overhead, same behavior as v2.1.0 for this path.
+		if not needed_paths.has(script_path):
+			surface_skipped += 1
+			_log_debug("[RTVCodegen] Surface-skip %s (no mod extends/hooks/overrides)" % filename)
 			continue
 
 		# Warn if a [script_overrides] replacement is also in play. For rewritten
@@ -445,6 +561,9 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	if zero_byte_skipped > 0:
 		_log_info("[RTVCodegen] Skipped %d zero-byte PCK entry(ies) (base game ships empty .gd files -- not hookable, not a modloader failure): %s" \
 				% [zero_byte_skipped, ", ".join(_pck_zero_byte_paths.keys())])
+	if surface_skipped > 0:
+		_log_info("[RTVCodegen] Surface-skipped %d vanilla script(s) with no mod interaction -- they run native (no dispatch overhead)" \
+				% surface_skipped)
 	if script_count > 0:
 		if defer_activation:
 			# Pass 1 pre-restart: write the zip + persist pass_state so Pass 2's

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -801,31 +801,14 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 				_log_warning("[RegistryProbe] Database: _rtv_vanilla_scenes=%d entries but get('%s') returned %s (not PackedScene) -- _get() injection broken" \
 						% [scene_count, probe_key, type_string(typeof(probe_result))])
 
-	# Reset counters before probes. The dispatch template increments
-	# _rtv_dispatch_count on entry, _rtv_dispatch_no_lib when the _lib
-	# null-check trips, and _rtv_dispatch_by_hook per hook_base.
-	Engine.set_meta("_rtv_dispatch_count", 0)
-	Engine.set_meta("_rtv_dispatch_no_lib", 0)
-	Engine.set_meta("_rtv_dispatch_by_hook", {})
 	# 30s gives the player time to get into gameplay so controller-level
-	# hooks can fire at least once.
+	# hooks can fire at least once. HOOK-API summary only; the per-wrapper
+	# dispatch counter was removed 2026-04-20 because its 2 Engine.set_meta
+	# calls per invocation cost ~0.37s CPU/sec on hot paths like
+	# hud-_physics_process and interface-_physics_process (93K calls/sec each).
 	get_tree().create_timer(30.0).timeout.connect(func():
-		var n: int = int(Engine.get_meta("_rtv_dispatch_count", 0))
-		var no_lib: int = int(Engine.get_meta("_rtv_dispatch_no_lib", 0))
-		var by_hook: Dictionary = Engine.get_meta("_rtv_dispatch_by_hook", {})
 		var pc: Dictionary = Engine.get_meta("_rtv_probe_counts", {})
 		var fa: Dictionary = Engine.get_meta("_rtv_probe_first_args", {})
-		if n > 0:
-			_log_info("[RTVCodegen] DISPATCH-LIVE: %d wrapper call(s) in 30s (no-lib fallback=%d)" % [n, no_lib])
-		else:
-			_log_critical("[RTVCodegen] DISPATCH-DEAD: 0 wrapper calls in 30s -- game code not hitting rewrite")
-		# Sort by count desc and log top 15
-		var pairs: Array = []
-		for k: String in by_hook:
-			pairs.append([k, int(by_hook[k])])
-		pairs.sort_custom(func(a, b): return a[1] > b[1])
-		for i in range(min(15, pairs.size())):
-			_log_info("[RTVCodegen]   hook_base=%s count=%d" % [pairs[i][0], pairs[i][1]])
 		# HOOK-API per-probe breakdown across phases:
 		var total := 0
 		for k: String in ["loader_pp", "simulation_proc", "profiler_proc",

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -929,27 +929,34 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 	get_tree().create_timer(30.0).timeout.connect(func():
 		var pc: Dictionary = Engine.get_meta("_rtv_probe_counts", {})
 		var fa: Dictionary = Engine.get_meta("_rtv_probe_first_args", {})
-		# Dispatch counts (dev mode only). Show top 15 hot methods + flag
-		# any that exceed 10000 calls in 30s -- those are runaway candidates
-		# (e.g. a mod's _ready firing in a loop).
+		# Dispatch counts (dev mode only). Show top 20 hot methods. No generic
+		# threshold -- hud/interface/character _physics_process legitimately
+		# hit 90K+ calls/sec × 30s instance counts, a count-based RUNAWAY
+		# flag would drown real anomalies in expected noise.
+		#
+		# Instead, call out _ready / _enter_tree / _init specifically: those
+		# fire once per node lifetime, so any count > 10 is a red flag that
+		# a mod is re-invoking them in a loop (typical cause of connect-
+		# already-connected error spam).
 		if _developer_mode and _dispatch_counts.size() > 0:
 			var pairs: Array = []
 			for k: String in _dispatch_counts:
 				pairs.append([k, int(_dispatch_counts[k])])
 			pairs.sort_custom(func(a, b): return a[1] > b[1])
 			_log_info("[RTVCodegen] DISPATCH-COUNT top %d / %d tracked methods (dev mode, 30s window):" \
-					% [min(15, pairs.size()), pairs.size()])
-			for i in range(min(15, pairs.size())):
-				var warn := "  !!HOT!!" if pairs[i][1] > 10000 else ""
-				_log_info("[RTVCodegen]   %-48s %d%s" % [pairs[i][0], pairs[i][1], warn])
-			# Extra: list any method exceeding the runaway threshold explicitly
-			# so "why is the game laggy" is greppable.
-			var runaway: Array = []
+					% [min(20, pairs.size()), pairs.size()])
+			for i in range(min(20, pairs.size())):
+				_log_info("[RTVCodegen]   %-48s %d" % [pairs[i][0], pairs[i][1]])
+			# Flag lifecycle methods that fire way more than they should.
+			var lifecycle_runaway: Array = []
 			for p in pairs:
-				if p[1] > 10000:
-					runaway.append("%s=%d" % [p[0], p[1]])
-			if runaway.size() > 0:
-				_log_critical("[RTVCodegen] RUNAWAY methods (>10000 calls/30s): %s -- a mod is likely calling one of these from a loop or frequent callback" % ", ".join(runaway))
+				var name: String = p[0]
+				if (name.ends_with("-_ready") or name.ends_with("-_enter_tree") \
+						or name.ends_with("-_init")) and int(p[1]) > 10:
+					lifecycle_runaway.append("%s=%d" % [name, p[1]])
+			if lifecycle_runaway.size() > 0:
+				_log_critical("[RTVCodegen] LIFECYCLE-RUNAWAY: %s -- these should fire once per node; elevated counts usually mean a mod is explicitly calling them from a loop or frequent callback, which cascades into connect-already-connected error spam" \
+						% ", ".join(lifecycle_runaway))
 		# HOOK-API per-probe breakdown across phases:
 		var total := 0
 		for k: String in ["loader_pp", "simulation_proc", "profiler_proc",

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -16,6 +16,8 @@ func load_all_mods(pass_label: String = "") -> void:
 	_hooks.clear()
 	_pending_script_overrides.clear()
 	_applied_script_overrides.clear()
+	_hooked_methods.clear()
+	_any_mod_declared_registry = false
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
@@ -50,6 +52,41 @@ func load_all_mods(pass_label: String = "") -> void:
 
 	for load_index in candidates.size():
 		_process_mod_candidate(candidates[load_index], load_index)
+
+	# After every mod has been scanned + its mod.txt parsed, collapse the
+	# per-mod .hook() call analysis into the global _hooked_methods map.
+	# Resolves each prefix ("controller") to a vanilla path and records
+	# the declared method name. _generate_hook_pack uses this + the
+	# [hooks] static declarations as the per-path per-method wrap mask.
+	_merge_hook_calls_into_wrap_mask()
+
+func _merge_hook_calls_into_wrap_mask() -> void:
+	if _mod_script_analysis.is_empty():
+		return
+	# Build a prefix -> res://Scripts/<File>.gd map. Script enumeration is
+	# driven by the PCK list (populated for the rewriter), but the class-name
+	# lookup covers the hot-path names (Camera, Controller, Interface, etc.)
+	# and is cheap enough to rebuild here. Fall back to lowercased filename
+	# match for scripts without class_name.
+	var prefix_to_path: Dictionary = {}
+	for cn: String in _class_name_to_path:
+		var p: String = _class_name_to_path[cn]
+		prefix_to_path[p.get_file().get_basename().to_lower()] = p
+	for sp: String in _all_game_script_paths:
+		var key := sp.get_file().get_basename().to_lower()
+		if not prefix_to_path.has(key):
+			prefix_to_path[key] = sp
+	for mod_name: String in _mod_script_analysis:
+		var analysis: Dictionary = _mod_script_analysis[mod_name]
+		for entry: Dictionary in (analysis.get("hook_calls", []) as Array):
+			var prefix: String = entry["prefix"]
+			var method: String = entry["method"]
+			if not prefix_to_path.has(prefix):
+				continue
+			var path: String = prefix_to_path[prefix]
+			if not _hooked_methods.has(path):
+				_hooked_methods[path] = {}
+			(_hooked_methods[path] as Dictionary)[method] = true
 
 func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	var file_name: String = c["file_name"]
@@ -108,32 +145,63 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	_loaded_mod_ids[mod_id] = true
 
-	# [hooks] is optional -- all class_name methods are pre-wrapped.
+	# [hooks] static declaration (v2.4.0 opt-in model). Format:
+	#   [hooks]
+	#   res://Scripts/Interface.gd = _ready, update_tooltip
+	# Populates _hooked_methods[path][method] so _generate_hook_pack can
+	# build a per-path, per-method wrap mask. One mod declaring [hooks]
+	# is enough to enroll that path for wrapping; other mods that extend
+	# the same vanilla script inherit the wrapped version naturally via
+	# Godot's extends resolution (no rewrite of the other mods' source).
 	if cfg != null and cfg.has_section("hooks"):
 		for key in cfg.get_section_keys("hooks"):
-			var script_path := str(key)
+			var script_path := str(key).strip_edges()
 			var methods_str := str(cfg.get_value("hooks", key))
+			if script_path.is_empty():
+				continue
+			if not _hooked_methods.has(script_path):
+				_hooked_methods[script_path] = {}
 			for method_name in methods_str.split(","):
 				method_name = method_name.strip_edges()
 				if method_name.is_empty():
 					continue
-				_log_info("  Hook hint: %s :: %s [%s]" % [script_path, method_name, mod_name])
+				(_hooked_methods[script_path] as Dictionary)[method_name] = true
+				_log_info("  Hook declared: %s :: %s [%s]" % [script_path, method_name, mod_name])
 
-	# [script_overrides] -- full script replacements that chain via extends.
-	if cfg != null and cfg.has_section("script_overrides"):
-		for key in cfg.get_section_keys("script_overrides"):
-			var vanilla_path := str(key).strip_edges()
-			var mod_script_path := str(cfg.get_value("script_overrides", key)).strip_edges()
-			if vanilla_path.is_empty() or mod_script_path.is_empty():
-				_log_warning("  Empty script_overrides entry -- skipped")
+	# [registry] opt-in (v2.4.0). Gates Database.gd wrapping + const-to-dict
+	# transform on explicit mod declaration. Without this, Database.gd stays
+	# unwrapped and lib.register()/override() will not work. The presence
+	# of the section is sufficient -- body content is parsed by the
+	# registry handlers per registry kind (currently only SCENES).
+	if cfg != null and cfg.has_section("registry"):
+		_any_mod_declared_registry = true
+		_log_info("  Registry declared [%s]" % mod_name)
+
+	# [script_extend] / [script_overrides] -- full script replacements that
+	# chain via Godot's extends resolution. Both section names accepted
+	# (script_extend is the preferred v2.4.0 name; script_overrides is the
+	# legacy alias kept for backward compat with mods written pre-cutover).
+	# Each entry: vanilla_path = mod_script_path. Higher-priority mods land
+	# last in the chain (most recent take_over_path wins, extends resolves
+	# to the prior chain tip).
+	var _extend_sections: Array[String] = ["script_extend", "script_overrides"]
+	if cfg != null:
+		for section in _extend_sections:
+			if not cfg.has_section(section):
 				continue
-			_pending_script_overrides.append({
-				"vanilla_path": vanilla_path,
-				"mod_script_path": mod_script_path,
-				"mod_name": mod_name,
-				"priority": c.get("priority", 0),
-			})
-			_log_info("  Script override: %s -> %s" % [vanilla_path, mod_script_path])
+			for key in cfg.get_section_keys(section):
+				var vanilla_path := str(key).strip_edges()
+				var mod_script_path := str(cfg.get_value(section, key)).strip_edges()
+				if vanilla_path.is_empty() or mod_script_path.is_empty():
+					_log_warning("  Empty [%s] entry -- skipped" % section)
+					continue
+				_pending_script_overrides.append({
+					"vanilla_path": vanilla_path,
+					"mod_script_path": mod_script_path,
+					"mod_name": mod_name,
+					"priority": c.get("priority", 0),
+				})
+				_log_info("  [%s] %s -> %s" % [section, vanilla_path, mod_script_path])
 
 	if cfg == null or not cfg.has_section("autoload"):
 		return
@@ -192,10 +260,16 @@ func _register_claim(res_path: String, mod_name: String, archive: String,
 	})
 
 
-# Apply [script_overrides] entries via take_over_path.  Each override is a mod
-# script that extends the vanilla script.  Processing in priority order (lowest
-# first) means each subsequent override's extends resolves to the previous one,
-# forming a natural chain: ModB -> ModA -> vanilla.
+# Apply [script_overrides] / [script_extend] entries via take_over_path.
+# Each override is a mod script that extends the vanilla script. Processing
+# in priority order (lowest first) means each subsequent override's extends
+# resolves to the previous one, forming a natural chain: ModB -> ModA -> vanilla.
+#
+# Legacy-syntax autofix runs on each mod source before reload() so Godot 4's
+# strict parser accepts Godot-3-era patterns (bodyless blocks, `tool`,
+# `onready var`, `export var`, bare `base()` calls). Narrow, semantically-
+# equivalent transform. Chain composition survives -- every intermediate
+# script in the chain goes through the same autofix.
 func _apply_script_overrides() -> void:
 	if _pending_script_overrides.is_empty():
 		return
@@ -218,8 +292,22 @@ func _apply_script_overrides() -> void:
 			_log_critical("[Overrides] Empty source: %s [%s]" % [mod_path, mod_name])
 			continue
 
+		# Normalize line endings + autofix legacy syntax. GDScript's strict
+		# reload parser rejects CRLF/LF mixes, bodyless blocks, and Godot-3
+		# annotations; v2.1.0-era mods commonly ship with these and break
+		# take_over_path when loaded as-is. Autofix is a no-op for clean
+		# source so modern mods pay no transform cost.
+		var normalized: String = source.replace("\r\n", "\n").replace("\r", "\n")
+		var af := _rtv_autofix_legacy_syntax(normalized)
+		var fixed_src: String = af["source"]
+		var af_total: int = int(af["bodyless"]) + int(af["tool"]) + int(af["onready"]) \
+				+ int(af["export"]) + int(af.get("base", 0))
+		if af_total > 0:
+			_log_info("[Overrides] Autofix %s: %d bodyless, %d tool, %d onready, %d export, %d base() -> super" \
+					% [mod_path, af["bodyless"], af["tool"], af["onready"], af["export"], af.get("base", 0)])
+
 		var new_script := GDScript.new()
-		new_script.source_code = source
+		new_script.source_code = fixed_src
 		var err := new_script.reload()
 		if err != OK:
 			_log_critical("[Overrides] Compile failed for %s (error %d) [%s]" % [mod_path, err, mod_name])
@@ -267,11 +355,12 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		"preload_paths":           [],
 		"calls_base":              false, # uses base() instead of super() -- Godot 3 or removed method
 		"total_gd_files":          0,
-		# Script prefixes mod calls .hook() on (e.g. "controller", "camera").
-		# Used by _generate_hook_pack to decide which vanilla scripts need
-		# wrapping -- only ones mods actually interact with via extends,
-		# take_over_path, or runtime .hook() get wrapped.
-		"hooked_script_prefixes":  [],
+		# .hook("<prefix>-<method>[-suffix]") declarations found in source.
+		# Each entry is {prefix, method}; _generate_hook_pack uses this to
+		# populate the per-path per-method wrap mask. A mod declaring zero
+		# hooks AND zero [hooks]/[registry] mod.txt sections leaves the
+		# wrap surface empty and skips hook pack generation entirely.
+		"hook_calls":              [],  # Array of {prefix, method}
 	}
 
 	for f in files:
@@ -280,10 +369,9 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 			var gd_bytes := zr.read_file(f)
 			if gd_bytes.size() > 0:
 				var gd_text := gd_bytes.get_string_from_utf8()
-				# Scan is unconditional now -- _generate_hook_pack relies on
-				# extends_paths + hooked_script_prefixes to narrow the wrap
-				# surface to what mods actually touch. Was dev-mode-only
-				# before we needed these fields for wrap decisions.
+				# Scan is unconditional. _generate_hook_pack reads hook_calls
+				# to build the wrap mask; the other fields feed diagnostics
+				# (conflict report, override verification).
 				_scan_gd_source(gd_text, gd_analysis)
 				if _class_name_to_path.size() > 0:
 					_check_class_name_safety(gd_text, f, mod_name)
@@ -372,15 +460,22 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 		if pl_path not in (analysis["preload_paths"] as Array):
 			(analysis["preload_paths"] as Array).append(pl_path)
 
-	# .hook("<prefix>-<method>[-suffix]") calls. Extract the leading prefix
-	# (lowercase script stem like "controller", "camera") so _generate_hook_pack
-	# can decide to wrap the corresponding vanilla script even when no mod
-	# extends it. Matches .hook("...") across whitespace + optional var receiver
-	# (e.g. lib.hook, Engine.get_meta("RTVModLib").hook, modlib.hook).
+	# .hook("<prefix>-<method>[-suffix]") calls. Capture (prefix, method)
+	# pairs so _generate_hook_pack can build a per-path, per-method wrap
+	# mask -- only methods a mod actually hooks get dispatch wrappers,
+	# matching godot-mod-loader's method_mask semantics. Prefix is the
+	# lowercase script stem ("controller", "camera"); method is the method
+	# name without the -pre/-post/-callback dispatch-variant suffix.
 	for m_hk in _re_hook_call.search_all(text):
 		var prefix := m_hk.get_string(1).to_lower()
-		if prefix not in (analysis["hooked_script_prefixes"] as Array):
-			(analysis["hooked_script_prefixes"] as Array).append(prefix)
+		var method := m_hk.get_string(2)
+		var already: bool = false
+		for existing: Dictionary in (analysis["hook_calls"] as Array):
+			if existing["prefix"] == prefix and existing["method"] == method:
+				already = true
+				break
+		if not already:
+			(analysis["hook_calls"] as Array).append({"prefix": prefix, "method": method})
 
 	# Method declarations -- needed for mod collision detection.
 	var func_matches := _re_func.search_all(text)

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -267,6 +267,11 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		"preload_paths":           [],
 		"calls_base":              false, # uses base() instead of super() -- Godot 3 or removed method
 		"total_gd_files":          0,
+		# Script prefixes mod calls .hook() on (e.g. "controller", "camera").
+		# Used by _generate_hook_pack to decide which vanilla scripts need
+		# wrapping -- only ones mods actually interact with via extends,
+		# take_over_path, or runtime .hook() get wrapped.
+		"hooked_script_prefixes":  [],
 	}
 
 	for f in files:
@@ -275,8 +280,11 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 			var gd_bytes := zr.read_file(f)
 			if gd_bytes.size() > 0:
 				var gd_text := gd_bytes.get_string_from_utf8()
-				if _developer_mode:
-					_scan_gd_source(gd_text, gd_analysis)
+				# Scan is unconditional now -- _generate_hook_pack relies on
+				# extends_paths + hooked_script_prefixes to narrow the wrap
+				# surface to what mods actually touch. Was dev-mode-only
+				# before we needed these fields for wrap decisions.
+				_scan_gd_source(gd_text, gd_analysis)
 				if _class_name_to_path.size() > 0:
 					_check_class_name_safety(gd_text, f, mod_name)
 
@@ -363,6 +371,16 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 		var pl_path := m_pl.get_string(1)
 		if pl_path not in (analysis["preload_paths"] as Array):
 			(analysis["preload_paths"] as Array).append(pl_path)
+
+	# .hook("<prefix>-<method>[-suffix]") calls. Extract the leading prefix
+	# (lowercase script stem like "controller", "camera") so _generate_hook_pack
+	# can decide to wrap the corresponding vanilla script even when no mod
+	# extends it. Matches .hook("...") across whitespace + optional var receiver
+	# (e.g. lib.hook, Engine.get_meta("RTVModLib").hook, modlib.hook).
+	for m_hk in _re_hook_call.search_all(text):
+		var prefix := m_hk.get_string(1).to_lower()
+		if prefix not in (analysis["hooked_script_prefixes"] as Array):
+			(analysis["hooked_script_prefixes"] as Array).append(prefix)
 
 	# Method declarations -- needed for mod collision detection.
 	var func_matches := _re_func.search_all(text)

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -369,10 +369,10 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 	var autofix := _rtv_autofix_legacy_syntax(src)
 	src = autofix["source"]
 	var af_total: int = int(autofix["bodyless"]) + int(autofix["tool"]) \
-			+ int(autofix["onready"]) + int(autofix["export"])
+			+ int(autofix["onready"]) + int(autofix["export"]) + int(autofix.get("base", 0))
 	if af_total > 0:
-		_log_info("[Autofix] %s: %d bodyless block(s), %d @tool, %d @onready, %d @export -- legacy syntax normalized" \
-				% [parsed.get("filename", "?"), autofix["bodyless"], autofix["tool"], autofix["onready"], autofix["export"]])
+		_log_info("[Autofix] %s: %d bodyless, %d @tool, %d @onready, %d @export, %d base()->super -- legacy syntax normalized" \
+				% [parsed.get("filename", "?"), autofix["bodyless"], autofix["tool"], autofix["onready"], autofix["export"], autofix.get("base", 0)])
 
 	# Database-specific transform: convert `const X = preload("...")` lines
 	# into a _rtv_vanilla_scenes dictionary. This makes Database.get(name)
@@ -681,12 +681,47 @@ func _rtv_autofix_legacy_syntax(source: String) -> Dictionary:
 	var fix_tool := 0
 	var fix_onready := 0
 	var fix_export := 0
+	var fix_base := 0
+
+	# Pre-pass: track which method a line belongs to, so `base(...)` inside
+	# a method body can be rewritten to `super.<method>(...)`. Godot 3's
+	# `base()` is no longer valid in Godot 4; parser fails with
+	# `Function "base()" not found in base self` and the failure cascades
+	# through chain-via-extends. Single autofix converts the common case.
+	var current_method: String = ""
+	var method_line_indent: String = ""
 
 	for i in lines.size():
 		var line: String = lines[i]
 
-		# Annotation migrations (line-local rewrites).
+		# Track enclosing method for `base()` rewrite. Top-level line (no
+		# indent) with `func <name>(` opens a method; top-level line without
+		# that closes the prior method's scope.
 		var lead := _rtv_leading_indent(line)
+		if lead.is_empty() and not line.strip_edges().is_empty():
+			var stripped_top := line.strip_edges()
+			if stripped_top.begins_with("func "):
+				var open_paren := stripped_top.find("(")
+				if open_paren > 5:
+					current_method = stripped_top.substr(5, open_paren - 5).strip_edges()
+					method_line_indent = ""
+			elif stripped_top.begins_with("static func ") or stripped_top.begins_with("@"):
+				# Skip static funcs and annotations (they don't open a "self"
+				# method where base() would resolve).
+				current_method = ""
+			else:
+				current_method = ""
+
+		# Rewrite `base(` / `base (` to `super.<method>(` when inside a
+		# method body. Don't touch literal `.base(` calls (already qualified).
+		if not current_method.is_empty() and line.find("base(") >= 0:
+			var rewritten := _rtv_rewrite_bare_base(line, current_method)
+			if rewritten != line:
+				line = rewritten
+				fix_base += 1
+
+		# Annotation migrations (line-local rewrites).
+		lead = _rtv_leading_indent(line)
 		var body_text := line.substr(lead.length())
 		if i == 0 and body_text.strip_edges() == "tool":
 			line = lead + "@tool"
@@ -731,7 +766,47 @@ func _rtv_autofix_legacy_syntax(source: String) -> Dictionary:
 		"tool": fix_tool,
 		"onready": fix_onready,
 		"export": fix_export,
+		"base": fix_base,
 	}
+
+# Rewrite bare `base(args)` or `base (args)` in a line to `super.<method>(args)`.
+# Skips `self.base(`, `<ident>.base(`, etc. -- only rewrites standalone `base(`
+# (possibly preceded by `=`, `+`, `(`, `[`, `,`, or whitespace). Per-line so
+# strings/comments past a `#` stay unchanged.
+func _rtv_rewrite_bare_base(line: String, method_name: String) -> String:
+	var comment_start := line.find("#")
+	var head: String = line if comment_start < 0 else line.substr(0, comment_start)
+	var tail: String = "" if comment_start < 0 else line.substr(comment_start)
+	# Walk from left to right looking for the word `base` not preceded by a
+	# letter/digit/underscore/dot (i.e. not part of an identifier or already
+	# qualified). Replace with `super.<method>`.
+	var i := 0
+	var rewritten := ""
+	while i < head.length():
+		if i + 4 <= head.length() and head.substr(i, 4) == "base":
+			# Check preceding character (word-boundary).
+			var prev_ok := true
+			if i > 0:
+				var pc := head[i - 1]
+				if pc >= "a" and pc <= "z":
+					prev_ok = false
+				elif pc >= "A" and pc <= "Z":
+					prev_ok = false
+				elif pc >= "0" and pc <= "9":
+					prev_ok = false
+				elif pc == "_" or pc == ".":
+					prev_ok = false
+			# Check trailing char is `(` or whitespace-then-`(`.
+			var j := i + 4
+			while j < head.length() and (head[j] == " " or head[j] == "\t"):
+				j += 1
+			if prev_ok and j < head.length() and head[j] == "(":
+				rewritten += "super." + method_name
+				i += 4
+				continue
+		rewritten += head[i]
+		i += 1
+	return rewritten + tail
 
 # Comment out `<var>.reload()` lines inside mod helper functions that also
 # call `take_over_path`. Rationale: mod override helpers (RTVCoop's _override,
@@ -826,8 +901,17 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 	var is_void: bool = is_engine_void or not bool(fe["has_return_value"])
 	var aw: String = "await " if is_coro else ""
 
-	var sig: String = "func %s():" % method_name if params.is_empty() \
-			else "func %s(%s):" % [method_name, params]
+	# Preserve the return type annotation so callers can still type-infer
+	# from wrapper returns (e.g. `var chargeLen = self.ChargeShot()` when
+	# ChargeShot is `-> int`). Without the annotation, GDScript's strict
+	# parser infers Variant and rejects untyped var decls in chained mod
+	# subclasses, cascading parse failures through the extends chain.
+	var return_annot: String = ""
+	var rt = fe.get("return_type")
+	if rt != null and not (rt as String).is_empty():
+		return_annot = " -> " + (rt as String)
+	var sig: String = "func %s()%s:" % [method_name, return_annot] if params.is_empty() \
+			else "func %s(%s)%s:" % [method_name, params, return_annot]
 
 	# Indent levels. GDScript requires consistent tabs-or-spaces per file;
 	# IXP uses 4-space, vanilla RTV uses tabs. Caller passes the source's

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -322,27 +322,13 @@ func _rtv_generate_override(script: Dictionary) -> String:
 # _read_vanilla_source / _detokenize_script). Passing already-rewritten source
 # produces duplicate-function parse errors.
 
-func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_prefix: String = "_rtv_vanilla_", extends_override: String = "", strip_class_name: bool = false) -> String:
+func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_prefix: String = "_rtv_vanilla_") -> String:
 	# rename_prefix defaults to "_rtv_vanilla_" for vanilla scripts.
 	# Mod subclasses pass "_rtv_mod_" so the renamed mod body doesn't shadow
 	# vanilla's renamed body via virtual dispatch. Without this: mod's body
 	# is _rtv_vanilla_<name>, vanilla's body is ALSO _rtv_vanilla_<name>, and
 	# vanilla's wrapper calls _rtv_vanilla_<name>() on self -- which is a mod
 	# instance -- which dispatches to mod's body again. Infinite loop.
-	#
-	# extends_override: when non-empty, rewrite the top-level
-	# `extends "res://Scripts/<X>.gd"` line to `extends "<override>"`.
-	# Used for chain-via-extends: when N mods all override the same vanilla,
-	# we chain them so every mod's body runs via Godot virtual dispatch.
-	# Chain-bottom mod's override resolves to a pristine vanilla copy
-	# (at res://_rtv_pristine_/...) that isn't touched by take_over_path,
-	# breaking the vanilla_path self-reference cycle take_over_path would
-	# otherwise create.
-	#
-	# strip_class_name: drop `class_name <Ident>` declarations. Only true
-	# for the pristine vanilla copies -- they live at a non-registered path
-	# so their class_name would conflict with the primary vanilla's
-	# class_name registration in global_script_class_cache.cfg.
 	var hookable: Array = []
 	for fe in parsed["functions"]:
 		if fe["is_static"]:
@@ -381,36 +367,6 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 	# scene returned for any vanilla name.
 	if rename_prefix == "_rtv_vanilla_" and parsed.get("filename", "") == "Database.gd":
 		src = _rtv_rewrite_database_constants(src)
-
-	# Chain-via-extends substitution. For a chained mod, redirect the
-	# top-level `extends "res://Scripts/<X>.gd"` (or `extends "res://<predecessor>/..."`)
-	# to whatever its chain predecessor lives at. Only the first matching
-	# extends line is rewritten -- GDScript only allows one extends per script.
-	if not extends_override.is_empty():
-		var new_lines: PackedStringArray = []
-		var replaced := false
-		for ln: String in src.split("\n"):
-			if not replaced:
-				var stripped := ln.strip_edges()
-				if stripped.begins_with("extends \"res://") or stripped.begins_with("extends\"res://"):
-					new_lines.append('extends "%s"' % extends_override)
-					replaced = true
-					continue
-			new_lines.append(ln)
-		src = "\n".join(new_lines)
-
-	# Strip class_name declarations. Pristine vanilla copies live at a
-	# non-registered path so their class_name would conflict with the
-	# primary vanilla's class_name registration. Chain-bottom mods extend
-	# the pristine copy, which has no class_name to conflict with.
-	if strip_class_name:
-		var cn_lines: PackedStringArray = []
-		for ln: String in src.split("\n"):
-			var stripped := ln.strip_edges()
-			if stripped.begins_with("class_name "):
-				continue
-			cn_lines.append(ln)
-		src = "\n".join(cn_lines)
 
 	# Pass 1: rename top-level "func <name>(" to "func _rtv_vanilla_<name>("
 	# AND rewrite bare super() calls inside that body to super.<name>().

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -812,6 +812,15 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		# ~10 dict ops + meta/prop/fn calls. Matches godot-mod-loader.
 		out += "%sif not _lib._any_mod_hooked:\n" % I1
 		out += "%sreturn %s%s\n" % [I2, aw, vanilla_call]
+		# Dev-mode-only per-method dispatch counter. Gated by a property
+		# read so non-dev users pay ~1 branch per call; dev users see a
+		# top-15 summary at 30s that pinpoints runaway method calls (e.g.
+		# a mod's _ready firing 3000x -- typical cause of connect-already-
+		# connected error spam). Counts only hook dispatches (after the
+		# _any_mod_hooked short-circuit), not every wrapped call, so the
+		# total stays meaningful even with hundreds of wrapped methods.
+		out += "%sif _lib._developer_mode:\n" % I1
+		out += "%s_lib._dispatch_counts[\"%s\"] = int(_lib._dispatch_counts.get(\"%s\", 0)) + 1\n" % [I2, hook_base, hook_base]
 		out += "%sif _lib._wrapper_active.has(\"%s\"):\n" % [I1, hook_base]
 		out += "%sreturn %s%s\n" % [I2, aw, vanilla_call]
 		out += "%s_lib._wrapper_active[\"%s\"] = true\n" % [I1, hook_base]
@@ -854,6 +863,9 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%sif not _lib._any_mod_hooked:\n" % I1
 		out += "%s%s%s\n" % [I2, aw, vanilla_call]
 		out += "%sreturn\n" % I2
+		# Dev-mode-only per-method dispatch counter (see non-void branch).
+		out += "%sif _lib._developer_mode:\n" % I1
+		out += "%s_lib._dispatch_counts[\"%s\"] = int(_lib._dispatch_counts.get(\"%s\", 0)) + 1\n" % [I2, hook_base, hook_base]
 		out += "%sif _lib._wrapper_active.has(\"%s\"):\n" % [I1, hook_base]
 		out += "%s%s%s\n" % [I2, aw, vanilla_call]
 		out += "%sreturn\n" % I2

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -322,13 +322,27 @@ func _rtv_generate_override(script: Dictionary) -> String:
 # _read_vanilla_source / _detokenize_script). Passing already-rewritten source
 # produces duplicate-function parse errors.
 
-func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_prefix: String = "_rtv_vanilla_") -> String:
+func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_prefix: String = "_rtv_vanilla_", extends_override: String = "", strip_class_name: bool = false) -> String:
 	# rename_prefix defaults to "_rtv_vanilla_" for vanilla scripts.
 	# Mod subclasses pass "_rtv_mod_" so the renamed mod body doesn't shadow
 	# vanilla's renamed body via virtual dispatch. Without this: mod's body
 	# is _rtv_vanilla_<name>, vanilla's body is ALSO _rtv_vanilla_<name>, and
 	# vanilla's wrapper calls _rtv_vanilla_<name>() on self -- which is a mod
 	# instance -- which dispatches to mod's body again. Infinite loop.
+	#
+	# extends_override: when non-empty, rewrite the top-level
+	# `extends "res://Scripts/<X>.gd"` line to `extends "<override>"`.
+	# Used for chain-via-extends: when N mods all override the same vanilla,
+	# we chain them so every mod's body runs via Godot virtual dispatch.
+	# Chain-bottom mod's override resolves to a pristine vanilla copy
+	# (at res://_rtv_pristine_/...) that isn't touched by take_over_path,
+	# breaking the vanilla_path self-reference cycle take_over_path would
+	# otherwise create.
+	#
+	# strip_class_name: drop `class_name <Ident>` declarations. Only true
+	# for the pristine vanilla copies -- they live at a non-registered path
+	# so their class_name would conflict with the primary vanilla's
+	# class_name registration in global_script_class_cache.cfg.
 	var hookable: Array = []
 	for fe in parsed["functions"]:
 		if fe["is_static"]:
@@ -367,6 +381,36 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 	# scene returned for any vanilla name.
 	if rename_prefix == "_rtv_vanilla_" and parsed.get("filename", "") == "Database.gd":
 		src = _rtv_rewrite_database_constants(src)
+
+	# Chain-via-extends substitution. For a chained mod, redirect the
+	# top-level `extends "res://Scripts/<X>.gd"` (or `extends "res://<predecessor>/..."`)
+	# to whatever its chain predecessor lives at. Only the first matching
+	# extends line is rewritten -- GDScript only allows one extends per script.
+	if not extends_override.is_empty():
+		var new_lines: PackedStringArray = []
+		var replaced := false
+		for ln: String in src.split("\n"):
+			if not replaced:
+				var stripped := ln.strip_edges()
+				if stripped.begins_with("extends \"res://") or stripped.begins_with("extends\"res://"):
+					new_lines.append('extends "%s"' % extends_override)
+					replaced = true
+					continue
+			new_lines.append(ln)
+		src = "\n".join(new_lines)
+
+	# Strip class_name declarations. Pristine vanilla copies live at a
+	# non-registered path so their class_name would conflict with the
+	# primary vanilla's class_name registration. Chain-bottom mods extend
+	# the pristine copy, which has no class_name to conflict with.
+	if strip_class_name:
+		var cn_lines: PackedStringArray = []
+		for ln: String in src.split("\n"):
+			var stripped := ln.strip_edges()
+			if stripped.begins_with("class_name "):
+				continue
+			cn_lines.append(ln)
+		src = "\n".join(cn_lines)
 
 	# Pass 1: rename top-level "func <name>(" to "func _rtv_vanilla_<name>("
 	# AND rewrite bare super() calls inside that body to super.<name>().

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -1,17 +1,17 @@
 ## ----- rewriter.gd -----
 ## Source-rewrite codegen. Given detokenized vanilla source + a parse
-## structure, produces a rewritten script where each non-static method is
-## renamed to _rtv_vanilla_<name> and dispatch wrappers are appended at the
-## original names. The wrappers fire pre/replace/post/callback hooks and
-## call the renamed body. Also rewrites mod subclass scripts (Step C) with
-## _rtv_mod_ prefix so hooks fire even when mods bypass super().
+## structure + an optional per-method mask, produces a rewritten script
+## where each non-static method in the mask (or every non-static method,
+## when the mask is empty) is renamed to _rtv_vanilla_<name> and a
+## dispatch wrapper is appended at the original name. The wrappers fire
+## pre/replace/post/callback hooks and call the renamed body.
+##
+## v2.4.0: mod-subclass rewrite removed (was the old Step C). Mods that
+## extend wrapped vanilla now compose via Godot's native extends
+## resolution -- no _rtv_mod_ prefix, no rewrite of mod source.
 ##
 ## Also owns: regex compilation, parse-script, autofix legacy syntax,
-## indent detection, bare-super rewriting, mod-subclass scanning.
-##
-## Note: the legacy _rtv_generate_override function emits Framework<Name>.gd
-## subclass wrappers for the extends-wrapper fallback path. The main rewriter
-## emits inline dispatch wrappers instead.
+## indent detection, bare-super rewriting.
 
 func _compile_regex() -> void:
 	_re_take_over = RegEx.new()
@@ -29,13 +29,16 @@ func _compile_regex() -> void:
 	# VostokMods compat: "100-ModName.vmz" encodes priority in the filename.
 	_re_filename_priority = RegEx.new()
 	_re_filename_priority.compile('^(-?\\d+)-(.*)')
-	# .hook("<prefix>-<method>[-pre|-post|-callback]") -- matches any
-	# `.hook("ident-` string literal. Used by scan pass to figure out which
-	# vanilla scripts a mod will dispatch through at runtime even when it
-	# doesn't extend them. The prefix captured here is the lowercase script
-	# stem (e.g. "controller", "camera").
+	# .hook("<prefix>-<method>[-pre|-post|-callback]") -- the first capture
+	# is the lowercase script stem (e.g. "controller"), the second is the
+	# declared method name. _generate_hook_pack uses the (prefix, method)
+	# pair to build a per-path, per-method wrap mask so only the methods a
+	# mod actually hooks get dispatch wrappers (matches godot-mod-loader's
+	# per-path method_mask). Unknown-suffix fallbacks are treated as plain
+	# methods (the -pre/-post/-callback suffix is a hook-dispatch variant,
+	# not a method-name distinction).
 	_re_hook_call = RegEx.new()
-	_re_hook_call.compile('\\.hook\\s*\\(\\s*"([A-Za-z_][\\w]*)-')
+	_re_hook_call.compile('\\.hook\\s*\\(\\s*"([A-Za-z_][\\w]*)-([A-Za-z_][\\w]*?)(?:-(?:pre|post|callback))?"')
 
 # Mod metadata collection (no mounting)
 
@@ -322,16 +325,19 @@ func _rtv_generate_override(script: Dictionary) -> String:
 # _read_vanilla_source / _detokenize_script). Passing already-rewritten source
 # produces duplicate-function parse errors.
 
-func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_prefix: String = "_rtv_vanilla_") -> String:
-	# rename_prefix defaults to "_rtv_vanilla_" for vanilla scripts.
-	# Mod subclasses pass "_rtv_mod_" so the renamed mod body doesn't shadow
-	# vanilla's renamed body via virtual dispatch. Without this: mod's body
-	# is _rtv_vanilla_<name>, vanilla's body is ALSO _rtv_vanilla_<name>, and
-	# vanilla's wrapper calls _rtv_vanilla_<name>() on self -- which is a mod
-	# instance -- which dispatches to mod's body again. Infinite loop.
+func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask: Dictionary = {}) -> String:
+	# method_mask (v2.4.0): Dictionary[method_name, true] restricting which
+	# methods get renamed + wrapped. Empty = wrap every non-static method
+	# (used for REGISTRY_TARGETS where whole-script injection is needed).
+	# Non-empty = wrap only declared methods; matches godot-mod-loader's
+	# per-path method_mask. Other methods stay vanilla, no dispatch
+	# overhead, no rename.
+	var apply_mask: bool = not method_mask.is_empty()
 	var hookable: Array = []
 	for fe in parsed["functions"]:
 		if fe["is_static"]:
+			continue
+		if apply_mask and not method_mask.has(fe["name"]):
 			continue
 		hookable.append(fe)
 	if hookable.is_empty():
@@ -365,7 +371,7 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 	# go through _get() (which checks mod overrides first) instead of
 	# resolving via direct const lookup -- mods can then override the
 	# scene returned for any vanilla name.
-	if rename_prefix == "_rtv_vanilla_" and parsed.get("filename", "") == "Database.gd":
+	if parsed.get("filename", "") == "Database.gd":
 		src = _rtv_rewrite_database_constants(src)
 
 	# Pass 1: rename top-level "func <name>(" to "func _rtv_vanilla_<name>("
@@ -399,7 +405,7 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 						name_end -= 1
 					var method_name := line.substr(5, name_end - 5)
 					if hookable_names.has(method_name):
-						lines[i] = "func " + rename_prefix + method_name + line.substr(name_end)
+						lines[i] = "func _rtv_vanilla_" + method_name + line.substr(name_end)
 						current_hooked_method = method_name
 			continue
 		# Indented line: inside some block. If inside a renamed method, rewrite
@@ -417,14 +423,12 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, rename_pref
 	var prefix := _rtv_script_hook_prefix(parsed["filename"])
 	var appended := "\n\n# --- Metro mod loader inline hook dispatch wrappers ---\n"
 	for fe in hookable:
-		appended += _rtv_dispatch_inline_src(fe, prefix, indent, rename_prefix) + "\n"
+		appended += _rtv_dispatch_inline_src(fe, prefix, indent) + "\n"
 
-	# Per-script registry injections. Only apply to vanilla rewrites (not mod
-	# subclasses) so we don't stamp the _rtv_registry_* fields onto every mod
-	# that inherits from a registry-bearing class. Registry handler on the
-	# loader writes into these injected fields at runtime.
-	if rename_prefix == "_rtv_vanilla_":
-		appended += _rtv_registry_injection(parsed["filename"], indent)
+	# Per-script registry injections. The REGISTRY_TARGETS gate in
+	# _generate_hook_pack already ensures these only fire for declared
+	# registry-opt-in paths.
+	appended += _rtv_registry_injection(parsed["filename"], indent)
 
 	return "\n".join(lines) + appended
 
@@ -845,12 +849,12 @@ func _rtv_strip_helper_reload(source: String) -> Dictionary:
 #  - no _rtv_ready_done flag (same class, no inheritance-chain double-fire)
 #  - prepends `await` when the vanilla method is a coroutine
 
-func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "\t", rename_prefix: String = "_rtv_vanilla_") -> String:
+func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "\t") -> String:
 	var method_name: String = fe["name"]
 	var params: String = fe["params"]
 	var param_names_str: String = ", ".join(fe["param_names"])
 	var hook_base: String = "%s-%s" % [prefix, method_name.to_lower()]
-	var vanilla_call: String = "%s%s(%s)" % [rename_prefix, method_name, param_names_str]
+	var vanilla_call: String = "_rtv_vanilla_%s(%s)" % [method_name, param_names_str]
 	var args_array: String = "[]" if param_names_str.is_empty() else "[%s]" % param_names_str
 	var is_coro: bool = bool(fe["is_coroutine"])
 	var is_engine_void: bool = method_name in RTV_ENGINE_VOID_METHODS
@@ -976,100 +980,6 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%s_lib._wrapper_active.erase(\"%s\")\n" % [I1, hook_base]
 		out += "%s_lib._caller = _rtv_prev_caller\n" % I1
 	return out
-
-# Step C: mod-script extends scanner. For each enabled mod, walk the archive
-# looking for .gd files whose first non-trivial line is extends-by-literal
-# "res://Scripts/<X>.gd" where <X> is a vanilla script we already rewrite.
-# Those mod scripts get the same rename+dispatch-wrapper treatment, shipped
-# at their own res:// path, so hooks fire even when the mod replaces a
-# method without calling super().
-#
-# Returns Array of Dictionary: { mod_name, res_path, vanilla_filename,
-# source, load_index }. res_path is the mod's path (res://ModDir/X.gd),
-# vanilla_filename keys hook dispatch prefix ("Controller.gd" -> "controller").
-func _scan_mod_extends_targets(vanilla_filenames: Dictionary) -> Array:
-	var candidates: Array = []
-	var entries := _ui_mod_entries.duplicate()
-	entries.sort_custom(_compare_load_order)
-	var load_index := 0
-	for entry: Dictionary in entries:
-		if not entry["enabled"]:
-			continue
-		var mod_name: String = entry["mod_name"]
-		var archive_path: String = entry["full_path"]
-		var ext: String = entry["ext"]
-		# Resolve to zip path for ZIPReader access.
-		var abs_archive: String = archive_path
-		if ext == "vmz":
-			var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
-			var cached := cache_dir.path_join(archive_path.get_file().get_basename() + ".zip")
-			if not FileAccess.file_exists(cached):
-				load_index += 1
-				continue
-			abs_archive = cached
-		elif ext == "folder":
-			# Folder mods materialize to a tmp zip during load_all_mods. Skip
-			# if that hasn't happened yet this session (rare path).
-			var folder_zip := ProjectSettings.globalize_path(TMP_DIR).path_join(
-					archive_path.get_file() + "_dev.zip")
-			if not FileAccess.file_exists(folder_zip):
-				load_index += 1
-				continue
-			abs_archive = folder_zip
-		elif ext != "zip" and ext != "pck":
-			load_index += 1
-			continue
-		var zr := ZIPReader.new()
-		if zr.open(abs_archive) != OK:
-			load_index += 1
-			continue
-		for f: String in zr.get_files():
-			var normalized := f.replace("\\", "/")
-			if normalized.get_extension().to_lower() != "gd":
-				continue
-			var bytes := zr.read_file(f)
-			if bytes.is_empty():
-				continue
-			var text := bytes.get_string_from_utf8()
-			var ext_target := _parse_extends_literal(text)
-			if ext_target.is_empty() or not ext_target.begins_with("res://Scripts/"):
-				continue
-			var vfn := ext_target.get_file()
-			if not vanilla_filenames.has(vfn):
-				continue
-			candidates.append({
-				"mod_name": mod_name,
-				"res_path": "res://" + normalized,
-				"vanilla_filename": vfn,
-				"source": text,
-				"load_index": load_index,
-			})
-		zr.close()
-		load_index += 1
-	return candidates
-
-# Parse first non-empty non-comment line for `extends "res://..."`. Returns
-# the quoted path, or "" if the script uses class-name extends, non-literal
-# extends (preload/load/variable), or something else.
-func _parse_extends_literal(source: String) -> String:
-	for raw in source.split("\n"):
-		var s := raw.strip_edges()
-		if s.is_empty() or s.begins_with("#"):
-			continue
-		# Skip tool/icon annotations that may precede extends.
-		if s.begins_with("@"):
-			continue
-		if not s.begins_with("extends"):
-			return ""
-		# "extends <target>" -- strip keyword + whitespace.
-		var rest := s.substr(7).strip_edges()
-		if rest.begins_with("\""):
-			var close := rest.find("\"", 1)
-			if close < 0:
-				return ""
-			return rest.substr(1, close - 1)
-		return ""
-	return ""
 
 # --- Script enumeration -----------------------------------------------------
 # DirAccess.get_files_at() returns at most 1 entry on res://Scripts/ in

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -29,6 +29,13 @@ func _compile_regex() -> void:
 	# VostokMods compat: "100-ModName.vmz" encodes priority in the filename.
 	_re_filename_priority = RegEx.new()
 	_re_filename_priority.compile('^(-?\\d+)-(.*)')
+	# .hook("<prefix>-<method>[-pre|-post|-callback]") -- matches any
+	# `.hook("ident-` string literal. Used by scan pass to figure out which
+	# vanilla scripts a mod will dispatch through at runtime even when it
+	# doesn't extend them. The prefix captured here is the lowercase script
+	# stem (e.g. "controller", "camera").
+	_re_hook_call = RegEx.new()
+	_re_hook_call.compile('\\.hook\\s*\\(\\s*"([A-Za-z_][\\w]*)-')
 
 # Mod metadata collection (no mounting)
 

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -786,19 +786,6 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 	var I3: String = indent + indent + indent
 
 	var out := ""
-	# Dispatch-live probe: one counter per hook_base via Engine meta dict,
-	# plus a one-shot print the first time each wrapper fires. That
-	# gives a definitive list of every wrapper that executes at runtime
-	# AND proves the wrapper body actually runs (not just that source
-	# matches). Remove in Step E.
-	var probe: String = ""
-	probe += "%svar _rtv_bh = Engine.get_meta(\"_rtv_dispatch_by_hook\", {}) as Dictionary\n" % I1
-	probe += "%svar _rtv_prev = int(_rtv_bh.get(\"%s\", 0))\n" % [I1, hook_base]
-	probe += "%s_rtv_bh[\"%s\"] = _rtv_prev + 1\n" % [I1, hook_base]
-	probe += "%sEngine.set_meta(\"_rtv_dispatch_by_hook\", _rtv_bh)\n" % I1
-	probe += "%sEngine.set_meta(\"_rtv_dispatch_count\", int(Engine.get_meta(\"_rtv_dispatch_count\", 0)) + 1)\n" % I1
-	probe += "%sif _rtv_prev == 0:\n" % I1
-	probe += "%sprint(\"[RTV-WRAPPER-FIRST] %s\")\n" % [I2, hook_base]
 	# Step C re-entry guard: when a mod's rewritten wrapper fires and its body
 	# calls super() into vanilla's rewritten wrapper, the nested wrapper would
 	# dispatch again. Guard checks _lib._wrapper_active for this hook_base and
@@ -806,11 +793,13 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 	# vanilla body. One dispatch per logical call regardless of chain depth.
 	if not is_void:
 		out += "%s\n" % sig
-		out += probe
-		out += "%svar _lib = Engine.get_meta(\"RTVModLib\") if Engine.has_meta(\"RTVModLib\") else null\n" % I1
-		out += "%sif !_lib:\n" % I1
-		out += "%sEngine.set_meta(\"_rtv_dispatch_no_lib\", int(Engine.get_meta(\"_rtv_dispatch_no_lib\", 0)) + 1)\n" % I2
+		# Engine.get_meta with a Nil default still prints an error when the key
+		# is absent (Godot 4.6 Object::get_meta at object.cpp:1155). Guard with
+		# has_meta so early-boot wrappers that fire before _register_rtv_modlib_meta
+		# (e.g. the 16 preempted class_name scripts) don't flood the log.
+		out += "%sif not Engine.has_meta(\"RTVModLib\"):\n" % I1
 		out += "%sreturn %s%s\n" % [I2, aw, vanilla_call]
+		out += "%svar _lib = Engine.get_meta(\"RTVModLib\")\n" % I1
 		# Global short-circuit: if no mod has called hook() this session, the
 		# whole dispatch pipeline is dead weight. Single bool check skips
 		# ~10 dict ops + meta/prop/fn calls. Matches godot-mod-loader.
@@ -849,12 +838,11 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%sreturn _result\n" % I1
 	else:
 		out += "%s\n" % sig
-		out += probe
-		out += "%svar _lib = Engine.get_meta(\"RTVModLib\") if Engine.has_meta(\"RTVModLib\") else null\n" % I1
-		out += "%sif !_lib:\n" % I1
-		out += "%sEngine.set_meta(\"_rtv_dispatch_no_lib\", int(Engine.get_meta(\"_rtv_dispatch_no_lib\", 0)) + 1)\n" % I2
+		# Same has_meta guard as non-void branch above.
+		out += "%sif not Engine.has_meta(\"RTVModLib\"):\n" % I1
 		out += "%s%s%s\n" % [I2, aw, vanilla_call]
 		out += "%sreturn\n" % I2
+		out += "%svar _lib = Engine.get_meta(\"RTVModLib\")\n" % I1
 		# Global short-circuit: see non-void branch above.
 		out += "%sif not _lib._any_mod_hooked:\n" % I1
 		out += "%s%s%s\n" % [I2, aw, vanilla_call]


### PR DESCRIPTION
## Summary

Hard cutover from the v3.0.0 inference-based wrap system to an opt-in declaration model. A modlist that declares nothing loads byte-identical to v2.1.0: no hook pack written, no vanilla rewrite, no mod-source rewrite, no static-init preemption. The system kicks in only when a mod explicitly signals intent via \`[hooks]\`, \`.hook()\`, or \`[registry]\`.

v3.0.0 broke legacy modlists because four inference triggers (\`extends_paths\`, \`take_over_literal_paths\`, a hardcoded pinned list, and unconditional \`REGISTRY_TARGETS\`) swept any mod extending vanilla into the wrap surface, then rewrote that mod's source (old Step C) for hook dispatch. The strict-parse path rejected real-world mod GDScript in five documented ways, and users had to downgrade to v2.1.0 to get working setups.

### Changes
- **Single gate** at \`_generate_hook_pack\` entry: if \`_hooked_methods\` is empty and no mod declared \`[registry]\`, early-return. All four inference triggers deleted.
- **Delete Step C** (mod subclass rewrite with \`_rtv_mod_\` prefix). Mods composing with wrapped vanilla rely on Godot's native \`extends\` resolution; call \`super.method()\` to chain into hook dispatch.
- **Per-method wrap mask**: only methods declared via \`[hooks]\` or scanned \`.hook(\"stem-method\", ...)\` calls get renamed to \`_rtv_vanilla_<name>\` + dispatch wrapper. Other methods stay vanilla.
- **\`[registry]\` opt-in** gates the Database.gd const-to-dict transform + \`_get()\` injection.
- **\`[script_extend]\`** as canonical name for chain-composition overrides (\`[script_overrides]\` kept as alias). Legacy-syntax autofix runs before \`reload()\` so Godot-3-era syntax parses.
- **Narrow static-init preempt** in \`src/boot.gd\`: \`wrapped_paths\` persisted to pass_state, read on next session instead of a hardcoded 16-script pinned list. Zero-declaration modlists trigger zero preempt.
- Bump \`MODLOADER_VERSION\` to 2.4.0 so stale pass_state wipes on first upgrade boot.

Net diff: 7 files, +398 / -831.

### Breaking change
Mods that relied on v3.0.0's auto-wrap + Step C to have hooks fire without calling \`super()\` no longer compose. Migration path in README:
- Call \`super.method()\` in overrides, OR
- Add \`[hooks]\` declarations to \`mod.txt\`

## Test plan

Verified with a 38-mod loadout (no declarations anywhere):

- [x] Gate fires on both Pass 1 and Pass 2: \`[RTVCodegen] No opt-in declarations ([hooks] / .hook() / [registry]) -- hook pack generation skipped. Legacy mode: vanilla scripts run unmodified (v2.1.0-equivalent).\`
- [x] No \`[RTVCodegen] Wrap surface\` / \`Generated N rewritten\` lines
- [x] No hook pack written to \`user://modloader_hooks/\`
- [x] No \`[FileScope] HOOK PACK preempted N\` static-init preempt lines
- [x] Version mismatch wipes stale pass_state on first boot: \`[FileScope] Version mismatch: saved=2.3.1 current=2.4.0 -- wiping\`
- [x] 36/38 mods register + instantiate successfully (MCM, ImmersiveAmmoCheck dynamic overrides, SecureContainer scene injection, Faction Warfare AI spawning, etc.)
- [x] Game boots to Cabin, transitions to Village, AI alive
- [x] Two mods show parse errors not caused by the cutover:
  - AlternativeMagCheck: depends on \`WeaponRigAPI\` mod that isn't enabled (pre-existing missing-dep)
  - CatHungerSlow: ships Godot-3 \`base().Cat(delta)\` syntax (also broken on v2.1.0)

Manual tests still TODO (need mod authors or hand-written test mods):
- [ ] Single mod with \`[hooks]\` declaration: verify only declared methods get dispatch wrappers
- [ ] Two mods with \`[script_extend]\` on the same vanilla: verify chain composition and legacy autofix
- [ ] \`[registry]\` opt-in: verify Database.gd is wrapped with declaration, unwrapped without