### PR TITLE
feat: Further registry work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,23 @@ FILES=(
     "$SRC/ui.gd"
     # Public API (hooks + registry)
     "$SRC/hooks_api.gd"
+    # Registry dispatcher + per-section handlers. shared.gd holds helpers
+    # used by more than one section; each section file owns its own verb
+    # implementations. New sections: add a file here + match arm in registry.gd.
     "$SRC/registry.gd"
+    "$SRC/registry/shared.gd"
+    "$SRC/registry/scenes.gd"
+    "$SRC/registry/items.gd"
+    "$SRC/registry/loot.gd"
+    "$SRC/registry/sounds.gd"
+    "$SRC/registry/recipes.gd"
+    "$SRC/registry/events.gd"
+    "$SRC/registry/traders.gd"
+    "$SRC/registry/inputs.gd"
+    "$SRC/registry/loader.gd"
+    "$SRC/registry/ai.gd"
+    "$SRC/registry/fish.gd"
+    "$SRC/registry/resources.gd"
     "$SRC/framework_wrappers.gd"
     # Codegen pipeline
     "$SRC/gdsc_detokenizer.gd"

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -1,0 +1,618 @@
+# Registry
+
+The registry system lets mods add, replace, patch, and remove content on the vanilla game data stores, items, scenes, loot tables, sounds, recipes, events, trader pools, inputs, shelters, AI types, fish species, and arbitrary `.tres` resources, without shipping a full `Database.gd` override or source-rewriting vanilla scripts.
+
+Registry mutations survive across scene loads (state lives on autoloads and preloaded resources) and unwind cleanly: every `register`/`override`/`patch` is reversible via `remove`/`revert`.
+
+## Opting in
+
+The registry is gated behind an opt-in declaration in `mod.txt`. Without it, the loader skips all registry-related rewriting and your `lib.register(...)` calls will fail silently.
+
+```ini
+[registry]
+```
+
+An empty `[registry]` section is enough, the loader only checks for its presence. Adding the section forces the rewriter to wrap `Database.gd`, `Loader.gd`, `AISpawner.gd`, and `FishPool.gd` with the injected fields the registry API needs. See [hook_pack.gd:20 `REGISTRY_TARGETS`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hook_pack.gd#L20).
+
+## Public API
+
+Mods reach the loader the same way as the hook system: `Engine.get_meta("RTVModLib")`. Source: [src/registry.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry.gd).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+await lib.frameworks_ready
+
+lib.register(lib.Registry.ITEMS, "my_mod_potion", my_potion_resource)
+lib.override(lib.Registry.SCENES, "Potato", preload("res://mymod/better_potato.tscn"))
+lib.patch(lib.Registry.ITEMS, "Potato", {"weight": 0.1, "value": 500})
+lib.remove(lib.Registry.ITEMS, "my_mod_potion")
+lib.revert(lib.Registry.SCENES, "Potato")
+```
+
+### Methods
+
+| Method | Purpose |
+|---|---|
+| `register(registry, id, data) -> bool` | Add a new entry. Fails on id collision with vanilla or prior mod registrations |
+| `override(registry, id, data) -> bool` | Replace an existing entry wholesale. Fails if the id doesn't resolve |
+| `patch(registry, id, fields) -> bool` | Mutate individual fields on an entry. Original values are stashed for revert |
+| `remove(registry, id) -> bool` | Undo a `register`. Fails on override-backed ids (use `revert`) |
+| `revert(registry, id, fields=[]) -> bool` | Undo an `override` or `patch`. Per-field revert when `fields` is non-empty |
+| `get_entry(registry, id) -> Variant` | Read the current entry (after any registry mutations). Returns `null` if missing |
+
+Every verb returns a bool indicating success; failures log a `push_warning` with the reason.
+
+### Registry constants
+
+Use `lib.Registry.<NAME>` rather than raw strings so typos surface at parse time:
+
+| Constant | String | Underlying store | Verbs supported |
+|---|---|---|---|
+| `SCENES` | `"scenes"` | `Database.gd` scene consts | register, override, remove, revert |
+| `ITEMS` | `"items"` | `ItemData` `.tres` keyed by `file` | register, override, patch, remove, revert |
+| `LOOT` | `"loot"` | `LootTable.items` arrays | register, override, remove, revert |
+| `SOUNDS` | `"sounds"` | `AudioLibrary.tres` `@export` fields | register, override, patch, remove, revert |
+| `RECIPES` | `"recipes"` | `Recipes.tres` category arrays | register, override, patch, remove, revert |
+| `EVENTS` | `"events"` | `Events.tres` events array | register, override, patch, remove, revert |
+| `TRADER_POOLS` | `"trader_pools"` | Per-item trader boolean flags | register, remove, revert |
+| `TRADER_TASKS` | `"trader_tasks"` | `TraderData.tasks` arrays | register, override, patch, remove, revert |
+| `INPUTS` | `"inputs"` | `InputMap` actions | register, override, patch, remove, revert |
+| `SCENE_PATHS` | `"scene_paths"` | Named scene lookup on `Loader.gd` | register, override, patch, remove, revert |
+| `SHELTERS` | `"shelters"` | `Loader.shelters` append-only list | register, remove |
+| `RANDOM_SCENES` | `"random_scenes"` | `Loader.randomScenes` append-only list | register, remove |
+| `AI_TYPES` | `"ai_types"` | Zone → agent scene overrides on `AISpawner` | register, override, remove, revert |
+| `FISH_SPECIES` | `"fish_species"` | `FishPool` extra species | register, remove |
+| `RESOURCES` | `"resources"` | Arbitrary `.tres` by absolute path | patch, revert |
+
+Unsupported verbs return `false` with a guidance warning (e.g. "patch on loot rejected, use override for content swaps").
+
+## Timing
+
+**Register during mod `_ready()`**, before vanilla game systems finish initializing. Several consumers populate local caches once and never re-read:
+
+- Trader stock, `LootContainer`, and `LootSimulation` copy from `LootTable` in their own `_ready()`.
+- `AudioLibrary` fields are read by `@export` binding at autoload time.
+- `InputMap` actions registered after gameplay starts work but don't appear in the remapping UI until a scene reload.
+
+Mod autoloads load **after** vanilla autoloads and **before** the first scene. Registering inside your mod's `_ready()` is almost always early enough. If you need hooks to finish first, `await lib.frameworks_ready` before any `register` call.
+
+Runtime re-registration after scene load is invisible to systems that already cached, the registry updates the underlying store, but the cache holds the old snapshot. Covered in the source-level note at [src/registry.gd:22-26](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry.gd#L22).
+
+## Verb semantics
+
+### register
+
+Adds a genuinely new entry. Fails if:
+- The id matches a vanilla const/field name on the underlying store (use `override` instead)
+- The id was already registered by a prior mod registration (or prior `register` call this session)
+- The payload fails the registry's shape check (wrong type, missing keys)
+
+### override
+
+Replaces an existing entry wholesale. The new payload takes the slot; the original is stashed for revert.
+
+```gdscript
+lib.override(lib.Registry.ITEMS, "Potato", my_replacement_item)
+var current = lib.get_entry(lib.Registry.ITEMS, "Potato")  # returns my_replacement_item
+lib.revert(lib.Registry.ITEMS, "Potato")                    # back to vanilla
+```
+
+Overrides on mod registrations are allowed, use this to resolve same-id conflicts between mods without touching the loser's code.
+
+### patch
+
+Mutates specific fields on the current entry (vanilla, override, or prior `register`). Stash-and-restore semantics: the first patch to a field saves its pre-patch value; subsequent patches to the same field don't re-stash, so a full `revert` returns to the true original.
+
+```gdscript
+lib.patch(lib.Registry.ITEMS, "Potato", {"weight": 0.1, "value": 500})
+lib.revert(lib.Registry.ITEMS, "Potato", ["weight"])  # restore just weight
+lib.revert(lib.Registry.ITEMS, "Potato")              # restore everything else
+```
+
+Registries that don't support patch (loot, scenes, trader_pools, fish_species) return `false` with guidance.
+
+### remove
+
+Reverses a prior `register`. Fails on override-backed or vanilla ids, those need `revert`.
+
+### revert
+
+Reverses an `override` or `patch`. Fails if there's nothing to undo (nothing overridden and no field stashes).
+
+- Bare `revert(registry, id)` with no `fields` argument unwinds everything for that id (patches first, then the override).
+- `revert(registry, id, ["field1", "field2"])` unwinds only those specific patched fields; other patches and the override stay.
+
+### get_entry
+
+Reads the current state without mutating. Useful for assertions and to chain reads after an override, the returned Variant is whatever the registry's logical "current entry" is.
+
+## Conflict-handling fundamentals
+
+Before the per-registry examples, the rules that apply across every registry:
+
+- **`register` on a colliding id fails.** Whether the collision is with vanilla or with an earlier mod's registration, the second caller's `register` returns `false` with a `push_warning`. No silent overwrite.
+- **`override` on an already-overridden id fails.** The second caller must `revert` first (if they want to replace the earlier mod's override) or target the override's id explicitly.
+- **`patch` on the same field stacks.** Both writes apply in call order; last writer's value is visible. The stash preserves the **true vanilla original** (the first patcher's pre-patch value), so a later `revert` returns to vanilla, not to the first patcher's value. Mod A's patch is lost on revert even if Mod A didn't call revert themselves.
+- **`patch` on different fields coexists.** Independent stash per field name; both mods' patches are respected simultaneously.
+- **Array-based registries (`loot`, `recipes`, `events`, `trader_tasks`) are additive on `register`.** Two mods registering different ids into the same array both succeed; the array just grows.
+- **Array `override` (the `replaces:` form) fails if the target is already gone.** If mod A swapped `vanillaX` for `newA`, mod B can't also swap `vanillaX`, it's no longer in the array. Mod B would have to target `newA` instead (which then silently undoes mod A's swap, avoid this).
+
+The rest of this doc walks each registry with a minimal example per verb and a note on any registry-specific conflict edge.
+
+---
+
+## SCENES
+
+Scene constants on `Database.gd` (e.g. `Potato`, `Beer`, `Cabin`). Keyed by the const name. Verbs: `register`, `override`, `remove`, `revert`.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var my_scene = preload("res://mymod/scenes/Biscuit.tscn")
+
+# register: add a new scene name
+lib.register(lib.Registry.SCENES, "mymod_biscuit", my_scene)
+
+# override: replace the scene a vanilla const resolves to
+lib.override(lib.Registry.SCENES, "Potato", preload("res://mymod/scenes/GoldenPotato.tscn"))
+
+# remove: undo a register
+lib.remove(lib.Registry.SCENES, "mymod_biscuit")
+
+# revert: undo an override
+lib.revert(lib.Registry.SCENES, "Potato")
+```
+
+**Conflicts.** Two mods overriding the same vanilla scene: second mod fails with `"already overridden (revert first to re-override)"`. First mod's scene is what players see.
+
+---
+
+## ITEMS
+
+`ItemData` Resources keyed by `file`. Verbs: all five.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var elixir = load("res://mymod/items/Elixir.tres")
+# elixir.file must equal "mymod_elixir"; register enforces this
+
+# register
+lib.register(lib.Registry.ITEMS, "mymod_elixir", elixir)
+
+# override: replace a vanilla item wholesale
+lib.override(lib.Registry.ITEMS, "Potato", load("res://mymod/items/GoldenPotato.tres"))
+
+# patch: mutate specific fields on the current entry
+lib.patch(lib.Registry.ITEMS, "Potato", {"weight": 0.1, "value": 500})
+
+# get_entry: read current state
+var current_potato = lib.get_entry(lib.Registry.ITEMS, "Potato")
+
+# revert per-field
+lib.revert(lib.Registry.ITEMS, "Potato", ["weight"])
+
+# revert everything for this id (patches + override)
+lib.revert(lib.Registry.ITEMS, "Potato")
+
+# remove: undo register
+lib.remove(lib.Registry.ITEMS, "mymod_elixir")
+```
+
+**Conflicts.**
+- Two overrides of the same item: second fails, first wins.
+- Two patches on the **same field**: both calls succeed, second value wins visually. The stash holds vanilla, so any revert on that id returns to vanilla, losing both patches.
+- Two patches on **different fields**: both coexist independently.
+
+---
+
+## LOOT
+
+Adds/swaps `ItemData` entries inside `LootTable.items`. IDs are mod-chosen handles (not tied to any in-game name). Verbs: `register`, `override`, `remove`, `revert`.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var fancy = load("res://mymod/items/FancyBandage.tres")
+
+# register: append to a loot table
+lib.register(lib.Registry.LOOT, "mymod_fancy_in_master", {
+    "item": fancy,
+    "table": "LT_Master",         # bare stem or "res://Loot/LT_Master.tres"
+})
+
+# override: swap an existing entry for a new one
+var replacement = load("res://mymod/items/ReplacementBandage.tres")
+var vanilla_bandage = load("res://Items/Medical/Bandage/Bandage.tres")
+lib.override(lib.Registry.LOOT, "mymod_swap_bandage", {
+    "item": replacement,
+    "table": "LT_Master",
+    "replaces": vanilla_bandage,  # must be an ItemData already in the table
+})
+
+# remove: pull the registered item out of the table
+lib.remove(lib.Registry.LOOT, "mymod_fancy_in_master")
+
+# revert: reinstate the `replaces` item, drop the override
+lib.revert(lib.Registry.LOOT, "mymod_swap_bandage")
+```
+
+**Patch is not supported** on loot; loot entries are whole `ItemData` references, not dicts of fields. Patch returns `false` with guidance ("use override for content swaps").
+
+**Conflicts.**
+- Two `register` calls adding the same item to the same table: rejected as a duplicate (the table would contain the same `ItemData` twice).
+- Two `override` calls with the same `replaces:` target: second fails because the first removed `replaces` from the table. Mod B would need to target mod A's new item; avoid this, it silently undoes mod A.
+
+---
+
+## SOUNDS
+
+`AudioEvent` fields on `AudioLibrary.tres`, plus mod-registered lookup entries. Verbs: all five.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var custom_event = preload("res://mymod/audio/Footstep.tres")  # AudioEvent
+
+# register: add a new sound id (lookup via get_entry only; vanilla code
+# can't reach these ids directly since it hardcodes property names)
+lib.register(lib.Registry.SOUNDS, "mymod_custom_footstep", custom_event)
+
+# register via Dictionary shorthand (builds an AudioEvent internally)
+lib.register(lib.Registry.SOUNDS, "mymod_dict_sound", {
+    "audioClips": [],
+    "volume": -3.0,
+    "randomPitch": true,
+})
+
+# override: replace a vanilla AudioLibrary @export field.
+# `id` must match a real @export field name on AudioLibrary.tres;
+# override rejects mod-registered ids (revert first to re-register).
+lib.override(lib.Registry.SOUNDS, "knifeSlash", custom_event)
+
+# patch: mutate AudioEvent fields (audioClips, volume, randomPitch)
+lib.patch(lib.Registry.SOUNDS, "knifeSlash", {"volume": -10.0, "randomPitch": true})
+
+# revert per-field / full / remove
+lib.revert(lib.Registry.SOUNDS, "knifeSlash", ["randomPitch"])
+lib.revert(lib.Registry.SOUNDS, "knifeSlash")
+lib.remove(lib.Registry.SOUNDS, "mymod_custom_footstep")
+```
+
+**Conflicts.** Same rules as items. `register` collisions with vanilla `@export` field names are rejected (use `override`). Override only works on vanilla fields, not mod-registered ids.
+
+---
+
+## RECIPES
+
+`RecipeData` Resources in per-category arrays on `Recipes.tres`. Verbs: all five. Patch accepts either a String handle OR a direct `RecipeData` ref.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var my_recipe = load("res://mymod/recipes/CraftElixir.tres")
+
+# register
+lib.register(lib.Registry.RECIPES, "mymod_craft_elixir", {
+    "recipe": my_recipe,
+    "category": "consumables",  # consumables, medical, equipment, weapons, electronics, misc, furniture
+})
+
+# override: swap one recipe for another in the same category
+var replacement = load("res://mymod/recipes/BetterElixir.tres")
+lib.override(lib.Registry.RECIPES, "mymod_swap_elixir", {
+    "recipe": replacement,
+    "category": "consumables",
+    "replaces": my_recipe,
+})
+
+# patch by handle
+lib.patch(lib.Registry.RECIPES, "mymod_craft_elixir", {"time": 30.0, "shelter": true})
+
+# patch by direct ref (no prior register needed; works on vanilla recipes too)
+var vanilla_recipe = some_recipes_category_array[0]
+lib.patch(lib.Registry.RECIPES, vanilla_recipe, {"time": 60.0})
+
+# revert by handle or by ref
+lib.revert(lib.Registry.RECIPES, "mymod_craft_elixir")
+lib.revert(lib.Registry.RECIPES, vanilla_recipe)
+
+# remove
+lib.remove(lib.Registry.RECIPES, "mymod_craft_elixir")
+```
+
+**Conflicts.** Same as loot for `register`/`override`. Patches stack per field.
+
+---
+
+## EVENTS
+
+`EventData` entries in `Events.tres`. Mirrors recipes exactly: `register`, `override`, `patch`, `remove`, `revert`. Patch accepts String handle or direct `EventData` ref.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var my_event = load("res://mymod/events/MeteorShower.tres")
+
+lib.register(lib.Registry.EVENTS, "mymod_meteor", {"event": my_event})
+
+lib.patch(lib.Registry.EVENTS, "mymod_meteor", {"possibility": 75, "day": 5})
+
+# override with 'replaces:' required
+var replacement = load("res://mymod/events/SolarFlare.tres")
+lib.override(lib.Registry.EVENTS, "mymod_swap_event", {
+    "event": replacement,
+    "replaces": my_event,
+})
+
+lib.revert(lib.Registry.EVENTS, "mymod_meteor")
+lib.remove(lib.Registry.EVENTS, "mymod_meteor")
+```
+
+---
+
+## TRADER_POOLS
+
+Flips a trader's boolean flag on an `ItemData` (e.g. `item.doctor = true` puts the item in the Doctor's pool). Verbs: `register`, `remove`, `revert` (revert is a straight alias for remove).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var potato = load("res://Items/Consumables/Potato/Potato.tres")
+
+# register: enable item for the Doctor trader
+lib.register(lib.Registry.TRADER_POOLS, "mymod_potato_doctor", {
+    "item": potato,
+    "trader": "Doctor",  # "Generalist", "Doctor", "Gunsmith"; case-insensitive
+})
+
+# remove / revert: restore the original flag value
+lib.remove(lib.Registry.TRADER_POOLS, "mymod_potato_doctor")
+# or equivalently:
+lib.revert(lib.Registry.TRADER_POOLS, "mymod_potato_doctor")
+```
+
+**No `override` or `patch`**. Pool membership is binary and ungated. Trader pool entries keyed by the mod handle, not the item; two mods can independently enable the same item for the same trader (both `register` calls succeed, flag stays `true` until both remove).
+
+**Conflicts.** Mostly harmless. The underlying flag is idempotent (`true` OR `true` = `true`). The only surprise: on `remove`, the flag restores to the stashed "original", whatever the flag was when that specific `register` call fired. If mod A registered first (stash=false), mod B registered second (stash=true, because mod A already flipped it), and mod A removes first, the flag goes back to `false` despite mod B still "owning" a registration. This is a known quirk; avoid double-registering the same item/trader pair across mods.
+
+---
+
+## TRADER_TASKS
+
+`TaskData` entries in per-trader `tasks` arrays. Verbs: all five. Patch accepts String handle or direct `TaskData` ref.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var my_task = load("res://mymod/tasks/DeliverPotatoes.tres")
+
+lib.register(lib.Registry.TRADER_TASKS, "mymod_potato_quest", {
+    "task": my_task,
+    "trader": "Generalist",
+})
+
+lib.patch(lib.Registry.TRADER_TASKS, "mymod_potato_quest", {"difficulty": "Hard"})
+
+# override with 'replaces:' required
+var replacement = load("res://mymod/tasks/DeliverBetterPotatoes.tres")
+lib.override(lib.Registry.TRADER_TASKS, "mymod_swap_quest", {
+    "task": replacement,
+    "trader": "Generalist",
+    "replaces": my_task,
+})
+
+lib.revert(lib.Registry.TRADER_TASKS, "mymod_potato_quest")
+lib.remove(lib.Registry.TRADER_TASKS, "mymod_potato_quest")
+```
+
+**Conflicts.** Same as loot. Two mods trying to `override` the same task: second fails when `replaces` isn't in the array anymore.
+
+---
+
+## INPUTS
+
+Declares new `InputMap` actions with a default event; lets mods rebind vanilla actions. Verbs: all five.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var key_h = InputEventKey.new()
+key_h.keycode = KEY_H
+
+# register a new action
+lib.register(lib.Registry.INPUTS, "mymod_quick_heal", {
+    "display_label": "Quick Heal",
+    "default_event": key_h,
+    "deadzone": 0.5,  # optional
+})
+
+# override an existing action's default event (vanilla or mod-registered)
+var key_f = InputEventKey.new()
+key_f.keycode = KEY_F
+lib.override(lib.Registry.INPUTS, "forward", {
+    "display_label": "Move Forward",
+    "default_event": key_f,
+})
+
+# patch specific fields (display_label, default_event, or deadzone)
+lib.patch(lib.Registry.INPUTS, "mymod_quick_heal", {"display_label": "Heal!"})
+
+lib.revert(lib.Registry.INPUTS, "forward")
+lib.remove(lib.Registry.INPUTS, "mymod_quick_heal")
+```
+
+**Conflicts.** Standard register/override rules. Two mods overriding the same action: second fails. InputMap rebinding is visible immediately; in-game key prompts update on next UI refresh.
+
+**UI caveat.** Vanilla's Settings → Keybinds panel reads from a hardcoded `inputs` dict inside `Inputs.gd`. Registering an action makes it functional in-game but it **won't appear in the rebind menu** without an additional hook on `Inputs-createactions-pre`. See `src/registry/inputs.gd:19-26` for details.
+
+---
+
+## SCENE_PATHS
+
+Named scene lookups on `Loader.gd` with optional `gameData` flags (`menu`, `shelter`, `permadeath`, `tutorial`). Verbs: all five. See [src/registry/loader.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry/loader.gd).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+
+# register a new scene name
+lib.register(lib.Registry.SCENE_PATHS, "mymod_bunker", {
+    "path": "res://mymod/scenes/bunker.tscn",
+    "shelter": true,
+})
+
+# override a vanilla scene const's path
+lib.override(lib.Registry.SCENE_PATHS, "Cabin", {
+    "path": "res://mymod/scenes/better_cabin.tscn",
+    "shelter": true,
+})
+
+# patch just the flags
+lib.patch(lib.Registry.SCENE_PATHS, "mymod_bunker", {"permadeath": true})
+
+lib.revert(lib.Registry.SCENE_PATHS, "Cabin")
+lib.remove(lib.Registry.SCENE_PATHS, "mymod_bunker")
+```
+
+**Conflicts.** Standard rules. Vanilla-const collisions on `register` are rejected; use `override`. Two mods overriding the same vanilla scene path: second fails.
+
+---
+
+## SHELTERS
+
+Append-only list of shelter names on `Loader.shelters`. Verbs: `register`, `remove` only.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+
+# register with path: auto-creates paired scene_paths entry with shelter=true
+lib.register(lib.Registry.SHELTERS, "mymod_bunker", {
+    "path": "res://mymod/scenes/bunker.tscn",
+})
+
+# register without path: the name must already be a scene name resolvable
+# by Loader.LoadScene, AND must NOT already be in Loader.shelters. In practice
+# you'd only do this to promote a mod-registered SCENE_PATHS entry to a shelter:
+lib.register(lib.Registry.SCENE_PATHS, "mymod_cave", {
+    "path": "res://mymod/scenes/cave.tscn",
+})
+lib.register(lib.Registry.SHELTERS, "mymod_cave", {})  # promote to shelter list
+
+# remove strips from Loader.shelters AND cleans up the auto scene_paths entry
+lib.remove(lib.Registry.SHELTERS, "mymod_bunker")
+```
+
+**No override / patch / revert**. The list is append-only. To swap a shelter's scene, `override` the corresponding `SCENE_PATHS` entry instead.
+
+**Conflicts.** Two mods registering the same shelter name: second fails. Collision with vanilla shelter list also rejected.
+
+---
+
+## RANDOM_SCENES
+
+Append-only list of `res://` paths on `Loader.randomScenes` (picked by `LoadSceneRandom()`). Verbs: `register`, `remove` only.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+
+lib.register(lib.Registry.RANDOM_SCENES, "mymod_wasteland_zone", {
+    "path": "res://mymod/scenes/wasteland.tscn",
+})
+
+lib.remove(lib.Registry.RANDOM_SCENES, "mymod_wasteland_zone")
+```
+
+**Conflicts.** Same handle or same path registered twice: second fails.
+
+---
+
+## AI_TYPES
+
+Zone → agent scene overrides on `AISpawner`. Zone is a string key (e.g. `"Area05"`). Verbs: `register`, `override`, `remove`, `revert`.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var zombie_scene = preload("res://mymod/ai/Zombie.tscn")
+
+# register: claim a zone for this agent type
+lib.register(lib.Registry.AI_TYPES, "mymod_zombie_area05", {
+    "scene": zombie_scene,
+    "zone": "Area05",
+})
+
+# override: force replace whoever currently owns that zone
+var ghoul = preload("res://mymod/ai/Ghoul.tscn")
+lib.override(lib.Registry.AI_TYPES, "mymod_ghoul_forced", {
+    "scene": ghoul,
+    "zone": "Area05",
+})
+
+# revert: restore the displaced registration's scene
+lib.revert(lib.Registry.AI_TYPES, "mymod_ghoul_forced")
+
+# remove: drop the registration (zone loses its override)
+lib.remove(lib.Registry.AI_TYPES, "mymod_zombie_area05")
+```
+
+**No patch.**
+
+**Conflicts.** Two mods registering into the same zone: second fails with `"zone 'Area05' already claimed by 'mymod_zombie_area05'"`. Use `override` to force a swap. The overridden registration is preserved internally; revert restores it.
+
+---
+
+## FISH_SPECIES
+
+Append-only list of `PackedScene` + `pool_id` entries on `FishPool`. Verbs: `register`, `remove` (revert is an alias).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var salmon = preload("res://mymod/fish/Salmon.tscn")
+
+# pool_id="all" (default): eligible in every fishing pool
+lib.register(lib.Registry.FISH_SPECIES, "mymod_salmon", {
+    "scene": salmon,
+    "pool_id": "all",
+})
+
+# pool_id="FP_2": restricted to one pool
+lib.register(lib.Registry.FISH_SPECIES, "mymod_trout_fp2", {
+    "scene": preload("res://mymod/fish/Trout.tscn"),
+    "pool_id": "FP_2",
+})
+
+lib.remove(lib.Registry.FISH_SPECIES, "mymod_salmon")
+# revert is equivalent:
+lib.revert(lib.Registry.FISH_SPECIES, "mymod_salmon")
+```
+
+**No override / patch.**
+
+---
+
+## RESOURCES
+
+Escape hatch: patch arbitrary fields on any `.tres` by absolute path. Verbs: `patch`, `revert` only.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var path = "res://Items/Consumables/Potato/Potato.tres"
+
+# patch any exposed field on the Resource
+lib.patch(lib.Registry.RESOURCES, path, {"weight": 0.01, "value": 9999})
+
+# revert per-field or full
+lib.revert(lib.Registry.RESOURCES, path, ["weight"])
+lib.revert(lib.Registry.RESOURCES, path)
+```
+
+**No register / override / remove**. This registry is for touching Resources that don't have a dedicated handler. For items specifically, prefer `ITEMS` which enforces `ItemData`-shape validation. Falling back to `RESOURCES` bypasses those checks.
+
+**Conflicts.** Same patch-stacking semantics as items: same-field writes last-wins, revert returns to vanilla regardless of how many mods patched.
+
+## Troubleshooting
+
+**`lib.register` returns `false`**
+- Double-check `[registry]` is in your `mod.txt`. Without it the rewriter skips the required injections and registry writes no-op.
+- Check the id doesn't collide with a vanilla name, use `override` instead.
+- Check the payload shape. Most registries require specific keys (`table`, `trader`, `path`, etc.), the warning message lists what's missing.
+
+**My registration succeeds but the game doesn't use it**
+- Timing. Register during your mod `_ready()`, not after scene load. Loot consumers in particular cache on first `_ready()`.
+- If you registered loot into a table but the trader's stock hasn't changed, the trader already populated its pool for the current day. Wait for the next refresh or force a day transition.
+
+## See also
+
+- [Hooks](Hooks): intercepting vanilla method calls
+- [Mod-Format](Mod-Format): `mod.txt` reference
+- [Architecture](Architecture): where the registry sits in the load pipeline

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -5,6 +5,7 @@
 - [Architecture](Architecture)
 - [Modules](Modules)
 - [Hooks](Hooks)
+- [Registry](Registry)
 - [Mod-Format](Mod-Format)
 - [GDSC-Detokenizer](GDSC-Detokenizer)
 - [Stability-Canaries](Stability-Canaries)

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -19,6 +19,9 @@
 # in its mod.txt -- see _generate_hook_pack's wrap-surface build.
 const REGISTRY_TARGETS: Array[String] = [
 	"Database.gd",
+	"Loader.gd",
+	"AISpawner.gd",
+	"FishPool.gd",
 ]
 
 func _is_registry_target(filename: String) -> bool:
@@ -589,12 +592,32 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 		# scripts (Database, GameData, Inputs, Loader, Menu, etc.) -- and
 		# the reload isn't needed anyway since the compiled methods
 		# already include our _rtv_vanilla_* renames.
+		#
+		# Staleness caveat: across modloader releases, the rewriter may add
+		# new injected fields (registry dicts, new prelude code) that aren't
+		# in the static-init-preloaded script from the previous session. We
+		# detect this by comparing the cached script's source_code to the
+		# freshly-generated source we'd emit. If they diverge, we skip the
+		# "already live" shortcut and fall through to the reload path. This
+		# covers the common case where someone updates the modloader and
+		# launches: first run picks up the new rewriter output instead of
+		# silently running last session's stale cache.
 		var already_live := false
 		for m in cached.get_script_method_list():
 			if str(m["name"]).begins_with("_rtv_vanilla_"):
 				already_live = true
 				break
 		if already_live:
+			var fresh_source := FileAccess.get_file_as_string(vp)
+			if not fresh_source.is_empty() and fresh_source != cached.source_code:
+				_log_info("[RTVCodegen] activate %s: cached rewrite is stale (static-init had an older pack), forcing fresh+take_over_path" % vp)
+				var fresh := ResourceLoader.load(vp, "", ResourceLoader.CACHE_MODE_IGNORE) as GDScript
+				if fresh == null:
+					_log_critical("[RTVCodegen] activate %s: fresh load returned null -- skip" % vp)
+					continue
+				fresh.take_over_path(vp)
+				activated += 1
+				continue
 			preactivated += 1
 			activated += 1
 			continue

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -1,27 +1,49 @@
 ## ----- registry.gd -----
 ## Public registry API for mods to add/override/edit vanilla game content.
 ##
-##
 ## Usage:
 ##   lib.register(lib.Registry.SCENES, "my_item", preload("res://mymod/item.tscn"))
 ##   lib.override(lib.Registry.SCENES, "Potato", preload("res://mymod/better_potato.tscn"))
 ##   lib.remove(lib.Registry.SCENES, "my_item")
 ##   lib.revert(lib.Registry.SCENES, "Potato")
 ##
-## Section 1 (this file): scenes on Database. Later sections add handlers for
-## items, loot, recipes, events, sounds, etc. -- each section plugs its own
-## entries into the dispatch match statements without changing the API shape.
+## This file owns:
+##   - the Registry const (canonical registry names)
+##   - rollback tracking dicts shared across sections
+##   - the five public verb dispatchers + get_entry() read API
+##
+## Per-registry handlers live in src/registry/*.gd. Adding a new registry is:
+##   1. Add a Registry.FOO constant below
+##   2. Add a match-arm per verb in this file
+##   3. Create src/registry/foo.gd with _register_foo / _override_foo etc.
+##   4. List the new file in build.sh's FILES array
+## No other file changes.
+##
+## Timing constraint: Trader / LootContainer / LootSimulation fill local
+## buckets from LootTables in their `_ready()` and never re-read. Mod authors
+## MUST register loot during their own mod `_ready()` -- earlier in the
+## autoload order -- or their entries won't propagate to world loot and
+## traders. Runtime re-registration after scene load is invisible.
 
 # Registry name constants. Mods use lib.Registry.SCENES etc. instead of raw
 # strings so typos surface at parse time.
 const Registry := {
 	SCENES = "scenes",
+	ITEMS = "items",
+	LOOT = "loot",
+	SOUNDS = "sounds",
+	RECIPES = "recipes",
+	EVENTS = "events",
+	TRADER_POOLS = "trader_pools",
+	TRADER_TASKS = "trader_tasks",
+	INPUTS = "inputs",
+	SCENE_PATHS = "scene_paths",
+	SHELTERS = "shelters",
+	RANDOM_SCENES = "random_scenes",
+	AI_TYPES = "ai_types",
+	FISH_SPECIES = "fish_species",
+	RESOURCES = "resources",
 	# Future sections populate the rest:
-	# ITEMS = "items",
-	# LOOT = "loot",
-	# RECIPES = "recipes",
-	# EVENTS = "events",
-	# SOUNDS = "sounds",
 	# TRADER_POOLS = "trader_pools",
 	# TRADER_TASKS = "trader_tasks",
 	# INPUTS = "inputs",
@@ -35,9 +57,15 @@ const Registry := {
 
 # Rollback tracking. Populated by register/override/patch, consumed by
 # remove/revert. Structure: reg -> {id -> {...per-verb data}}.
-var _registry_registered: Dictionary = {}   # scenes -> {id -> true}
-var _registry_overridden: Dictionary = {}   # scenes -> {id -> original_value}
-# _registry_patched reserved for Tier-2 when patch() lands.
+#   _registry_registered: reg -> {id -> data}         (newly created entries)
+#   _registry_overridden: reg -> {id -> original}     (full-entry replacements)
+#   _registry_patched:    reg -> {id -> {field -> original_value}}
+# Per-field patch tracking stores the value as it was BEFORE the first patch
+# to that field; subsequent patches to the same field don't overwrite the
+# stash, so revert restores true original state.
+var _registry_registered: Dictionary = {}
+var _registry_overridden: Dictionary = {}
+var _registry_patched: Dictionary = {}
 
 # ---- Public verbs ----
 
@@ -49,6 +77,22 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		return false
 	match registry:
 		"scenes": return _register_scene(id, data)
+		"items": return _register_item(id, data)
+		"loot": return _register_loot(id, data)
+		"sounds": return _register_sound(id, data)
+		"recipes": return _register_recipe(id, data)
+		"events": return _register_event(id, data)
+		"trader_pools": return _register_trader_pool(id, data)
+		"trader_tasks": return _register_trader_task(id, data)
+		"inputs": return _register_input(id, data)
+		"scene_paths": return _register_scene_path(id, data)
+		"shelters": return _register_shelter(id, data)
+		"random_scenes": return _register_random_scene(id, data)
+		"ai_types": return _register_ai_type(id, data)
+		"fish_species": return _register_fish_species(id, data)
+		"resources":
+			push_warning("[Registry] register: 'resources' doesn't support register (the target .tres already exists in vanilla -- use patch to mutate its fields)")
+			return false
 		_:
 			push_warning("[Registry] register: unknown registry '%s'" % registry)
 			return false
@@ -61,18 +105,97 @@ func override(registry: String, id: String, data: Variant) -> bool:
 		return false
 	match registry:
 		"scenes": return _override_scene(id, data)
+		"items": return _override_item(id, data)
+		"loot": return _override_loot(id, data)
+		"sounds": return _override_sound(id, data)
+		"recipes": return _override_recipe(id, data)
+		"events": return _override_event(id, data)
+		"trader_pools":
+			push_warning("[Registry] override: 'trader_pools' doesn't support override (pool entries are boolean flags on ItemData -- just register/remove)")
+			return false
+		"trader_tasks": return _override_trader_task(id, data)
+		"inputs": return _override_input(id, data)
+		"scene_paths": return _override_scene_path(id, data)
+		"shelters":
+			push_warning("[Registry] override: 'shelters' doesn't support override (it's an append-only list -- use register/remove)")
+			return false
+		"random_scenes":
+			push_warning("[Registry] override: 'random_scenes' doesn't support override (append-only list -- use register/remove)")
+			return false
+		"ai_types": return _override_ai_type(id, data)
+		"fish_species":
+			push_warning("[Registry] override: 'fish_species' doesn't support override (append-only list -- use register/remove)")
+			return false
+		"resources":
+			push_warning("[Registry] override: 'resources' doesn't support override (vanilla .tres already exists -- use patch to mutate fields)")
+			return false
 		_:
 			push_warning("[Registry] override: unknown registry '%s'" % registry)
 			return false
 
-## Partial update: merge `fields` into the entry at `id`. Not all registries
-## support this (a scene is a single PackedScene, so SCENES does not). Future
-## tiers (items, recipes) will.
-func patch(registry: String, id: String, fields: Dictionary) -> bool:
+## Partial update: merge `fields` into the entry at `id`. Not every registry
+## supports patch -- scenes are monolithic PackedScenes, loot entries are
+## bare ItemData references (patch via the items registry instead). Returns
+## false with guidance on unsupported registries.
+##
+## `id` is String for most registries. The 'recipes' and 'events' registries
+## also accept a direct Resource ref (RecipeData / EventData) so mods can
+## patch vanilla entries without first registering a handle -- same
+## semantics, just skips the indirection when the mod already holds the ref.
+func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
+	if id is String and id == "":
+		push_warning("[Registry] patch(%s, ...) called with empty id" % registry)
+		return false
 	match registry:
 		"scenes":
 			push_warning("[Registry] patch: 'scenes' registry doesn't support patch (scenes are monolithic PackedScenes -- use override instead)")
 			return false
+		"items":
+			if not (id is String):
+				push_warning("[Registry] patch('items', ...): id must be a String")
+				return false
+			return _patch_item(id, fields)
+		"loot":
+			push_warning("[Registry] patch: 'loot' registry doesn't support patch (loot entries are ItemData references -- patch the ItemData via the 'items' registry instead)")
+			return false
+		"sounds":
+			if not (id is String):
+				push_warning("[Registry] patch('sounds', ...): id must be a String")
+				return false
+			return _patch_sound(id, fields)
+		"recipes": return _patch_recipe(id, fields)
+		"events": return _patch_event(id, fields)
+		"trader_pools":
+			push_warning("[Registry] patch: 'trader_pools' doesn't support patch (entries are boolean flags -- use register/remove)")
+			return false
+		"trader_tasks": return _patch_trader_task(id, fields)
+		"inputs":
+			if not (id is String):
+				push_warning("[Registry] patch('inputs', ...): id must be a String")
+				return false
+			return _patch_input(id, fields)
+		"scene_paths":
+			if not (id is String):
+				push_warning("[Registry] patch('scene_paths', ...): id must be a String")
+				return false
+			return _patch_scene_path(id, fields)
+		"shelters":
+			push_warning("[Registry] patch: 'shelters' doesn't support patch (entries are bare strings)")
+			return false
+		"random_scenes":
+			push_warning("[Registry] patch: 'random_scenes' doesn't support patch (entries are bare paths)")
+			return false
+		"ai_types":
+			push_warning("[Registry] patch: 'ai_types' doesn't support patch (entries are {scene, zone} refs -- use override to swap the scene)")
+			return false
+		"fish_species":
+			push_warning("[Registry] patch: 'fish_species' doesn't support patch (entries are {scene, pool_id} refs)")
+			return false
+		"resources":
+			if not (id is String):
+				push_warning("[Registry] patch('resources', ...): id must be a res:// path String")
+				return false
+			return _patch_resource(id, fields)
 		_:
 			push_warning("[Registry] patch: unknown registry '%s'" % registry)
 			return false
@@ -83,117 +206,158 @@ func patch(registry: String, id: String, fields: Dictionary) -> bool:
 func remove(registry: String, id: String) -> bool:
 	match registry:
 		"scenes": return _remove_scene(id)
+		"items": return _remove_item(id)
+		"loot": return _remove_loot(id)
+		"sounds": return _remove_sound(id)
+		"recipes": return _remove_recipe(id)
+		"events": return _remove_event(id)
+		"trader_pools": return _remove_trader_pool(id)
+		"trader_tasks": return _remove_trader_task(id)
+		"inputs": return _remove_input(id)
+		"scene_paths": return _remove_scene_path(id)
+		"shelters": return _remove_shelter(id)
+		"random_scenes": return _remove_random_scene(id)
+		"ai_types": return _remove_ai_type(id)
+		"fish_species": return _remove_fish_species(id)
+		"resources":
+			push_warning("[Registry] remove: 'resources' doesn't support remove (use revert to undo patches)")
+			return false
 		_:
 			push_warning("[Registry] remove: unknown registry '%s'" % registry)
 			return false
 
-## Undo an override() (or patch() once supported). `fields` is reserved for
-## per-field revert on patch registries; leave empty to revert everything.
-func revert(registry: String, id: String, fields: Array = []) -> bool:
+## Undo an override() or patch(). `fields` is for per-field revert on patch
+## registries; leave empty to revert everything (both override and all
+## accumulated patches on the id).
+##
+## `id` widens to Variant for symmetry with patch(): the 'recipes' and
+## 'events' registries accept either a String handle or a Resource ref.
+## Other registries require String.
+func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 	match registry:
-		"scenes": return _revert_scene(id)
+		"scenes":
+			if not (id is String):
+				push_warning("[Registry] revert('scenes', ...): id must be a String")
+				return false
+			return _revert_scene(id)
+		"items":
+			if not (id is String):
+				push_warning("[Registry] revert('items', ...): id must be a String")
+				return false
+			return _revert_item(id, fields)
+		"loot":
+			if not (id is String):
+				push_warning("[Registry] revert('loot', ...): id must be a String")
+				return false
+			return _revert_loot(id)
+		"sounds":
+			if not (id is String):
+				push_warning("[Registry] revert('sounds', ...): id must be a String")
+				return false
+			return _revert_sound(id, fields)
+		"recipes": return _revert_recipe(id, fields)
+		"events": return _revert_event(id, fields)
+		"trader_pools":
+			if not (id is String):
+				push_warning("[Registry] revert('trader_pools', ...): id must be a String")
+				return false
+			return _revert_trader_pool(id)
+		"trader_tasks": return _revert_trader_task(id, fields)
+		"inputs":
+			if not (id is String):
+				push_warning("[Registry] revert('inputs', ...): id must be a String")
+				return false
+			return _revert_input(id, fields)
+		"scene_paths":
+			if not (id is String):
+				push_warning("[Registry] revert('scene_paths', ...): id must be a String")
+				return false
+			return _revert_scene_path(id, fields)
+		"shelters":
+			if not (id is String):
+				push_warning("[Registry] revert('shelters', ...): id must be a String")
+				return false
+			return _remove_shelter(id)
+		"random_scenes":
+			if not (id is String):
+				push_warning("[Registry] revert('random_scenes', ...): id must be a String")
+				return false
+			return _remove_random_scene(id)
+		"ai_types":
+			if not (id is String):
+				push_warning("[Registry] revert('ai_types', ...): id must be a String")
+				return false
+			return _revert_ai_type(id)
+		"fish_species":
+			if not (id is String):
+				push_warning("[Registry] revert('fish_species', ...): id must be a String")
+				return false
+			return _remove_fish_species(id)
+		"resources":
+			if not (id is String):
+				push_warning("[Registry] revert('resources', ...): id must be a res:// path String")
+				return false
+			return _revert_resource(id, fields)
 		_:
 			push_warning("[Registry] revert: unknown registry '%s'" % registry)
 			return false
 
-# ---- Scenes handlers (Database.gd via injected _get()) ----
-#
-# The rewriter injects _rtv_mod_scenes + _rtv_override_scenes + _get() into
-# Database.gd at build time. Registration just writes into those dicts on
-# the live Database autoload node. Vanilla game code doing Database.get(name)
-# hits the injected _get() and resolves through the mod dicts before falling
-# back to vanilla constants.
-
-func _database_node() -> Node:
-	var db = get_tree().root.get_node_or_null("Database")
-	if db == null:
-		push_warning("[Registry] Database autoload not in tree yet -- is the loader still booting?")
-	return db
-
-func _register_scene(id: String, data: Variant) -> bool:
-	if not (data is PackedScene):
-		push_warning("[Registry] register('scenes', '%s', ...) expects a PackedScene, got %s" % [id, typeof(data)])
-		return false
-	var db := _database_node()
-	if db == null:
-		return false
-	# Collision check: vanilla const, prior mod registration, or mod override.
-	if _scene_exists_in_vanilla(db, id):
-		push_warning("[Registry] register('scenes', '%s'): id collides with vanilla constant; use override instead" % id)
-		return false
-	if db._rtv_mod_scenes.has(id):
-		push_warning("[Registry] register('scenes', '%s'): already registered by a mod" % id)
-		return false
-	db._rtv_mod_scenes[id] = data
-	_track_registered("scenes", id)
-	_log_debug("[Registry] registered scene '%s'" % id)
-	return true
-
-func _override_scene(id: String, data: Variant) -> bool:
-	if not (data is PackedScene):
-		push_warning("[Registry] override('scenes', '%s', ...) expects a PackedScene, got %s" % [id, typeof(data)])
-		return false
-	var db := _database_node()
-	if db == null:
-		return false
-	# The rewriter converts Database's `const X = preload(...)` into entries
-	# in _rtv_vanilla_scenes, so db.get(id) routes through _get() -- which
-	# checks _rtv_override_scenes first. Writing to that dict is enough to
-	# replace the scene a vanilla id resolves to.
-	var original = db.get(id)
-	if original == null:
-		push_warning("[Registry] override('scenes', '%s'): no existing entry to override" % id)
-		return false
-	var ov: Dictionary = _registry_overridden.get("scenes", {})
-	if not ov.has(id):
-		ov[id] = original
-		_registry_overridden["scenes"] = ov
-	db._rtv_override_scenes[id] = data
-	_log_debug("[Registry] overrode scene '%s'" % id)
-	return true
-
-func _remove_scene(id: String) -> bool:
-	var db := _database_node()
-	if db == null:
-		return false
-	if not db._rtv_mod_scenes.has(id):
-		push_warning("[Registry] remove('scenes', '%s'): not registered by a mod" % id)
-		return false
-	db._rtv_mod_scenes.erase(id)
-	var reg: Dictionary = _registry_registered.get("scenes", {})
-	reg.erase(id)
-	_registry_registered["scenes"] = reg
-	_log_debug("[Registry] removed scene '%s'" % id)
-	return true
-
-func _revert_scene(id: String) -> bool:
-	var db := _database_node()
-	if db == null:
-		return false
-	if not db._rtv_override_scenes.has(id):
-		push_warning("[Registry] revert('scenes', '%s'): no mod override to revert" % id)
-		return false
-	db._rtv_override_scenes.erase(id)
-	var ov: Dictionary = _registry_overridden.get("scenes", {})
-	ov.erase(id)
-	_registry_overridden["scenes"] = ov
-	_log_debug("[Registry] reverted scene '%s'" % id)
-	return true
-
-# ---- Helpers ----
-
-func _track_registered(registry: String, id: String) -> void:
-	var reg: Dictionary = _registry_registered.get(registry, {})
-	reg[id] = true
-	_registry_registered[registry] = reg
-
-# A scene id collides with vanilla if Database's rewritten _rtv_vanilla_scenes
-# dict contains it. The rewriter moves every `const X = preload(...)` from
-# vanilla Database.gd into that dict. get_script_constant_map() used to be
-# the way to check before we rewrote the consts; now the dict is the
-# canonical source of truth for "vanilla-shipped names."
-func _scene_exists_in_vanilla(db: Node, id: String) -> bool:
-	if not ("_rtv_vanilla_scenes" in db):
-		return false
-	var vs = db._rtv_vanilla_scenes as Dictionary
-	return vs.has(id)
+## Read API: resolve an id to its current value (vanilla, mod-registered, or
+## mod-overridden, in the same priority the game itself sees). Useful for
+## debugging and for mods that want to introspect what's registered. Returns
+## null if the id doesn't resolve.
+func get_entry(registry: String, id: String) -> Variant:
+	match registry:
+		"scenes":
+			var db := _database_node()
+			return null if db == null else db.get(id)
+		"items":
+			return _lookup_item(id)
+		"loot":
+			# Returns the {item, table} dict the mod registered under id, or
+			# null if the id isn't a mod loot registration. Reads through
+			# overrides first (matches lookup precedence elsewhere).
+			var reg: Dictionary = _registry_registered.get("loot", {})
+			return reg.get(id)
+		"sounds":
+			return _lookup_sound(id)
+		"recipes":
+			var reg: Dictionary = _registry_registered.get("recipes", {})
+			return reg.get(id)
+		"events":
+			var reg: Dictionary = _registry_registered.get("events", {})
+			return reg.get(id)
+		"trader_pools":
+			var reg: Dictionary = _registry_registered.get("trader_pools", {})
+			return reg.get(id)
+		"trader_tasks":
+			var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+			return reg.get(id)
+		"inputs":
+			var reg: Dictionary = _registry_registered.get("inputs", {})
+			return reg.get(id)
+		"scene_paths":
+			var reg: Dictionary = _registry_registered.get("scene_paths", {})
+			return reg.get(id)
+		"shelters":
+			var reg: Dictionary = _registry_registered.get("shelters", {})
+			return reg.get(id)
+		"random_scenes":
+			var reg: Dictionary = _registry_registered.get("random_scenes", {})
+			return reg.get(id)
+		"ai_types":
+			var reg: Dictionary = _registry_registered.get("ai_types", {})
+			return reg.get(id)
+		"fish_species":
+			var reg: Dictionary = _registry_registered.get("fish_species", {})
+			return reg.get(id)
+		"resources":
+			# For the raw-resource escape hatch, `id` is a res:// path.
+			# Returns the loaded Resource (with any live patches applied),
+			# or null if the path doesn't resolve.
+			if not (id is String):
+				return null
+			return load(id)
+		_:
+			push_warning("[Registry] get_entry: unknown registry '%s'" % registry)
+			return null

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -21,8 +21,8 @@
 ##
 ## Timing constraint: Trader / LootContainer / LootSimulation fill local
 ## buckets from LootTables in their `_ready()` and never re-read. Mod authors
-## MUST register loot during their own mod `_ready()` -- earlier in the
-## autoload order -- or their entries won't propagate to world loot and
+## MUST register loot during their own mod `_ready()`; earlier in the
+## autoload order; or their entries won't propagate to world loot and
 ## traders. Runtime re-registration after scene load is invisible.
 
 # Registry name constants. Mods use lib.Registry.SCENES etc. instead of raw
@@ -91,7 +91,7 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		"ai_types": return _register_ai_type(id, data)
 		"fish_species": return _register_fish_species(id, data)
 		"resources":
-			push_warning("[Registry] register: 'resources' doesn't support register (the target .tres already exists in vanilla -- use patch to mutate its fields)")
+			push_warning("[Registry] register: 'resources' doesn't support register (the target .tres already exists in vanilla; use patch to mutate its fields)")
 			return false
 		_:
 			push_warning("[Registry] register: unknown registry '%s'" % registry)
@@ -111,36 +111,36 @@ func override(registry: String, id: String, data: Variant) -> bool:
 		"recipes": return _override_recipe(id, data)
 		"events": return _override_event(id, data)
 		"trader_pools":
-			push_warning("[Registry] override: 'trader_pools' doesn't support override (pool entries are boolean flags on ItemData -- just register/remove)")
+			push_warning("[Registry] override: 'trader_pools' doesn't support override (pool entries are boolean flags on ItemData; just register/remove)")
 			return false
 		"trader_tasks": return _override_trader_task(id, data)
 		"inputs": return _override_input(id, data)
 		"scene_paths": return _override_scene_path(id, data)
 		"shelters":
-			push_warning("[Registry] override: 'shelters' doesn't support override (it's an append-only list -- use register/remove)")
+			push_warning("[Registry] override: 'shelters' doesn't support override (it's an append-only list; use register/remove)")
 			return false
 		"random_scenes":
-			push_warning("[Registry] override: 'random_scenes' doesn't support override (append-only list -- use register/remove)")
+			push_warning("[Registry] override: 'random_scenes' doesn't support override (append-only list; use register/remove)")
 			return false
 		"ai_types": return _override_ai_type(id, data)
 		"fish_species":
-			push_warning("[Registry] override: 'fish_species' doesn't support override (append-only list -- use register/remove)")
+			push_warning("[Registry] override: 'fish_species' doesn't support override (append-only list; use register/remove)")
 			return false
 		"resources":
-			push_warning("[Registry] override: 'resources' doesn't support override (vanilla .tres already exists -- use patch to mutate fields)")
+			push_warning("[Registry] override: 'resources' doesn't support override (vanilla .tres already exists; use patch to mutate fields)")
 			return false
 		_:
 			push_warning("[Registry] override: unknown registry '%s'" % registry)
 			return false
 
 ## Partial update: merge `fields` into the entry at `id`. Not every registry
-## supports patch -- scenes are monolithic PackedScenes, loot entries are
+## supports patch; scenes are monolithic PackedScenes, loot entries are
 ## bare ItemData references (patch via the items registry instead). Returns
 ## false with guidance on unsupported registries.
 ##
 ## `id` is String for most registries. The 'recipes' and 'events' registries
 ## also accept a direct Resource ref (RecipeData / EventData) so mods can
-## patch vanilla entries without first registering a handle -- same
+## patch vanilla entries without first registering a handle; same
 ## semantics, just skips the indirection when the mod already holds the ref.
 func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 	if id is String and id == "":
@@ -148,7 +148,7 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 		return false
 	match registry:
 		"scenes":
-			push_warning("[Registry] patch: 'scenes' registry doesn't support patch (scenes are monolithic PackedScenes -- use override instead)")
+			push_warning("[Registry] patch: 'scenes' registry doesn't support patch (scenes are monolithic PackedScenes; use override instead)")
 			return false
 		"items":
 			if not (id is String):
@@ -156,7 +156,7 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 				return false
 			return _patch_item(id, fields)
 		"loot":
-			push_warning("[Registry] patch: 'loot' registry doesn't support patch (loot entries are ItemData references -- patch the ItemData via the 'items' registry instead)")
+			push_warning("[Registry] patch: 'loot' registry doesn't support patch (loot entries are ItemData references; patch the ItemData via the 'items' registry instead)")
 			return false
 		"sounds":
 			if not (id is String):
@@ -166,7 +166,7 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 		"recipes": return _patch_recipe(id, fields)
 		"events": return _patch_event(id, fields)
 		"trader_pools":
-			push_warning("[Registry] patch: 'trader_pools' doesn't support patch (entries are boolean flags -- use register/remove)")
+			push_warning("[Registry] patch: 'trader_pools' doesn't support patch (entries are boolean flags; use register/remove)")
 			return false
 		"trader_tasks": return _patch_trader_task(id, fields)
 		"inputs":
@@ -186,7 +186,7 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 			push_warning("[Registry] patch: 'random_scenes' doesn't support patch (entries are bare paths)")
 			return false
 		"ai_types":
-			push_warning("[Registry] patch: 'ai_types' doesn't support patch (entries are {scene, zone} refs -- use override to swap the scene)")
+			push_warning("[Registry] patch: 'ai_types' doesn't support patch (entries are {scene, zone} refs; use override to swap the scene)")
 			return false
 		"fish_species":
 			push_warning("[Registry] patch: 'fish_species' doesn't support patch (entries are {scene, pool_id} refs)")
@@ -201,7 +201,7 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 			return false
 
 ## Undo a register(). Fails if the id wasn't registered by a mod (can't
-## remove vanilla entries via this API -- use override with a disabled
+## remove vanilla entries via this API; use override with a disabled
 ## equivalent, or rely on the game's own toggle mechanisms).
 func remove(registry: String, id: String) -> bool:
 	match registry:

--- a/src/registry/ai.gd
+++ b/src/registry/ai.gd
@@ -1,0 +1,155 @@
+## ----- registry/ai.gd -----
+## Section 10: ai_types (AISpawner zone -> agent scene overrides).
+##
+## Vanilla AISpawner.gd hardcodes a zone -> agent-scene mapping:
+##   if zone == Zone.Area05: agent = bandit
+##   elif zone == Zone.BorderZone: agent = guard
+##   elif zone == Zone.Vostok: agent = military
+##
+## The rewriter transforms each `agent = <name>` into
+##   agent = _rtv_resolve_ai_type(zone, <name>)
+## where the resolver (injected into AISpawner.gd) reads
+##   Engine.get_meta("_rtv_ai_overrides", {})
+## and returns the mod-registered PackedScene for the current zone (or the
+## vanilla scene if no override is registered).
+##
+## Design choices:
+##   - AISpawner is a per-scene Node3D, not an autoload. There can be many
+##     instances, each running _ready() independently. We use Engine.meta
+##     to broadcast overrides to all of them.
+##   - Zone keys are String names matching the Zone enum ("Area05",
+##     "BorderZone", "Vostok"). The resolver uses Zone.keys()[zone_int] to
+##     convert back at lookup time.
+##   - Only override is meaningful here: a single agent scene per zone.
+##     Register "adds a new entry" is semantically the same as override
+##     for this registry, so we expose both verbs but they share a slot.
+##
+## Data shape:
+##   {scene: PackedScene, zone: String}
+
+const _VALID_ZONES := ["Area05", "BorderZone", "Vostok"]
+
+# Keep the overrides we install in Engine meta, keyed by zone name, so the
+# injected resolver on every AISpawner instance finds them. Each id in
+# _registry_registered tracks a {scene, zone} payload; the engine-meta dict
+# is derived from those registrations at each write.
+const _AI_ENGINE_META_KEY := "_rtv_ai_overrides"
+
+func _rebuild_ai_engine_meta() -> void:
+	# Collapse all active id registrations into a single zone -> scene dict
+	# for the resolver. If multiple mods register/override the same zone,
+	# the last write wins -- same semantics as other registries that share
+	# a slot.
+	var flat: Dictionary = {}
+	var reg: Dictionary = _registry_registered.get("ai_types", {})
+	for id in reg.keys():
+		var entry: Dictionary = reg[id]
+		flat[entry["zone"]] = entry["scene"]
+	Engine.set_meta(_AI_ENGINE_META_KEY, flat)
+
+func _validate_ai_type_data(id: String, verb: String, data: Variant) -> Array:
+	# Returns [scene, zone] on success, [null, ""] on error.
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('ai_types', '%s', ...) expects Dictionary {scene, zone}, got %s" % [verb, id, typeof(data)])
+		return [null, ""]
+	var d: Dictionary = data
+	if not d.has("scene") or not d.has("zone"):
+		push_warning("[Registry] %s('ai_types', '%s', ...) data dict missing 'scene' or 'zone' key" % [verb, id])
+		return [null, ""]
+	var scene = d["scene"]
+	if not (scene is PackedScene):
+		push_warning("[Registry] %s('ai_types', '%s'): scene is not a PackedScene" % [verb, id])
+		return [null, ""]
+	var zone = d["zone"]
+	if not (zone is String):
+		push_warning("[Registry] %s('ai_types', '%s'): zone must be a String (e.g. 'Area05')" % [verb, id])
+		return [null, ""]
+	if not (zone in _VALID_ZONES):
+		push_warning("[Registry] %s('ai_types', '%s'): unknown zone '%s' (valid: %s)" % [verb, id, zone, _VALID_ZONES])
+		return [null, ""]
+	return [scene, zone]
+
+func _register_ai_type(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("ai_types", {})
+	if reg.has(id):
+		push_warning("[Registry] register('ai_types', '%s'): already registered (pick a unique handle or use override)" % id)
+		return false
+	var parts := _validate_ai_type_data(id, "register", data)
+	var scene = parts[0]
+	var zone: String = parts[1]
+	if scene == null:
+		return false
+	# Collision: another mod already claimed this zone. Register is one-per-
+	# zone; use override to forcibly replace someone else's claim.
+	for existing_id in reg.keys():
+		if reg[existing_id]["zone"] == zone:
+			push_warning("[Registry] register('ai_types', '%s'): zone '%s' already claimed by '%s' -- use override to replace" % [id, zone, existing_id])
+			return false
+	reg[id] = {"scene": scene, "zone": zone}
+	_registry_registered["ai_types"] = reg
+	_rebuild_ai_engine_meta()
+	_log_debug("[Registry] registered ai_type '%s' (zone=%s)" % [id, zone])
+	return true
+
+func _override_ai_type(id: String, data: Variant) -> bool:
+	# Override is semantically "claim this zone even if another mod did."
+	# It drops any conflicting registrations from other mods and installs
+	# this one. On revert, the displaced registrations come back.
+	var ov: Dictionary = _registry_overridden.get("ai_types", {})
+	if ov.has(id):
+		push_warning("[Registry] override('ai_types', '%s'): already overridden (revert first)" % id)
+		return false
+	var parts := _validate_ai_type_data(id, "override", data)
+	var scene = parts[0]
+	var zone: String = parts[1]
+	if scene == null:
+		return false
+	var reg: Dictionary = _registry_registered.get("ai_types", {})
+	# Stash displaced registrations so revert can restore them.
+	var displaced: Array = []
+	for existing_id in reg.keys():
+		if reg[existing_id]["zone"] == zone:
+			displaced.append({"id": existing_id, "entry": reg[existing_id]})
+	for entry in displaced:
+		reg.erase(entry["id"])
+	reg[id] = {"scene": scene, "zone": zone}
+	_registry_registered["ai_types"] = reg
+	ov[id] = {"displaced": displaced, "zone": zone}
+	_registry_overridden["ai_types"] = ov
+	_rebuild_ai_engine_meta()
+	_log_debug("[Registry] overrode ai_type '%s' (zone=%s, displaced %d entry/entries)" % [id, zone, displaced.size()])
+	return true
+
+func _remove_ai_type(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("ai_types", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('ai_types', '%s'): not registered by a mod" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("ai_types", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('ai_types', '%s'): entry is an override, use revert instead" % id)
+		return false
+	reg.erase(id)
+	_registry_registered["ai_types"] = reg
+	_rebuild_ai_engine_meta()
+	_log_debug("[Registry] removed ai_type '%s'" % id)
+	return true
+
+func _revert_ai_type(id: String) -> bool:
+	var ov: Dictionary = _registry_overridden.get("ai_types", {})
+	if not ov.has(id):
+		push_warning("[Registry] revert('ai_types', '%s'): no override to revert" % id)
+		return false
+	var entry: Dictionary = ov[id]
+	var reg: Dictionary = _registry_registered.get("ai_types", {})
+	# Drop the override entry and restore anything it displaced.
+	reg.erase(id)
+	var displaced: Array = entry["displaced"]
+	for d in displaced:
+		reg[d["id"]] = d["entry"]
+	_registry_registered["ai_types"] = reg
+	ov.erase(id)
+	_registry_overridden["ai_types"] = ov
+	_rebuild_ai_engine_meta()
+	_log_debug("[Registry] reverted ai_type '%s' (restored %d displaced)" % [id, displaced.size()])
+	return true

--- a/src/registry/ai.gd
+++ b/src/registry/ai.gd
@@ -1,5 +1,4 @@
 ## ----- registry/ai.gd -----
-## Section 10: ai_types (AISpawner zone -> agent scene overrides).
 ##
 ## Vanilla AISpawner.gd hardcodes a zone -> agent-scene mapping:
 ##   if zone == Zone.Area05: agent = bandit
@@ -38,7 +37,7 @@ const _AI_ENGINE_META_KEY := "_rtv_ai_overrides"
 func _rebuild_ai_engine_meta() -> void:
 	# Collapse all active id registrations into a single zone -> scene dict
 	# for the resolver. If multiple mods register/override the same zone,
-	# the last write wins -- same semantics as other registries that share
+	# the last write wins; same semantics as other registries that share
 	# a slot.
 	var flat: Dictionary = {}
 	var reg: Dictionary = _registry_registered.get("ai_types", {})
@@ -83,7 +82,7 @@ func _register_ai_type(id: String, data: Variant) -> bool:
 	# zone; use override to forcibly replace someone else's claim.
 	for existing_id in reg.keys():
 		if reg[existing_id]["zone"] == zone:
-			push_warning("[Registry] register('ai_types', '%s'): zone '%s' already claimed by '%s' -- use override to replace" % [id, zone, existing_id])
+			push_warning("[Registry] register('ai_types', '%s'): zone '%s' already claimed by '%s'; use override to replace" % [id, zone, existing_id])
 			return false
 	reg[id] = {"scene": scene, "zone": zone}
 	_registry_registered["ai_types"] = reg

--- a/src/registry/events.gd
+++ b/src/registry/events.gd
@@ -1,0 +1,268 @@
+## ----- registry/events.gd -----
+## Section 6: events (Events.tres events array + EventData field patches).
+##
+## Events.tres holds a single `events: Array[EventData]` that EventSystem.gd
+## const-preloads and filters into per-type buckets (dynamic/trader/special)
+## at _ready(). Same timing constraint as loot / recipes: mods must register
+## during their own _ready() for additions to propagate into EventSystem's
+## buckets before the first GetAvailableEvents() call.
+##
+## EventData has no unique id (name isn't unique; vanilla can have duplicate
+## names across days). Registry uses mod-chosen handles like loot / recipes.
+##
+## Data shapes:
+##   register: {event: EventData}
+##   override: {event: EventData, replaces: EventData}
+##   patch:    id can be a String handle OR an EventData Resource ref
+##             directly -- lets mods patch vanilla events in one call
+##             without registering a handle first.
+##
+## Caveat for mod authors: EventData.function is a method name resolved on
+## EventSystem via Callable(self, event.function). Registering a new event
+## whose function string refers to a method EventSystem doesn't have will
+## make that event a no-op when it fires. Either reuse a vanilla function
+## name (FighterJet, ActivateTrader, etc.) or hook EventSystem to inject
+## your own handler.
+
+const _EVENTS_PATH := "res://Events/Events.tres"
+
+var _events_cache: Resource = null
+var _events_warned: bool = false
+
+func _events_resource() -> Resource:
+	if _events_cache != null:
+		return _events_cache
+	var res = load(_EVENTS_PATH)
+	if res == null:
+		if not _events_warned:
+			push_warning("[Registry] events: Events.tres missing at %s -- events registry is inert" % _EVENTS_PATH)
+			_events_warned = true
+		return null
+	_events_cache = res
+	return res
+
+# Shape check: consistent with other registries' _looks_like_* helpers.
+# EventData's canonical fields are name, type, function, possibility.
+func _looks_like_event_data(res: Resource) -> bool:
+	return _resource_has_property(res, "function") \
+			and _resource_has_property(res, "possibility") \
+			and _resource_has_property(res, "day")
+
+# Validates {event} payload. Returns [event, arr] or [null, null] on error.
+func _validate_event_data(id: String, verb: String, data: Variant) -> Array:
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('events', '%s', ...) expects Dictionary {event}, got %s" % [verb, id, typeof(data)])
+		return [null, null]
+	var d: Dictionary = data
+	if not d.has("event"):
+		push_warning("[Registry] %s('events', '%s', ...) data dict missing 'event' key" % [verb, id])
+		return [null, null]
+	var event = d["event"]
+	if not (event is Resource) or not _looks_like_event_data(event):
+		push_warning("[Registry] %s('events', '%s'): event is not an EventData Resource" % [verb, id])
+		return [null, null]
+	var events_res := _events_resource()
+	if events_res == null:
+		return [null, null]
+	var arr = events_res.get("events")
+	if not (arr is Array):
+		push_warning("[Registry] %s('events', '%s'): Events.events is not an Array" % [verb, id])
+		return [null, null]
+	return [event, arr]
+
+func _register_event(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("events", {})
+	if reg.has(id):
+		push_warning("[Registry] register('events', '%s'): already registered (pick a unique handle)" % id)
+		return false
+	var parts := _validate_event_data(id, "register", data)
+	var event = parts[0]
+	var arr = parts[1]
+	if event == null or arr == null:
+		return false
+	if not _typed_array_accepts(arr, event):
+		push_warning("[Registry] register('events', '%s'): event type doesn't match Events.events typed array" % id)
+		return false
+	if event in arr:
+		push_warning("[Registry] register('events', '%s'): event is already present in the array; use override instead" % id)
+		return false
+	arr.append(event)
+	reg[id] = {"event": event}
+	_registry_registered["events"] = reg
+	_log_debug("[Registry] registered event '%s' (name=%s)" % [id, event.get("name")])
+	return true
+
+func _override_event(id: String, data: Variant) -> bool:
+	var ov: Dictionary = _registry_overridden.get("events", {})
+	if ov.has(id):
+		push_warning("[Registry] override('events', '%s'): already overridden (revert first to re-override)" % id)
+		return false
+	if not (data is Dictionary) or not data.has("replaces"):
+		push_warning("[Registry] override('events', '%s', ...) requires {event, replaces: EventData}" % id)
+		return false
+	var parts := _validate_event_data(id, "override", data)
+	var new_event = parts[0]
+	var arr = parts[1]
+	if new_event == null or arr == null:
+		return false
+	var old_event = data["replaces"]
+	if not (old_event is Resource) or not _looks_like_event_data(old_event):
+		push_warning("[Registry] override('events', '%s'): 'replaces' is not an EventData Resource" % id)
+		return false
+	if not _typed_array_accepts(arr, new_event):
+		push_warning("[Registry] override('events', '%s'): event type doesn't match Events.events typed array" % id)
+		return false
+	var idx: int = arr.find(old_event)
+	if idx < 0:
+		push_warning("[Registry] override('events', '%s'): 'replaces' not present in Events.events" % id)
+		return false
+	if new_event in arr:
+		push_warning("[Registry] override('events', '%s'): new event already in array -- would duplicate" % id)
+		return false
+	arr[idx] = new_event
+	ov[id] = {
+		"event": new_event,
+		"replaced": old_event,
+		"index": idx,
+	}
+	_registry_overridden["events"] = ov
+	var reg: Dictionary = _registry_registered.get("events", {})
+	reg[id] = {"event": new_event}
+	_registry_registered["events"] = reg
+	_log_debug("[Registry] overrode event '%s'" % id)
+	return true
+
+# Resolves whatever the mod passed (String handle or EventData ref) to:
+#   [event, patch_key]
+# where patch_key is the stable Variant used in _registry_patched to track
+# per-field original values. For handles it's the String; for direct refs
+# it's "ref:<instance_id>" so distinct Resource instances don't collide.
+func _resolve_event_patch_target(id: Variant) -> Array:
+	if id is String:
+		var reg: Dictionary = _registry_registered.get("events", {})
+		if reg.has(id):
+			return [reg[id]["event"], id]
+		push_warning("[Registry] patch('events', '%s'): no registered handle with that id (register first, or pass an EventData Resource ref directly)" % id)
+		return [null, null]
+	if id is Resource and _looks_like_event_data(id):
+		return [id, "ref:%d" % id.get_instance_id()]
+	push_warning("[Registry] patch('events', ...): id must be a String handle or an EventData Resource")
+	return [null, null]
+
+func _patch_event(id: Variant, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('events', ...): empty fields dict is a no-op")
+		return false
+	var resolved := _resolve_event_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	var patched: Dictionary = _registry_patched.get("events", {})
+	var stash: Dictionary = patched.get(key, {})
+	for field in fields.keys():
+		var fname := String(field)
+		if not _resource_has_property(target, fname):
+			push_warning("[Registry] patch('events'): field '%s' doesn't exist on EventData" % fname)
+			continue
+		if not stash.has(fname):
+			stash[fname] = target.get(fname)
+		target.set(fname, fields[field])
+	patched[key] = stash
+	_registry_patched["events"] = patched
+	_log_debug("[Registry] patched event (key=%s) fields %s" % [key, fields.keys()])
+	return true
+
+func _remove_event(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("events", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('events', '%s'): not a mod event registration" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("events", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('events', '%s'): entry is an override, use revert instead" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var event: Resource = entry["event"]
+	var events_res := _events_resource()
+	if events_res != null:
+		var arr = events_res.get("events")
+		if arr is Array:
+			var idx: int = arr.find(event)
+			if idx >= 0:
+				arr.remove_at(idx)
+			else:
+				push_warning("[Registry] remove('events', '%s'): event not found in array; tracking cleared" % id)
+	reg.erase(id)
+	_registry_registered["events"] = reg
+	_log_debug("[Registry] removed event '%s'" % id)
+	return true
+
+func _revert_event(id: Variant, fields: Array) -> bool:
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("events", {})
+	var patched: Dictionary = _registry_patched.get("events", {})
+	# Resolve patch key + target (matches _resolve_event_patch_target).
+	var patch_key = null
+	var patch_target: Resource = null
+	if id is String:
+		patch_key = id
+		var reg: Dictionary = _registry_registered.get("events", {})
+		if reg.has(id):
+			patch_target = reg[id]["event"]
+	elif id is Resource and _looks_like_event_data(id):
+		patch_key = "ref:%d" % id.get_instance_id()
+		patch_target = id
+	# Full revert: patches first, then override.
+	if fields.is_empty():
+		if patch_key != null and patched.has(patch_key):
+			if patch_target != null:
+				var stash: Dictionary = patched[patch_key]
+				for fname in stash.keys():
+					patch_target.set(fname, stash[fname])
+			patched.erase(patch_key)
+			_registry_patched["events"] = patched
+			did_something = true
+		if id is String and ov.has(id):
+			var entry: Dictionary = ov[id]
+			var events_res := _events_resource()
+			if events_res != null:
+				var arr = events_res.get("events")
+				if arr is Array:
+					var current_idx: int = arr.find(entry["event"])
+					if current_idx >= 0:
+						arr[current_idx] = entry["replaced"]
+					else:
+						push_warning("[Registry] revert('events', '%s'): override's event missing from array, appending original at end" % id)
+						arr.append(entry["replaced"])
+			ov.erase(id)
+			_registry_overridden["events"] = ov
+			var reg2: Dictionary = _registry_registered.get("events", {})
+			reg2.erase(id)
+			_registry_registered["events"] = reg2
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('events'): nothing to revert for that id")
+		return did_something
+	# Per-field revert: patches only.
+	if patch_key == null or not patched.has(patch_key):
+		push_warning("[Registry] revert('events'): no patches found for that id")
+		return false
+	if patch_target == null:
+		push_warning("[Registry] revert('events'): patch target no longer resolves")
+		return false
+	var stash2: Dictionary = patched[patch_key]
+	for field in fields:
+		var fname := String(field)
+		if not stash2.has(fname):
+			push_warning("[Registry] revert('events'): field '%s' wasn't patched" % fname)
+			continue
+		patch_target.set(fname, stash2[fname])
+		stash2.erase(fname)
+		did_something = true
+	if stash2.is_empty():
+		patched.erase(patch_key)
+	else:
+		patched[patch_key] = stash2
+	_registry_patched["events"] = patched
+	return did_something

--- a/src/registry/events.gd
+++ b/src/registry/events.gd
@@ -1,5 +1,4 @@
 ## ----- registry/events.gd -----
-## Section 6: events (Events.tres events array + EventData field patches).
 ##
 ## Events.tres holds a single `events: Array[EventData]` that EventSystem.gd
 ## const-preloads and filters into per-type buckets (dynamic/trader/special)
@@ -14,7 +13,7 @@
 ##   register: {event: EventData}
 ##   override: {event: EventData, replaces: EventData}
 ##   patch:    id can be a String handle OR an EventData Resource ref
-##             directly -- lets mods patch vanilla events in one call
+##             directly; lets mods patch vanilla events in one call
 ##             without registering a handle first.
 ##
 ## Caveat for mod authors: EventData.function is a method name resolved on
@@ -35,7 +34,7 @@ func _events_resource() -> Resource:
 	var res = load(_EVENTS_PATH)
 	if res == null:
 		if not _events_warned:
-			push_warning("[Registry] events: Events.tres missing at %s -- events registry is inert" % _EVENTS_PATH)
+			push_warning("[Registry] events: Events.tres missing at %s; events registry is inert" % _EVENTS_PATH)
 			_events_warned = true
 		return null
 	_events_cache = res
@@ -117,7 +116,7 @@ func _override_event(id: String, data: Variant) -> bool:
 		push_warning("[Registry] override('events', '%s'): 'replaces' not present in Events.events" % id)
 		return false
 	if new_event in arr:
-		push_warning("[Registry] override('events', '%s'): new event already in array -- would duplicate" % id)
+		push_warning("[Registry] override('events', '%s'): new event already in array; would duplicate" % id)
 		return false
 	arr[idx] = new_event
 	ov[id] = {

--- a/src/registry/fish.gd
+++ b/src/registry/fish.gd
@@ -1,5 +1,4 @@
 ## ----- registry/fish.gd -----
-## Section 11: fish_species (FishPool species array additions).
 ##
 ## Vanilla FishPool.gd is a MeshInstance3D placed in scenes (several per map)
 ## with an `@export var species: Array[PackedScene]` populated in the editor.
@@ -20,7 +19,7 @@
 ##
 ## Timing: FishPool is a scene Node, not an autoload. Its _ready() fires
 ## when its containing scene loads. Mods must register before entering the
-## map scene -- mod autoload _ready() is fine, as the main menu loads
+## map scene; mod autoload _ready() is fine, as the main menu loads
 ## first and any map scene comes later.
 
 const _FISH_ENGINE_META_KEY := "_rtv_fish_species"
@@ -53,7 +52,7 @@ func _register_fish_species(id: String, data: Variant) -> bool:
 	if not (scene is PackedScene):
 		push_warning("[Registry] register('fish_species', '%s'): scene is not a PackedScene" % id)
 		return false
-	# Default pool_id to "all" if not given -- most mods want their fish
+	# Default pool_id to "all" if not given; most mods want their fish
 	# in every pool. Explicit pool names override for fine-grained placement.
 	var pool_id: String = "all"
 	if d.has("pool_id"):

--- a/src/registry/fish.gd
+++ b/src/registry/fish.gd
@@ -1,0 +1,79 @@
+## ----- registry/fish.gd -----
+## Section 11: fish_species (FishPool species array additions).
+##
+## Vanilla FishPool.gd is a MeshInstance3D placed in scenes (several per map)
+## with an `@export var species: Array[PackedScene]` populated in the editor.
+## At _ready() it picks 1-10 random fish from species and instantiates them.
+##
+## The rewriter injects a prelude at the top of FishPool._ready() that
+## reads Engine.get_meta("_rtv_fish_species", []) and appends matching
+## entries to the local `species` array before the random-spawn loop. So
+## mods register once and every pool picks it up without editor edits.
+##
+## Data shape:
+##   {scene: PackedScene, pool_id: String}
+## where pool_id is either "all" (every FishPool instance gets this scene)
+## or a specific Node name like "FP_2" (only that one pool).
+##
+## Verbs: register, remove, revert (remove alias). Override/patch not
+## meaningful for a flat list of {scene, pool_id} tuples.
+##
+## Timing: FishPool is a scene Node, not an autoload. Its _ready() fires
+## when its containing scene loads. Mods must register before entering the
+## map scene -- mod autoload _ready() is fine, as the main menu loads
+## first and any map scene comes later.
+
+const _FISH_ENGINE_META_KEY := "_rtv_fish_species"
+
+func _rebuild_fish_engine_meta() -> void:
+	# Flatten all id registrations into a flat Array for the prelude loop.
+	# Each entry is {scene, pool_id}. Preserving registration order keeps
+	# behavior deterministic across mod load orders (prelude appends in
+	# array order; dedupe by scene ensures same scene via multiple ids
+	# doesn't multiply spawn weight).
+	var flat: Array = []
+	var reg: Dictionary = _registry_registered.get("fish_species", {})
+	for id in reg.keys():
+		flat.append(reg[id])
+	Engine.set_meta(_FISH_ENGINE_META_KEY, flat)
+
+func _register_fish_species(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("fish_species", {})
+	if reg.has(id):
+		push_warning("[Registry] register('fish_species', '%s'): already registered (pick a unique handle)" % id)
+		return false
+	if not (data is Dictionary):
+		push_warning("[Registry] register('fish_species', '%s', ...) expects Dictionary {scene, pool_id}, got %s" % [id, typeof(data)])
+		return false
+	var d: Dictionary = data
+	if not d.has("scene"):
+		push_warning("[Registry] register('fish_species', '%s'): data missing 'scene' key" % id)
+		return false
+	var scene = d["scene"]
+	if not (scene is PackedScene):
+		push_warning("[Registry] register('fish_species', '%s'): scene is not a PackedScene" % id)
+		return false
+	# Default pool_id to "all" if not given -- most mods want their fish
+	# in every pool. Explicit pool names override for fine-grained placement.
+	var pool_id: String = "all"
+	if d.has("pool_id"):
+		if not (d["pool_id"] is String):
+			push_warning("[Registry] register('fish_species', '%s'): pool_id must be a String" % id)
+			return false
+		pool_id = d["pool_id"]
+	reg[id] = {"scene": scene, "pool_id": pool_id}
+	_registry_registered["fish_species"] = reg
+	_rebuild_fish_engine_meta()
+	_log_debug("[Registry] registered fish_species '%s' (pool_id=%s)" % [id, pool_id])
+	return true
+
+func _remove_fish_species(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("fish_species", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('fish_species', '%s'): not registered by a mod" % id)
+		return false
+	reg.erase(id)
+	_registry_registered["fish_species"] = reg
+	_rebuild_fish_engine_meta()
+	_log_debug("[Registry] removed fish_species '%s'" % id)
+	return true

--- a/src/registry/inputs.gd
+++ b/src/registry/inputs.gd
@@ -1,5 +1,4 @@
 ## ----- registry/inputs.gd -----
-## Section 8: inputs (Godot InputMap actions).
 ##
 ## Thin wrapper over InputMap.add_action / erase_action / action_add_event
 ## so mods can declare their own input actions with a default keybind.
@@ -9,8 +8,8 @@
 ##
 ## Data shape:
 ##   register: {display_label: String, default_event: InputEvent, deadzone: float (optional, default 0.5)}
-##   override: same shape -- replaces the default event on an existing action (vanilla or mod)
-##   patch:    {display_label, default_event, deadzone} subset -- mutates the
+##   override: same shape; replaces the default event on an existing action (vanilla or mod)
+##   patch:    {display_label, default_event, deadzone} subset; mutates the
 ##             registry metadata (display_label + deadzone) and/or swaps the
 ##             event on InputMap.
 ##
@@ -22,7 +21,7 @@
 ## that UI). Registering an action here makes it functional in-game, but it
 ## won't appear in the rebind menu until a hook on Inputs-createactions-pre
 ## merges lib.get_entry(INPUTS, id) results into the UI's dict. That hook
-## isn't installed by this registry -- mod authors can install it themselves,
+## isn't installed by this registry; mod authors can install it themselves,
 ## or we add it via a loader-installed hook pack later.
 ##
 ## User keybind persistence: vanilla stores rebinds in user://Preferences.tres
@@ -68,7 +67,7 @@ func _register_input(id: String, data: Variant) -> bool:
 		push_warning("[Registry] register('inputs', '%s'): already registered by a mod" % id)
 		return false
 	if InputMap.has_action(id):
-		push_warning("[Registry] register('inputs', '%s'): action already exists in InputMap (vanilla or another mod -- use override instead)" % id)
+		push_warning("[Registry] register('inputs', '%s'): action already exists in InputMap (vanilla or another mod; use override instead)" % id)
 		return false
 	var payload := _validate_input_payload(id, "register", data)
 	if payload.is_empty():
@@ -95,7 +94,7 @@ func _override_input(id: String, data: Variant) -> bool:
 			originals.append(e)
 		# InputMap has no deadzone getter pre-4.x; grab via project_settings
 		# if available, else assume default. Action deadzone isn't routinely
-		# inspected so we can accept approximation -- only matters for revert.
+		# inspected so we can accept approximation; only matters for revert.
 		ov[id] = {
 			"events": originals,
 			"deadzone": _DEFAULT_DEADZONE,
@@ -235,7 +234,7 @@ func _revert_input(id: String, fields: Array) -> bool:
 			ov.erase(id)
 			_registry_overridden["inputs"] = ov
 			# If the action was vanilla (no registered entry in reg beyond
-			# an override-added stub), leave reg intact -- reg now reflects
+			# an override-added stub), leave reg intact; reg now reflects
 			# vanilla state. If the mod also registered the action itself,
 			# reg stays pointing at the mod's registration.
 			did_something = true

--- a/src/registry/inputs.gd
+++ b/src/registry/inputs.gd
@@ -1,0 +1,278 @@
+## ----- registry/inputs.gd -----
+## Section 8: inputs (Godot InputMap actions).
+##
+## Thin wrapper over InputMap.add_action / erase_action / action_add_event
+## so mods can declare their own input actions with a default keybind.
+## Registered actions are immediately usable via
+##     Input.is_action_pressed("mymod_heal")
+## everywhere in the mod's code.
+##
+## Data shape:
+##   register: {display_label: String, default_event: InputEvent, deadzone: float (optional, default 0.5)}
+##   override: same shape -- replaces the default event on an existing action (vanilla or mod)
+##   patch:    {display_label, default_event, deadzone} subset -- mutates the
+##             registry metadata (display_label + deadzone) and/or swaps the
+##             event on InputMap.
+##
+## The `id` IS the action name. Mods use it directly with Input.is_action_*.
+## So mods should namespace: "mymod_heal", not just "heal".
+##
+## Settings UI caveat: vanilla's Settings -> Keybinds panel reads from a
+## hardcoded `inputs` Dictionary inside Inputs.gd (the Control script for
+## that UI). Registering an action here makes it functional in-game, but it
+## won't appear in the rebind menu until a hook on Inputs-createactions-pre
+## merges lib.get_entry(INPUTS, id) results into the UI's dict. That hook
+## isn't installed by this registry -- mod authors can install it themselves,
+## or we add it via a loader-installed hook pack later.
+##
+## User keybind persistence: vanilla stores rebinds in user://Preferences.tres
+## (Preferences.actionEvents). Those persist across mod unload/reload as long
+## as the mod re-registers its action on boot. If the mod is uninstalled
+## entirely, orphan entries linger harmlessly in Preferences.tres.
+
+# Default deadzone for InputMap actions. Matches vanilla's project.godot.
+const _DEFAULT_DEADZONE := 0.5
+
+func _validate_input_payload(id: String, verb: String, data: Variant) -> Dictionary:
+	# Returns validated {display_label, default_event, deadzone} on success,
+	# empty dict on error (with warning already pushed).
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('inputs', '%s', ...) expects Dictionary {display_label, default_event, deadzone?}, got %s" \
+				% [verb, id, typeof(data)])
+		return {}
+	var d: Dictionary = data
+	if not d.has("default_event"):
+		push_warning("[Registry] %s('inputs', '%s', ...) data dict missing 'default_event' key" % [verb, id])
+		return {}
+	var ev = d["default_event"]
+	if not (ev is InputEvent):
+		push_warning("[Registry] %s('inputs', '%s'): default_event is not an InputEvent (got %s)" % [verb, id, typeof(ev)])
+		return {}
+	var display_label = d.get("display_label", id)
+	if not (display_label is String):
+		push_warning("[Registry] %s('inputs', '%s'): display_label must be a String" % [verb, id])
+		return {}
+	var deadzone = d.get("deadzone", _DEFAULT_DEADZONE)
+	if not (deadzone is float or deadzone is int):
+		push_warning("[Registry] %s('inputs', '%s'): deadzone must be a number" % [verb, id])
+		return {}
+	return {
+		"display_label": display_label,
+		"default_event": ev,
+		"deadzone": float(deadzone),
+	}
+
+func _register_input(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("inputs", {})
+	if reg.has(id):
+		push_warning("[Registry] register('inputs', '%s'): already registered by a mod" % id)
+		return false
+	if InputMap.has_action(id):
+		push_warning("[Registry] register('inputs', '%s'): action already exists in InputMap (vanilla or another mod -- use override instead)" % id)
+		return false
+	var payload := _validate_input_payload(id, "register", data)
+	if payload.is_empty():
+		return false
+	InputMap.add_action(id, payload["deadzone"])
+	InputMap.action_add_event(id, payload["default_event"])
+	reg[id] = payload
+	_registry_registered["inputs"] = reg
+	_log_debug("[Registry] registered input '%s' (label=%s)" % [id, payload["display_label"]])
+	return true
+
+func _override_input(id: String, data: Variant) -> bool:
+	if not InputMap.has_action(id):
+		push_warning("[Registry] override('inputs', '%s'): no such action in InputMap" % id)
+		return false
+	var payload := _validate_input_payload(id, "override", data)
+	if payload.is_empty():
+		return false
+	var ov: Dictionary = _registry_overridden.get("inputs", {})
+	# Stash original event list + deadzone once so revert can restore.
+	if not ov.has(id):
+		var originals: Array = []
+		for e in InputMap.action_get_events(id):
+			originals.append(e)
+		# InputMap has no deadzone getter pre-4.x; grab via project_settings
+		# if available, else assume default. Action deadzone isn't routinely
+		# inspected so we can accept approximation -- only matters for revert.
+		ov[id] = {
+			"events": originals,
+			"deadzone": _DEFAULT_DEADZONE,
+		}
+		_registry_overridden["inputs"] = ov
+	InputMap.action_erase_events(id)
+	InputMap.action_add_event(id, payload["default_event"])
+	# Update the metadata dict too so get_entry/patch see the current label.
+	var reg: Dictionary = _registry_registered.get("inputs", {})
+	reg[id] = payload
+	_registry_registered["inputs"] = reg
+	_log_debug("[Registry] overrode input '%s' (label=%s)" % [id, payload["display_label"]])
+	return true
+
+func _patch_input(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('inputs', '%s', ...): empty fields dict is a no-op" % id)
+		return false
+	if not InputMap.has_action(id):
+		push_warning("[Registry] patch('inputs', '%s'): no such action in InputMap" % id)
+		return false
+	# Patch works on the metadata we track, plus InputMap mutation for the
+	# event field. Each patchable field maps to specific state:
+	#   display_label -> reg[id]["display_label"]  (UI hint only)
+	#   default_event -> replaces the first event in InputMap
+	#   deadzone      -> InputMap.action_set_deadzone
+	const _patchable := ["display_label", "default_event", "deadzone"]
+	var reg: Dictionary = _registry_registered.get("inputs", {})
+	# If the id isn't in our reg (vanilla action we haven't touched yet),
+	# seed a stub so patch/revert have somewhere to stash label changes.
+	if not reg.has(id):
+		reg[id] = {
+			"display_label": id,
+			"default_event": null,
+			"deadzone": _DEFAULT_DEADZONE,
+		}
+	var current: Dictionary = reg[id]
+	var patched: Dictionary = _registry_patched.get("inputs", {})
+	var stash: Dictionary = patched.get(id, {})
+	var any_applied := false
+	for field in fields.keys():
+		var fname := String(field)
+		if not (fname in _patchable):
+			push_warning("[Registry] patch('inputs', '%s'): field '%s' not patchable (valid: %s)" % [id, fname, _patchable])
+			continue
+		var val = fields[field]
+		# Per-field validation.
+		match fname:
+			"display_label":
+				if not (val is String):
+					push_warning("[Registry] patch('inputs', '%s'): display_label must be String" % id)
+					continue
+				if not stash.has(fname):
+					stash[fname] = current.get("display_label", id)
+				current["display_label"] = val
+			"default_event":
+				if not (val is InputEvent):
+					push_warning("[Registry] patch('inputs', '%s'): default_event must be InputEvent" % id)
+					continue
+				if not stash.has(fname):
+					# Stash the CURRENT first event from InputMap so revert
+					# restores exactly what was active, even if vanilla +
+					# override chains exist.
+					var existing := InputMap.action_get_events(id)
+					stash[fname] = existing[0] if existing.size() > 0 else null
+				InputMap.action_erase_events(id)
+				InputMap.action_add_event(id, val)
+				current["default_event"] = val
+			"deadzone":
+				if not (val is float or val is int):
+					push_warning("[Registry] patch('inputs', '%s'): deadzone must be a number" % id)
+					continue
+				if not stash.has(fname):
+					stash[fname] = current.get("deadzone", _DEFAULT_DEADZONE)
+				InputMap.action_set_deadzone(id, float(val))
+				current["deadzone"] = float(val)
+		any_applied = true
+	if not any_applied:
+		return false
+	reg[id] = current
+	_registry_registered["inputs"] = reg
+	patched[id] = stash
+	_registry_patched["inputs"] = patched
+	_log_debug("[Registry] patched input '%s' fields %s" % [id, fields.keys()])
+	return true
+
+func _remove_input(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("inputs", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('inputs', '%s'): not registered by a mod" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("inputs", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('inputs', '%s'): entry is an override, use revert instead" % id)
+		return false
+	if InputMap.has_action(id):
+		InputMap.erase_action(id)
+	reg.erase(id)
+	_registry_registered["inputs"] = reg
+	_log_debug("[Registry] removed input '%s'" % id)
+	return true
+
+func _revert_input(id: String, fields: Array) -> bool:
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("inputs", {})
+	var patched: Dictionary = _registry_patched.get("inputs", {})
+	# Full revert: restore patch stash, then restore override events.
+	if fields.is_empty():
+		if patched.has(id):
+			var stash: Dictionary = patched[id]
+			var reg2: Dictionary = _registry_registered.get("inputs", {})
+			var current: Dictionary = reg2.get(id, {})
+			for fname in stash.keys():
+				match fname:
+					"display_label":
+						current["display_label"] = stash[fname]
+					"default_event":
+						InputMap.action_erase_events(id)
+						if stash[fname] != null:
+							InputMap.action_add_event(id, stash[fname])
+						current["default_event"] = stash[fname]
+					"deadzone":
+						InputMap.action_set_deadzone(id, float(stash[fname]))
+						current["deadzone"] = stash[fname]
+			if not current.is_empty():
+				reg2[id] = current
+				_registry_registered["inputs"] = reg2
+			patched.erase(id)
+			_registry_patched["inputs"] = patched
+			did_something = true
+		if ov.has(id):
+			var entry: Dictionary = ov[id]
+			InputMap.action_erase_events(id)
+			for e in entry["events"]:
+				InputMap.action_add_event(id, e)
+			InputMap.action_set_deadzone(id, float(entry["deadzone"]))
+			ov.erase(id)
+			_registry_overridden["inputs"] = ov
+			# If the action was vanilla (no registered entry in reg beyond
+			# an override-added stub), leave reg intact -- reg now reflects
+			# vanilla state. If the mod also registered the action itself,
+			# reg stays pointing at the mod's registration.
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('inputs', '%s'): nothing to revert" % id)
+		return did_something
+	# Per-field revert (patches only).
+	if not patched.has(id):
+		push_warning("[Registry] revert('inputs', '%s', %s): no patches on this id" % [id, fields])
+		return false
+	var stash2: Dictionary = patched[id]
+	var reg3: Dictionary = _registry_registered.get("inputs", {})
+	var current2: Dictionary = reg3.get(id, {})
+	for field in fields:
+		var fname := String(field)
+		if not stash2.has(fname):
+			push_warning("[Registry] revert('inputs', '%s'): field '%s' wasn't patched" % [id, fname])
+			continue
+		match fname:
+			"display_label":
+				current2["display_label"] = stash2[fname]
+			"default_event":
+				InputMap.action_erase_events(id)
+				if stash2[fname] != null:
+					InputMap.action_add_event(id, stash2[fname])
+				current2["default_event"] = stash2[fname]
+			"deadzone":
+				InputMap.action_set_deadzone(id, float(stash2[fname]))
+				current2["deadzone"] = stash2[fname]
+		stash2.erase(fname)
+		did_something = true
+	if stash2.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = stash2
+	_registry_patched["inputs"] = patched
+	if not current2.is_empty():
+		reg3[id] = current2
+		_registry_registered["inputs"] = reg3
+	return did_something

--- a/src/registry/items.gd
+++ b/src/registry/items.gd
@@ -1,10 +1,9 @@
 ## ----- registry/items.gd -----
-## Section 2: items (ItemData Resources).
 ##
 ## Items are ItemData Resources (or subclasses: WeaponData, AttachmentData, etc).
 ## Godot's Resource caching means every `load("res://Items/.../Potato.tres")`
 ## returns the same instance, so mutating the loaded ItemData mutates it for
-## every holder -- including what saves deserialize on next load, because
+## every holder; including what saves deserialize on next load, because
 ## SlotData serializes ItemData references by-value.
 ##
 ## Vanilla has no central file-string -> ItemData lookup; code passes ItemData
@@ -31,7 +30,7 @@ func _register_item(id: String, data: Variant) -> bool:
 	if reg.has(id):
 		push_warning("[Registry] register('items', '%s'): already registered by a mod" % id)
 		return false
-	# Keep ItemData.file in sync with the registry id -- vanilla code reads
+	# Keep ItemData.file in sync with the registry id; vanilla code reads
 	# itemData.file directly and assumes it matches the item's canonical name.
 	if data.get("file") != id:
 		data.set("file", id)
@@ -101,7 +100,7 @@ func _remove_item(id: String) -> bool:
 		return false
 	# Block remove on entries that are actually overrides, not registrations.
 	# An override lives in reg too (see _override_item rationale) but must be
-	# reverted, not removed -- remove implies "undo a register()".
+	# reverted, not removed; remove implies "undo a register()".
 	var ov: Dictionary = _registry_overridden.get("items", {})
 	if ov.has(id):
 		push_warning("[Registry] remove('items', '%s'): entry is an override, use revert instead" % id)
@@ -168,7 +167,7 @@ func _revert_item(id: String, fields: Array) -> bool:
 	return did_something
 
 # Lookup precedence: mod registrations (which includes overrides) first, then
-# vanilla. Matches the scenes registry's override > mod > vanilla shape --
+# vanilla. Matches the scenes registry's override > mod > vanilla shape;
 # here overrides live inside the mod-registered dict, so the order collapses
 # to "mod entries beat vanilla."
 func _lookup_item(id: String) -> Resource:
@@ -186,7 +185,7 @@ func _build_vanilla_item_cache() -> void:
 	_vanilla_item_cache_built = true
 	var master = load("res://Loot/LT_Master.tres")
 	if master == null or not ("items" in master):
-		push_warning("[Registry] LT_Master.tres missing or unreadable -- items registry lookups will only see mod entries")
+		push_warning("[Registry] LT_Master.tres missing or unreadable; items registry lookups will only see mod entries")
 		return
 	for it in master.items:
 		if it == null:

--- a/src/registry/items.gd
+++ b/src/registry/items.gd
@@ -1,0 +1,196 @@
+## ----- registry/items.gd -----
+## Section 2: items (ItemData Resources).
+##
+## Items are ItemData Resources (or subclasses: WeaponData, AttachmentData, etc).
+## Godot's Resource caching means every `load("res://Items/.../Potato.tres")`
+## returns the same instance, so mutating the loaded ItemData mutates it for
+## every holder -- including what saves deserialize on next load, because
+## SlotData serializes ItemData references by-value.
+##
+## Vanilla has no central file-string -> ItemData lookup; code passes ItemData
+## references around directly. So `register` doesn't need to inject anything
+## global: we keep mod-registered items in a dict keyed by `file` and expose
+## them via get_entry(). `file` is the primary id since vanilla code reads
+## itemData.file directly.
+
+# Vanilla item resolution: LT_Master.items is the authoritative list of every
+# ItemData that ships with the game. Scan it for a matching `file` string.
+# Cached on first hit since LT_Master is static for a given game install.
+var _vanilla_item_cache: Dictionary = {}
+var _vanilla_item_cache_built: bool = false
+
+func _register_item(id: String, data: Variant) -> bool:
+	if not (data is Resource) or not _looks_like_item_data(data):
+		push_warning("[Registry] register('items', '%s', ...) expects an ItemData Resource, got %s" % [id, typeof(data)])
+		return false
+	# Collision: vanilla item with matching file, or prior mod registration.
+	if _find_vanilla_item(id) != null:
+		push_warning("[Registry] register('items', '%s'): id collides with vanilla item; use override or patch instead" % id)
+		return false
+	var reg: Dictionary = _registry_registered.get("items", {})
+	if reg.has(id):
+		push_warning("[Registry] register('items', '%s'): already registered by a mod" % id)
+		return false
+	# Keep ItemData.file in sync with the registry id -- vanilla code reads
+	# itemData.file directly and assumes it matches the item's canonical name.
+	if data.get("file") != id:
+		data.set("file", id)
+	reg[id] = data
+	_registry_registered["items"] = reg
+	_log_debug("[Registry] registered item '%s'" % id)
+	return true
+
+func _override_item(id: String, data: Variant) -> bool:
+	if not (data is Resource) or not _looks_like_item_data(data):
+		push_warning("[Registry] override('items', '%s', ...) expects an ItemData Resource, got %s" % [id, typeof(data)])
+		return false
+	var existing := _lookup_item(id)
+	if existing == null:
+		push_warning("[Registry] override('items', '%s'): no existing item to override" % id)
+		return false
+	# Stash the original (by ref) once; subsequent overrides don't clobber.
+	var ov: Dictionary = _registry_overridden.get("items", {})
+	if not ov.has(id):
+		ov[id] = existing
+		_registry_overridden["items"] = ov
+	# Overrides live in _registry_registered because lookup precedence is
+	# override > register > vanilla, and we key both by id. Track in
+	# overridden map so revert can restore; the live value in registered dict
+	# is what lookups hit.
+	var reg: Dictionary = _registry_registered.get("items", {})
+	reg[id] = data
+	_registry_registered["items"] = reg
+	if data.get("file") != id:
+		data.set("file", id)
+	_log_debug("[Registry] overrode item '%s'" % id)
+	return true
+
+func _patch_item(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('items', '%s', ...): empty fields dict is a no-op" % id)
+		return false
+	var target := _lookup_item(id)
+	if target == null:
+		push_warning("[Registry] patch('items', '%s'): no item with that id" % id)
+		return false
+	var patched: Dictionary = _registry_patched.get("items", {})
+	var stash: Dictionary = patched.get(id, {})
+	for field in fields.keys():
+		var field_name := String(field)
+		# Resource.get() returns null both for "missing" and for legitimate
+		# null values. Prefer property-list check so mistyped field names
+		# surface as warnings instead of silently patching a phantom field.
+		if not _resource_has_property(target, field_name):
+			push_warning("[Registry] patch('items', '%s'): field '%s' doesn't exist on %s" \
+					% [id, field_name, target.get_class()])
+			continue
+		# First-write-wins stash: keep pre-any-patch value so revert restores
+		# the true original no matter how many patches have piled on.
+		if not stash.has(field_name):
+			stash[field_name] = target.get(field_name)
+		target.set(field_name, fields[field])
+	patched[id] = stash
+	_registry_patched["items"] = patched
+	_log_debug("[Registry] patched item '%s' fields %s" % [id, fields.keys()])
+	return true
+
+func _remove_item(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("items", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('items', '%s'): not registered by a mod" % id)
+		return false
+	# Block remove on entries that are actually overrides, not registrations.
+	# An override lives in reg too (see _override_item rationale) but must be
+	# reverted, not removed -- remove implies "undo a register()".
+	var ov: Dictionary = _registry_overridden.get("items", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('items', '%s'): entry is an override, use revert instead" % id)
+		return false
+	reg.erase(id)
+	_registry_registered["items"] = reg
+	_log_debug("[Registry] removed item '%s'" % id)
+	return true
+
+func _revert_item(id: String, fields: Array) -> bool:
+	# Two revert modes: (a) full-entry revert of an override(), (b) per-field
+	# revert of patch()es. Caller distinguishes by presence of `fields`.
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("items", {})
+	var patched: Dictionary = _registry_patched.get("items", {})
+	# Full revert: no fields specified -> undo override AND clear all patches.
+	# Order matters: restore patch stash FIRST (onto the currently-resolving
+	# entry, which may be an override), THEN drop the override so lookups
+	# fall back to vanilla. Reversing would restore patch values onto vanilla
+	# ItemData, mutating the base resource permanently.
+	if fields.is_empty():
+		if patched.has(id):
+			var target := _lookup_item(id)
+			if target != null:
+				var stash: Dictionary = patched[id]
+				for fname in stash.keys():
+					target.set(fname, stash[fname])
+			patched.erase(id)
+			_registry_patched["items"] = patched
+			did_something = true
+		if ov.has(id):
+			var reg: Dictionary = _registry_registered.get("items", {})
+			reg.erase(id)
+			_registry_registered["items"] = reg
+			ov.erase(id)
+			_registry_overridden["items"] = ov
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('items', '%s'): nothing to revert" % id)
+		return did_something
+	# Per-field revert: only undo the named fields on a patch(). Overrides
+	# are whole-entry and don't combine with field-level revert.
+	if not patched.has(id):
+		push_warning("[Registry] revert('items', '%s', %s): no patches on this id" % [id, fields])
+		return false
+	var target := _lookup_item(id)
+	if target == null:
+		push_warning("[Registry] revert('items', '%s', %s): id no longer resolves" % [id, fields])
+		return false
+	var stash: Dictionary = patched[id]
+	for field in fields:
+		var fname := String(field)
+		if not stash.has(fname):
+			push_warning("[Registry] revert('items', '%s'): field '%s' wasn't patched" % [id, fname])
+			continue
+		target.set(fname, stash[fname])
+		stash.erase(fname)
+		did_something = true
+	if stash.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = stash
+	_registry_patched["items"] = patched
+	return did_something
+
+# Lookup precedence: mod registrations (which includes overrides) first, then
+# vanilla. Matches the scenes registry's override > mod > vanilla shape --
+# here overrides live inside the mod-registered dict, so the order collapses
+# to "mod entries beat vanilla."
+func _lookup_item(id: String) -> Resource:
+	var reg: Dictionary = _registry_registered.get("items", {})
+	if reg.has(id):
+		return reg[id]
+	return _find_vanilla_item(id)
+
+func _find_vanilla_item(id: String) -> Resource:
+	if not _vanilla_item_cache_built:
+		_build_vanilla_item_cache()
+	return _vanilla_item_cache.get(id)
+
+func _build_vanilla_item_cache() -> void:
+	_vanilla_item_cache_built = true
+	var master = load("res://Loot/LT_Master.tres")
+	if master == null or not ("items" in master):
+		push_warning("[Registry] LT_Master.tres missing or unreadable -- items registry lookups will only see mod entries")
+		return
+	for it in master.items:
+		if it == null:
+			continue
+		var f = it.get("file")
+		if f != null and String(f) != "":
+			_vanilla_item_cache[String(f)] = it

--- a/src/registry/loader.gd
+++ b/src/registry/loader.gd
@@ -1,5 +1,4 @@
 ## ----- registry/loader.gd -----
-## Section 9: scene_paths + shelters + random_scenes.
 ##
 ## Three related registries that all mutate state on the Loader autoload.
 ## The rewriter injects into Loader.gd:
@@ -20,7 +19,7 @@
 ##     remove / revert: standard
 ##
 ## - shelters: append-only list of shelter NAMES (each name must also be a
-##   resolvable scene -- pass `{path, ...}` and we'll auto-register in
+##   resolvable scene; pass `{path, ...}` and we'll auto-register in
 ##   scene_paths too, or pass just {} if the name is already a vanilla
 ##   scene or was pre-registered via scene_paths)
 ##     register: {path?: String, menu?: bool, shelter?: bool, ...}
@@ -35,7 +34,7 @@
 func _loader_node() -> Node:
 	var ldr = get_tree().root.get_node_or_null("Loader")
 	if ldr == null:
-		push_warning("[Registry] Loader autoload not in tree yet -- is the loader still booting?")
+		push_warning("[Registry] Loader autoload not in tree yet; is the loader still booting?")
 	return ldr
 
 # GDScript's has_script_constant() isn't a real API; script constants are
@@ -65,7 +64,7 @@ func _register_scene_path(id: String, data: Variant) -> bool:
 	if ldr == null:
 		return false
 	if not ("_rtv_mod_scene_paths" in ldr):
-		push_warning("[Registry] register('scene_paths'): Loader.gd is missing injected scene-path fields -- rewriter didn't fire, is the hook pack installed?")
+		push_warning("[Registry] register('scene_paths'): Loader.gd is missing injected scene-path fields; rewriter didn't fire, is the hook pack installed?")
 		return false
 	# Collision: an existing mod registration, or a mod override on this id.
 	if ldr._rtv_mod_scene_paths.has(id) or ldr._rtv_override_scene_paths.has(id):
@@ -73,7 +72,7 @@ func _register_scene_path(id: String, data: Variant) -> bool:
 		return false
 	# Collision with vanilla: vanilla scene names are the top-level const
 	# identifiers on Loader (Cabin, Attic, etc.). Reject so mods use
-	# override() instead. Detect via script constant map -- Loader.gd's
+	# override() instead. Detect via script constant map; Loader.gd's
 	# const declarations are still intact for scene paths.
 	if _vanilla_scene_const_exists(ldr, id):
 		push_warning("[Registry] register('scene_paths', '%s'): name collides with a vanilla scene const; use override instead" % id)

--- a/src/registry/loader.gd
+++ b/src/registry/loader.gd
@@ -1,0 +1,361 @@
+## ----- registry/loader.gd -----
+## Section 9: scene_paths + shelters + random_scenes.
+##
+## Three related registries that all mutate state on the Loader autoload.
+## The rewriter injects into Loader.gd:
+##   - _rtv_mod_scene_paths / _rtv_override_scene_paths dicts
+##   - _rtv_vanilla_shelters snapshot (for revert)
+##   - const `shelters` rewritten to a var (so we can append)
+##   - a prelude at the top of LoadScene that checks the dicts and sets
+##     scenePath + gameData flags before the vanilla if-elif runs
+##
+## Timing: Loader is an autoload, so the prelude is active from engine boot.
+## Mod registrations can happen any time after the Loader autoload is in
+## the tree (usually mod _ready() is safe).
+##
+## - scene_paths: named scene lookups with optional gameData flags
+##     register: {path: String, menu?: bool, shelter?: bool, permadeath?: bool, tutorial?: bool}
+##     override: same shape as register; swaps the vanilla entry for a mod one
+##     patch: mutate individual fields on a mod-registered entry
+##     remove / revert: standard
+##
+## - shelters: append-only list of shelter NAMES (each name must also be a
+##   resolvable scene -- pass `{path, ...}` and we'll auto-register in
+##   scene_paths too, or pass just {} if the name is already a vanilla
+##   scene or was pre-registered via scene_paths)
+##     register: {path?: String, menu?: bool, shelter?: bool, ...}
+##     remove: strips from shelters list (and auto-cleans any auto-linked
+##             scene_paths entry)
+##
+## - random_scenes: append-only list of res:// paths added to Loader's
+##   randomScenes var (picked by LoadSceneRandom()).
+##     register: {path: String}
+##     remove: strips from randomScenes
+
+func _loader_node() -> Node:
+	var ldr = get_tree().root.get_node_or_null("Loader")
+	if ldr == null:
+		push_warning("[Registry] Loader autoload not in tree yet -- is the loader still booting?")
+	return ldr
+
+# GDScript's has_script_constant() isn't a real API; script constants are
+# read via get_script_constant_map() -> Dictionary. Check for `id` among
+# the vanilla scene-path consts declared at module scope on Loader.gd.
+var _vanilla_scene_const_cache: Dictionary = {}
+var _vanilla_scene_const_built: bool = false
+func _vanilla_scene_const_exists(ldr: Node, id: String) -> bool:
+	if not _vanilla_scene_const_built:
+		var script = ldr.get_script()
+		if script != null:
+			_vanilla_scene_const_cache = script.get_script_constant_map()
+		_vanilla_scene_const_built = true
+	return _vanilla_scene_const_cache.has(id)
+
+# -------- scene_paths --------
+
+func _register_scene_path(id: String, data: Variant) -> bool:
+	if not (data is Dictionary):
+		push_warning("[Registry] register('scene_paths', '%s', ...) expects Dictionary, got %s" % [id, typeof(data)])
+		return false
+	var d: Dictionary = data
+	if not d.has("path") or not (d["path"] is String):
+		push_warning("[Registry] register('scene_paths', '%s'): data requires string 'path' key" % id)
+		return false
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	if not ("_rtv_mod_scene_paths" in ldr):
+		push_warning("[Registry] register('scene_paths'): Loader.gd is missing injected scene-path fields -- rewriter didn't fire, is the hook pack installed?")
+		return false
+	# Collision: an existing mod registration, or a mod override on this id.
+	if ldr._rtv_mod_scene_paths.has(id) or ldr._rtv_override_scene_paths.has(id):
+		push_warning("[Registry] register('scene_paths', '%s'): already registered/overridden by a mod" % id)
+		return false
+	# Collision with vanilla: vanilla scene names are the top-level const
+	# identifiers on Loader (Cabin, Attic, etc.). Reject so mods use
+	# override() instead. Detect via script constant map -- Loader.gd's
+	# const declarations are still intact for scene paths.
+	if _vanilla_scene_const_exists(ldr, id):
+		push_warning("[Registry] register('scene_paths', '%s'): name collides with a vanilla scene const; use override instead" % id)
+		return false
+	ldr._rtv_mod_scene_paths[id] = d
+	var reg: Dictionary = _registry_registered.get("scene_paths", {})
+	reg[id] = d
+	_registry_registered["scene_paths"] = reg
+	_log_debug("[Registry] registered scene_path '%s' -> %s" % [id, d.get("path")])
+	return true
+
+func _override_scene_path(id: String, data: Variant) -> bool:
+	if not (data is Dictionary):
+		push_warning("[Registry] override('scene_paths', '%s', ...) expects Dictionary, got %s" % [id, typeof(data)])
+		return false
+	var d: Dictionary = data
+	if not d.has("path") or not (d["path"] is String):
+		push_warning("[Registry] override('scene_paths', '%s'): data requires string 'path' key" % id)
+		return false
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	if not ("_rtv_override_scene_paths" in ldr):
+		push_warning("[Registry] override('scene_paths'): Loader.gd is missing injected fields")
+		return false
+	# Verify target exists: either a vanilla scene const or a mod scene_paths
+	# registration. Overriding mod entries is allowed for same-id conflict
+	# resolution between mods.
+	var is_vanilla_const: bool = _vanilla_scene_const_exists(ldr, id)
+	var is_mod_registration: bool = ldr._rtv_mod_scene_paths.has(id)
+	if not is_vanilla_const and not is_mod_registration:
+		push_warning("[Registry] override('scene_paths', '%s'): no vanilla scene const or mod registration with that name" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("scene_paths", {})
+	if not ov.has(id):
+		# Stash the original. For vanilla, that's {path: <const value>} with
+		# the appropriate flags (we don't know them without replicating the
+		# if-elif, so stash minimally and on revert we just clear the
+		# override; vanilla's if-elif handles the restore naturally).
+		if is_vanilla_const:
+			ov[id] = {"vanilla": true}
+		else:
+			ov[id] = {"vanilla": false, "data": ldr._rtv_mod_scene_paths[id]}
+		_registry_overridden["scene_paths"] = ov
+	ldr._rtv_override_scene_paths[id] = d
+	_log_debug("[Registry] overrode scene_path '%s'" % id)
+	return true
+
+func _patch_scene_path(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('scene_paths', '%s'): empty fields is a no-op" % id)
+		return false
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	# Patch operates on the dict entry the mod registered/overrode. Walk
+	# override first, then mod registration.
+	var target_dict: Dictionary
+	var target_store: String  # "override" or "mod"
+	if ldr._rtv_override_scene_paths.has(id):
+		target_dict = ldr._rtv_override_scene_paths[id]
+		target_store = "override"
+	elif ldr._rtv_mod_scene_paths.has(id):
+		target_dict = ldr._rtv_mod_scene_paths[id]
+		target_store = "mod"
+	else:
+		push_warning("[Registry] patch('scene_paths', '%s'): no mod registration or override to patch" % id)
+		return false
+	var patched: Dictionary = _registry_patched.get("scene_paths", {})
+	var stash: Dictionary = patched.get(id, {})
+	for field in fields.keys():
+		var fname := String(field)
+		if not stash.has(fname):
+			# Capture whether the key existed at all so revert can erase vs
+			# restore accurately.
+			if target_dict.has(fname):
+				stash[fname] = target_dict[fname]
+			else:
+				stash[fname] = "__rtv_missing__"
+		target_dict[fname] = fields[field]
+	# Write back since dicts are references in GDScript, but re-store to be
+	# explicit (helps readers and matches our pattern).
+	if target_store == "override":
+		ldr._rtv_override_scene_paths[id] = target_dict
+	else:
+		ldr._rtv_mod_scene_paths[id] = target_dict
+		# Mirror into the loader-side _registry_registered for get_entry.
+		var reg: Dictionary = _registry_registered.get("scene_paths", {})
+		reg[id] = target_dict
+		_registry_registered["scene_paths"] = reg
+	patched[id] = stash
+	_registry_patched["scene_paths"] = patched
+	return true
+
+func _remove_scene_path(id: String) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	var reg: Dictionary = _registry_registered.get("scene_paths", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('scene_paths', '%s'): not a mod registration" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("scene_paths", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('scene_paths', '%s'): entry is an override, use revert instead" % id)
+		return false
+	ldr._rtv_mod_scene_paths.erase(id)
+	reg.erase(id)
+	_registry_registered["scene_paths"] = reg
+	_log_debug("[Registry] removed scene_path '%s'" % id)
+	return true
+
+func _revert_scene_path(id: String, fields: Array) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("scene_paths", {})
+	var patched: Dictionary = _registry_patched.get("scene_paths", {})
+	# Single-scope var declarations: GDScript is function-scoped, so
+	# declaring `target_dict` / `stash` in both the full-revert and
+	# per-field branches below would shadow. Declare once up front.
+	var target_dict: Dictionary
+	var stash: Dictionary
+	if fields.is_empty():
+		# Patches first (onto whatever dict is current).
+		if patched.has(id):
+			stash = patched[id]
+			if ldr._rtv_override_scene_paths.has(id):
+				target_dict = ldr._rtv_override_scene_paths[id]
+			elif ldr._rtv_mod_scene_paths.has(id):
+				target_dict = ldr._rtv_mod_scene_paths[id]
+			for fname in stash.keys():
+				# Type-check before equality: comparing a bool to a String
+				# with == raises a runtime error under strict GDScript, so
+				# gate the sentinel check by type.
+				var stashed_val = stash[fname]
+				if stashed_val is String and stashed_val == "__rtv_missing__":
+					target_dict.erase(fname)
+				else:
+					target_dict[fname] = stashed_val
+			patched.erase(id)
+			_registry_patched["scene_paths"] = patched
+			did_something = true
+		if ov.has(id):
+			ldr._rtv_override_scene_paths.erase(id)
+			ov.erase(id)
+			_registry_overridden["scene_paths"] = ov
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('scene_paths', '%s'): nothing to revert" % id)
+		return did_something
+	# Per-field patch revert.
+	if not patched.has(id):
+		push_warning("[Registry] revert('scene_paths', '%s', %s): no patches on this id" % [id, fields])
+		return false
+	if ldr._rtv_override_scene_paths.has(id):
+		target_dict = ldr._rtv_override_scene_paths[id]
+	elif ldr._rtv_mod_scene_paths.has(id):
+		target_dict = ldr._rtv_mod_scene_paths[id]
+	else:
+		push_warning("[Registry] revert('scene_paths', '%s'): id no longer resolves" % id)
+		return false
+	stash = patched[id]
+	for field in fields:
+		var fname := String(field)
+		if not stash.has(fname):
+			push_warning("[Registry] revert('scene_paths', '%s'): field '%s' wasn't patched" % [id, fname])
+			continue
+		var stashed_val = stash[fname]
+		if stashed_val is String and stashed_val == "__rtv_missing__":
+			target_dict.erase(fname)
+		else:
+			target_dict[fname] = stashed_val
+		stash.erase(fname)
+		did_something = true
+	if stash.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = stash
+	_registry_patched["scene_paths"] = patched
+	return did_something
+
+# -------- shelters --------
+#
+# The shelters list holds bare strings. Registering a shelter also requires
+# a scene behind the name; if the mod provides `path`, we auto-register a
+# paired scene_paths entry so LoadScene(name) works. Otherwise we assume
+# the name is already resolvable (vanilla, or previously registered).
+
+func _register_shelter(id: String, data: Variant) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	if not (data is Dictionary):
+		push_warning("[Registry] register('shelters', '%s', ...) expects Dictionary (can be empty if scene already registered)" % id)
+		return false
+	var d: Dictionary = data
+	var reg: Dictionary = _registry_registered.get("shelters", {})
+	if reg.has(id):
+		push_warning("[Registry] register('shelters', '%s'): already registered" % id)
+		return false
+	if id in ldr.shelters:
+		push_warning("[Registry] register('shelters', '%s'): name already in shelters list (vanilla?)" % id)
+		return false
+	# If a `path` is given, auto-register the scene_paths entry so the
+	# shelter name resolves to a real scene. Force the shelter gameData
+	# flag to true by default since it's a shelter.
+	var auto_scene_path := false
+	if d.has("path"):
+		var sp_data: Dictionary = d.duplicate()
+		# Default shelter flag to true; caller can explicitly pass shelter=false
+		# to opt out.
+		if not sp_data.has("shelter"):
+			sp_data["shelter"] = true
+		if not _register_scene_path(id, sp_data):
+			# The scene_paths registration failed (probably a collision);
+			# abort the shelter register too to keep state consistent.
+			return false
+		auto_scene_path = true
+	ldr.shelters.append(id)
+	reg[id] = {"auto_scene_path": auto_scene_path, "data": d}
+	_registry_registered["shelters"] = reg
+	_log_debug("[Registry] registered shelter '%s' (auto scene_path=%s)" % [id, auto_scene_path])
+	return true
+
+func _remove_shelter(id: String) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	var reg: Dictionary = _registry_registered.get("shelters", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('shelters', '%s'): not a mod registration" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var idx: int = ldr.shelters.find(id)
+	if idx >= 0:
+		ldr.shelters.remove_at(idx)
+	# Clean up the auto-created scene_paths entry too (if any).
+	if entry.get("auto_scene_path", false):
+		_remove_scene_path(id)
+	reg.erase(id)
+	_registry_registered["shelters"] = reg
+	_log_debug("[Registry] removed shelter '%s'" % id)
+	return true
+
+# -------- random_scenes --------
+
+func _register_random_scene(id: String, data: Variant) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	if not (data is Dictionary) or not data.has("path") or not (data["path"] is String):
+		push_warning("[Registry] register('random_scenes', '%s', ...) expects Dictionary with 'path' key" % id)
+		return false
+	var reg: Dictionary = _registry_registered.get("random_scenes", {})
+	if reg.has(id):
+		push_warning("[Registry] register('random_scenes', '%s'): already registered" % id)
+		return false
+	var path: String = data["path"]
+	if path in ldr.randomScenes:
+		push_warning("[Registry] register('random_scenes', '%s'): path already in randomScenes" % id)
+		return false
+	ldr.randomScenes.append(path)
+	reg[id] = {"path": path}
+	_registry_registered["random_scenes"] = reg
+	_log_debug("[Registry] registered random_scene '%s' -> %s" % [id, path])
+	return true
+
+func _remove_random_scene(id: String) -> bool:
+	var ldr := _loader_node()
+	if ldr == null:
+		return false
+	var reg: Dictionary = _registry_registered.get("random_scenes", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('random_scenes', '%s'): not a mod registration" % id)
+		return false
+	var path: String = reg[id]["path"]
+	var idx: int = ldr.randomScenes.find(path)
+	if idx >= 0:
+		ldr.randomScenes.remove_at(idx)
+	reg.erase(id)
+	_registry_registered["random_scenes"] = reg
+	_log_debug("[Registry] removed random_scene '%s'" % id)
+	return true

--- a/src/registry/loot.gd
+++ b/src/registry/loot.gd
@@ -1,16 +1,15 @@
 ## ----- registry/loot.gd -----
-## Section 3: loot (LootTable.items mutation).
 ##
 ## Loot registrations mutate the `items: Array[ItemData]` on loaded LootTable
 ## Resources. Godot's Resource cache ensures every `load("res://Loot/X.tres")`
 ## returns the same instance, so appending to that array affects any later
-## consumer that reads it -- provided the consumer hasn't already copied it
+## consumer that reads it; provided the consumer hasn't already copied it
 ## into a local bucket (see registry.gd module docstring for the timing
 ## constraint: mods must register during their own _ready()).
 ##
 ## Data shape (passed to register/override):
 ##   {item: ItemData, table: String}
-## Override additionally requires `replaces: ItemData` -- the existing entry
+## Override additionally requires `replaces: ItemData`; the existing entry
 ## to swap out. `table` is either a LootTable name like "LT_Master" (resolved
 ## to its .tres path) or an absolute res:// path. Named tables are the
 ## idiomatic form for vanilla; paths are the escape hatch.
@@ -110,7 +109,7 @@ func _register_loot(id: String, data: Variant) -> bool:
 		return false
 	# Idempotent append: don't double-insert if the mod's item is already in
 	# the table (e.g., after an editor rebuild). The existing entry isn't
-	# ours to track, so we still fail the register -- mod authors should use
+	# ours to track, so we still fail the register; mod authors should use
 	# override if they want to force a swap.
 	if item in table_res.items:
 		push_warning("[Registry] register('loot', '%s'): item is already present in table; use override to swap an existing entry" % id)
@@ -151,7 +150,7 @@ func _override_loot(id: String, data: Variant) -> bool:
 		push_warning("[Registry] override('loot', '%s'): 'replaces' item not present in table" % id)
 		return false
 	if new_item in table_res.items:
-		push_warning("[Registry] override('loot', '%s'): new item is already in the table -- would duplicate" % id)
+		push_warning("[Registry] override('loot', '%s'): new item is already in the table; would duplicate" % id)
 		return false
 	table_res.items[idx] = new_item
 	ov[id] = {
@@ -210,7 +209,7 @@ func _revert_loot(id: String) -> bool:
 	if idx >= 0:
 		table_res.items[idx] = old_item
 	else:
-		# Override entry is gone -- someone (another mod? sanitizer?) stripped
+		# Override entry is gone; someone (another mod? sanitizer?) stripped
 		# it. Put the original back at the end rather than nothing.
 		push_warning("[Registry] revert('loot', '%s'): override entry missing from table, appending original at end" % id)
 		table_res.items.append(old_item)

--- a/src/registry/loot.gd
+++ b/src/registry/loot.gd
@@ -1,0 +1,223 @@
+## ----- registry/loot.gd -----
+## Section 3: loot (LootTable.items mutation).
+##
+## Loot registrations mutate the `items: Array[ItemData]` on loaded LootTable
+## Resources. Godot's Resource cache ensures every `load("res://Loot/X.tres")`
+## returns the same instance, so appending to that array affects any later
+## consumer that reads it -- provided the consumer hasn't already copied it
+## into a local bucket (see registry.gd module docstring for the timing
+## constraint: mods must register during their own _ready()).
+##
+## Data shape (passed to register/override):
+##   {item: ItemData, table: String}
+## Override additionally requires `replaces: ItemData` -- the existing entry
+## to swap out. `table` is either a LootTable name like "LT_Master" (resolved
+## to its .tres path) or an absolute res:// path. Named tables are the
+## idiomatic form for vanilla; paths are the escape hatch.
+##
+## Rollback tracking is per-id: _registry_registered["loot"][id] = the data
+## dict the mod registered. That lets remove() find the exact (table, item)
+## pair to strip from the array. Override stashes the displaced entry as an
+## ItemData ref so revert can put it back.
+
+# Map short table names -> absolute res:// paths. If a mod passes an already-
+# absolute path, we use it as-is.
+const _LOOT_TABLE_PATHS := {
+	"LT_Master": "res://Loot/LT_Master.tres",
+	# Custom tables (event-driven): res://Loot/Custom/
+	"LT_Airdrop": "res://Loot/Custom/LT_Airdrop.tres",
+	"LT_Patient_Report": "res://Loot/Custom/LT_Patient_Report.tres",
+	"LT_Punisher": "res://Loot/Custom/LT_Punisher.tres",
+	"LT_Oil_Sample": "res://Loot/Custom/LT_Oil_Sample.tres",
+	# Tutorial tables: res://Loot/Tutorial/
+	"LT_Weapons_01": "res://Loot/Tutorial/LT_Weapons_01.tres",
+	"LT_Weapons_02": "res://Loot/Tutorial/LT_Weapons_02.tres",
+	"LT_Weapons_03": "res://Loot/Tutorial/LT_Weapons_03.tres",
+	"LT_Weapons_04": "res://Loot/Tutorial/LT_Weapons_04.tres",
+	"LT_Ammo": "res://Loot/Tutorial/LT_Ammo.tres",
+	"LT_Medical": "res://Loot/Tutorial/LT_Medical.tres",
+	"LT_Equipment": "res://Loot/Tutorial/LT_Equipment.tres",
+	"LT_Armor": "res://Loot/Tutorial/LT_Armor.tres",
+	"LT_Grenades": "res://Loot/Tutorial/LT_Grenades.tres",
+	"LT_Attachments": "res://Loot/Tutorial/LT_Attachments.tres",
+	"LT_Items": "res://Loot/Tutorial/LT_Items.tres",
+	# Kit tables: res://Loot/Kits/
+	"Kit_Colt": "res://Loot/Kits/Kit_Colt.tres",
+	"Kit_Glock": "res://Loot/Kits/Kit_Glock.tres",
+	"Kit_MP5K": "res://Loot/Kits/Kit_MP5K.tres",
+	"Kit_Makarov": "res://Loot/Kits/Kit_Makarov.tres",
+	"Kit_Mosin": "res://Loot/Kits/Kit_Mosin.tres",
+	"Kit_Remington": "res://Loot/Kits/Kit_Remington.tres",
+}
+
+# Returns the loaded LootTable Resource or null + warning. Accepts bare names
+# ("LT_Master") and absolute paths. Bare names let mods stay concise for the
+# common case; absolute paths are the escape hatch for user-authored tables.
+func _resolve_loot_table(table_ref: String) -> Resource:
+	if table_ref == "":
+		push_warning("[Registry] loot: empty table name")
+		return null
+	var path := table_ref
+	if _LOOT_TABLE_PATHS.has(table_ref):
+		path = _LOOT_TABLE_PATHS[table_ref]
+	elif not table_ref.begins_with("res://"):
+		push_warning("[Registry] loot: unknown table '%s' (not a known vanilla table name and not an absolute res:// path)" % table_ref)
+		return null
+	var res = load(path)
+	if res == null:
+		push_warning("[Registry] loot: couldn't load table at '%s'" % path)
+		return null
+	if not ("items" in res):
+		push_warning("[Registry] loot: resource at '%s' has no `items` array (not a LootTable?)" % path)
+		return null
+	return res
+
+# Validates the {item, table} payload. Returns [item, table_res] or
+# [null, null] on error (with a warning already issued).
+func _validate_loot_data(id: String, verb: String, data: Variant) -> Array:
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('loot', '%s', ...) expects Dictionary {item, table}, got %s" % [verb, id, typeof(data)])
+		return [null, null]
+	var d: Dictionary = data
+	if not d.has("item") or not d.has("table"):
+		push_warning("[Registry] %s('loot', '%s', ...) data dict missing 'item' or 'table' key" % [verb, id])
+		return [null, null]
+	var item = d["item"]
+	if not (item is Resource) or not _looks_like_item_data(item):
+		push_warning("[Registry] %s('loot', '%s'): item is not an ItemData Resource" % [verb, id])
+		return [null, null]
+	var table = d["table"]
+	if not (table is String):
+		push_warning("[Registry] %s('loot', '%s'): table must be a String (name or res:// path)" % [verb, id])
+		return [null, null]
+	var table_res := _resolve_loot_table(table)
+	if table_res == null:
+		return [null, null]
+	return [item, table_res]
+
+func _register_loot(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("loot", {})
+	if reg.has(id):
+		push_warning("[Registry] register('loot', '%s'): already registered (ids are mod-chosen handles, pick a unique one)" % id)
+		return false
+	var parts := _validate_loot_data(id, "register", data)
+	var item = parts[0]
+	var table_res = parts[1]
+	if item == null or table_res == null:
+		return false
+	if not _typed_array_accepts(table_res.items, item):
+		push_warning("[Registry] register('loot', '%s'): item type doesn't match table's typed array (table wants ItemData or subclass; got a Resource with a different script)" % id)
+		return false
+	# Idempotent append: don't double-insert if the mod's item is already in
+	# the table (e.g., after an editor rebuild). The existing entry isn't
+	# ours to track, so we still fail the register -- mod authors should use
+	# override if they want to force a swap.
+	if item in table_res.items:
+		push_warning("[Registry] register('loot', '%s'): item is already present in table; use override to swap an existing entry" % id)
+		return false
+	table_res.items.append(item)
+	# Stash what we registered so remove() can locate and strip it.
+	reg[id] = {"item": item, "table": data["table"], "table_res": table_res}
+	_registry_registered["loot"] = reg
+	_log_debug("[Registry] registered loot '%s' (%s -> %s)" % [id, data["table"], item.get("file")])
+	return true
+
+# For loot, override swaps an ItemData already present in a table for a new
+# one. The `id` is the mod's handle; the displaced entry is what gets
+# restored on revert. Data payload extends the register shape with the entry
+# to swap out: {item, table, replaces: ItemData}.
+func _override_loot(id: String, data: Variant) -> bool:
+	var ov: Dictionary = _registry_overridden.get("loot", {})
+	if ov.has(id):
+		push_warning("[Registry] override('loot', '%s'): already overridden (revert first to re-override)" % id)
+		return false
+	if not (data is Dictionary) or not data.has("replaces"):
+		push_warning("[Registry] override('loot', '%s', ...) requires {item, table, replaces: ItemData}; 'replaces' is the existing entry to swap out" % id)
+		return false
+	var parts := _validate_loot_data(id, "override", data)
+	var new_item = parts[0]
+	var table_res = parts[1]
+	if new_item == null or table_res == null:
+		return false
+	var old_item = data["replaces"]
+	if not (old_item is Resource) or not _looks_like_item_data(old_item):
+		push_warning("[Registry] override('loot', '%s'): 'replaces' is not an ItemData Resource" % id)
+		return false
+	if not _typed_array_accepts(table_res.items, new_item):
+		push_warning("[Registry] override('loot', '%s'): item type doesn't match table's typed array (table wants ItemData or subclass)" % id)
+		return false
+	var idx: int = table_res.items.find(old_item)
+	if idx < 0:
+		push_warning("[Registry] override('loot', '%s'): 'replaces' item not present in table" % id)
+		return false
+	if new_item in table_res.items:
+		push_warning("[Registry] override('loot', '%s'): new item is already in the table -- would duplicate" % id)
+		return false
+	table_res.items[idx] = new_item
+	ov[id] = {
+		"item": new_item,
+		"table": data["table"],
+		"table_res": table_res,
+		"replaced": old_item,
+		"index": idx,
+	}
+	_registry_overridden["loot"] = ov
+	# Also record in registered map so get_entry() can surface the override.
+	var reg: Dictionary = _registry_registered.get("loot", {})
+	reg[id] = {"item": new_item, "table": data["table"], "table_res": table_res}
+	_registry_registered["loot"] = reg
+	_log_debug("[Registry] overrode loot '%s' in %s (%s -> %s)" \
+			% [id, data["table"], old_item.get("file"), new_item.get("file")])
+	return true
+
+func _remove_loot(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("loot", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('loot', '%s'): not a mod loot registration" % id)
+		return false
+	# Block remove on override-backed entries; revert is the correct verb.
+	var ov: Dictionary = _registry_overridden.get("loot", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('loot', '%s'): this id is an override, use revert instead" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var table_res: Resource = entry["table_res"]
+	var item: Resource = entry["item"]
+	var idx: int = table_res.items.find(item)
+	if idx >= 0:
+		table_res.items.remove_at(idx)
+	else:
+		# The entry was registered but something (another mod? editor?)
+		# stripped it from the table already. Clean up our tracking anyway.
+		push_warning("[Registry] remove('loot', '%s'): item not found in table; tracking cleared" % id)
+	reg.erase(id)
+	_registry_registered["loot"] = reg
+	_log_debug("[Registry] removed loot '%s'" % id)
+	return true
+
+func _revert_loot(id: String) -> bool:
+	var ov: Dictionary = _registry_overridden.get("loot", {})
+	if not ov.has(id):
+		push_warning("[Registry] revert('loot', '%s'): no override to revert" % id)
+		return false
+	var entry: Dictionary = ov[id]
+	var table_res: Resource = entry["table_res"]
+	var current_item: Resource = entry["item"]
+	var old_item: Resource = entry["replaced"]
+	# Find the override in the table now (index may have shifted if other
+	# registers/removes happened meanwhile) and put the original back.
+	var idx: int = table_res.items.find(current_item)
+	if idx >= 0:
+		table_res.items[idx] = old_item
+	else:
+		# Override entry is gone -- someone (another mod? sanitizer?) stripped
+		# it. Put the original back at the end rather than nothing.
+		push_warning("[Registry] revert('loot', '%s'): override entry missing from table, appending original at end" % id)
+		table_res.items.append(old_item)
+	ov.erase(id)
+	_registry_overridden["loot"] = ov
+	var reg: Dictionary = _registry_registered.get("loot", {})
+	reg.erase(id)
+	_registry_registered["loot"] = reg
+	_log_debug("[Registry] reverted loot '%s'" % id)
+	return true

--- a/src/registry/recipes.gd
+++ b/src/registry/recipes.gd
@@ -1,5 +1,4 @@
 ## ----- registry/recipes.gd -----
-## Section 5: crafting recipes (Recipes.tres per-category arrays).
 ##
 ## Recipes.tres is a Resource with seven Array[RecipeData] fields: consumables,
 ## medical, equipment, weapons, electronics, misc, furniture. Interface.gd
@@ -7,7 +6,7 @@
 ## the crafting tab the player opened. Godot's Resource cache means every
 ## `load()` (or const preload) of Recipes.tres returns the same instance, so
 ## appending a RecipeData to a category array propagates to the crafting UI
-## provided the mod mutates before Interface._ready() fires -- same timing
+## provided the mod mutates before Interface._ready() fires; same timing
 ## constraint as loot.
 ##
 ## RecipeData has no unique id field (just name + input + output + proximity
@@ -16,7 +15,7 @@
 ##   register: {recipe: RecipeData, category: "consumables"}
 ##   override: {recipe: RecipeData, category, replaces: RecipeData}
 ##   patch:    id can be a String handle OR a RecipeData Resource ref
-##             directly -- lets mods patch vanilla recipes in one call
+##             directly; lets mods patch vanilla recipes in one call
 ##             without registering a handle first.
 ##
 ## Patch rollback keys on object identity (get_instance_id) when the caller
@@ -35,7 +34,7 @@ func _recipes_resource() -> Resource:
 	var res = load(_RECIPES_PATH)
 	if res == null:
 		if not _recipes_warned:
-			push_warning("[Registry] recipes: Recipes.tres missing at %s -- recipes registry is inert" % _RECIPES_PATH)
+			push_warning("[Registry] recipes: Recipes.tres missing at %s; recipes registry is inert" % _RECIPES_PATH)
 			_recipes_warned = true
 		return null
 	_recipes_cache = res
@@ -128,7 +127,7 @@ func _override_recipe(id: String, data: Variant) -> bool:
 		push_warning("[Registry] override('recipes', '%s'): 'replaces' not present in category '%s'" % [id, category])
 		return false
 	if new_recipe in arr:
-		push_warning("[Registry] override('recipes', '%s'): new recipe already in category -- would duplicate" % id)
+		push_warning("[Registry] override('recipes', '%s'): new recipe already in category; would duplicate" % id)
 		return false
 	arr[idx] = new_recipe
 	ov[id] = {

--- a/src/registry/recipes.gd
+++ b/src/registry/recipes.gd
@@ -1,0 +1,284 @@
+## ----- registry/recipes.gd -----
+## Section 5: crafting recipes (Recipes.tres per-category arrays).
+##
+## Recipes.tres is a Resource with seven Array[RecipeData] fields: consumables,
+## medical, equipment, weapons, electronics, misc, furniture. Interface.gd
+## const-preloads Recipes.tres, then walks whichever category array matches
+## the crafting tab the player opened. Godot's Resource cache means every
+## `load()` (or const preload) of Recipes.tres returns the same instance, so
+## appending a RecipeData to a category array propagates to the crafting UI
+## provided the mod mutates before Interface._ready() fires -- same timing
+## constraint as loot.
+##
+## RecipeData has no unique id field (just name + input + output + proximity
+## flags), so the registry's id is a mod-chosen handle the same way loot
+## works. Payloads:
+##   register: {recipe: RecipeData, category: "consumables"}
+##   override: {recipe: RecipeData, category, replaces: RecipeData}
+##   patch:    id can be a String handle OR a RecipeData Resource ref
+##             directly -- lets mods patch vanilla recipes in one call
+##             without registering a handle first.
+##
+## Patch rollback keys on object identity (get_instance_id) when the caller
+## passed a Resource ref, or on the mod's String handle otherwise. Either way
+## revert can find the stash and restore original field values.
+
+const _RECIPE_CATEGORIES := ["consumables", "medical", "equipment", "weapons", "electronics", "misc", "furniture"]
+const _RECIPES_PATH := "res://Crafting/Recipes.tres"
+
+var _recipes_cache: Resource = null
+var _recipes_warned: bool = false
+
+func _recipes_resource() -> Resource:
+	if _recipes_cache != null:
+		return _recipes_cache
+	var res = load(_RECIPES_PATH)
+	if res == null:
+		if not _recipes_warned:
+			push_warning("[Registry] recipes: Recipes.tres missing at %s -- recipes registry is inert" % _RECIPES_PATH)
+			_recipes_warned = true
+		return null
+	_recipes_cache = res
+	return res
+
+# Shape check: does this Resource carry the RecipeData fields? Consistent
+# with _looks_like_item_data / _looks_like_audio_event.
+func _looks_like_recipe_data(res: Resource) -> bool:
+	return _resource_has_property(res, "name") \
+			and _resource_has_property(res, "input") \
+			and _resource_has_property(res, "output")
+
+func _valid_category(category: String) -> bool:
+	return category in _RECIPE_CATEGORIES
+
+# Validates {recipe, category} payload for register / override. Returns
+# [recipe, category_array, category_string] or [null, null, ""] on error.
+func _validate_recipe_data(id: String, verb: String, data: Variant) -> Array:
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('recipes', '%s', ...) expects Dictionary {recipe, category}, got %s" % [verb, id, typeof(data)])
+		return [null, null, ""]
+	var d: Dictionary = data
+	if not d.has("recipe") or not d.has("category"):
+		push_warning("[Registry] %s('recipes', '%s', ...) data dict missing 'recipe' or 'category' key" % [verb, id])
+		return [null, null, ""]
+	var recipe = d["recipe"]
+	if not (recipe is Resource) or not _looks_like_recipe_data(recipe):
+		push_warning("[Registry] %s('recipes', '%s'): recipe is not a RecipeData Resource" % [verb, id])
+		return [null, null, ""]
+	var category = d["category"]
+	if not (category is String) or not _valid_category(category):
+		push_warning("[Registry] %s('recipes', '%s'): category must be one of %s, got '%s'" \
+				% [verb, id, _RECIPE_CATEGORIES, category])
+		return [null, null, ""]
+	var recipes := _recipes_resource()
+	if recipes == null:
+		return [null, null, ""]
+	var arr = recipes.get(category)
+	if not (arr is Array):
+		push_warning("[Registry] %s('recipes', '%s'): Recipes.%s is not an Array" % [verb, id, category])
+		return [null, null, ""]
+	return [recipe, arr, String(category)]
+
+func _register_recipe(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("recipes", {})
+	if reg.has(id):
+		push_warning("[Registry] register('recipes', '%s'): already registered (pick a unique handle)" % id)
+		return false
+	var parts := _validate_recipe_data(id, "register", data)
+	var recipe = parts[0]
+	var arr = parts[1]
+	var category: String = parts[2]
+	if recipe == null or arr == null:
+		return false
+	if not _typed_array_accepts(arr, recipe):
+		push_warning("[Registry] register('recipes', '%s'): recipe type doesn't match Recipes.%s typed array" % [id, category])
+		return false
+	if recipe in arr:
+		push_warning("[Registry] register('recipes', '%s'): recipe is already present in category '%s'; use override instead" % [id, category])
+		return false
+	arr.append(recipe)
+	reg[id] = {"recipe": recipe, "category": category}
+	_registry_registered["recipes"] = reg
+	_log_debug("[Registry] registered recipe '%s' (category=%s, name=%s)" % [id, category, recipe.get("name")])
+	return true
+
+func _override_recipe(id: String, data: Variant) -> bool:
+	var ov: Dictionary = _registry_overridden.get("recipes", {})
+	if ov.has(id):
+		push_warning("[Registry] override('recipes', '%s'): already overridden (revert first to re-override)" % id)
+		return false
+	if not (data is Dictionary) or not data.has("replaces"):
+		push_warning("[Registry] override('recipes', '%s', ...) requires {recipe, category, replaces: RecipeData}" % id)
+		return false
+	var parts := _validate_recipe_data(id, "override", data)
+	var new_recipe = parts[0]
+	var arr = parts[1]
+	var category: String = parts[2]
+	if new_recipe == null or arr == null:
+		return false
+	var old_recipe = data["replaces"]
+	if not (old_recipe is Resource) or not _looks_like_recipe_data(old_recipe):
+		push_warning("[Registry] override('recipes', '%s'): 'replaces' is not a RecipeData Resource" % id)
+		return false
+	if not _typed_array_accepts(arr, new_recipe):
+		push_warning("[Registry] override('recipes', '%s'): recipe type doesn't match Recipes.%s typed array" % [id, category])
+		return false
+	var idx: int = arr.find(old_recipe)
+	if idx < 0:
+		push_warning("[Registry] override('recipes', '%s'): 'replaces' not present in category '%s'" % [id, category])
+		return false
+	if new_recipe in arr:
+		push_warning("[Registry] override('recipes', '%s'): new recipe already in category -- would duplicate" % id)
+		return false
+	arr[idx] = new_recipe
+	ov[id] = {
+		"recipe": new_recipe,
+		"category": category,
+		"replaced": old_recipe,
+		"index": idx,
+	}
+	_registry_overridden["recipes"] = ov
+	var reg: Dictionary = _registry_registered.get("recipes", {})
+	reg[id] = {"recipe": new_recipe, "category": category}
+	_registry_registered["recipes"] = reg
+	_log_debug("[Registry] overrode recipe '%s' in %s" % [id, category])
+	return true
+
+# Resolves whatever the mod passed (String handle or RecipeData Resource) to:
+#   [recipe, patch_key]
+# where patch_key is the stable Variant we use in _registry_patched to
+# track per-field original values. For handles it's the String; for direct
+# refs it's the object's instance_id (int), so distinct Resource instances
+# don't collide.
+func _resolve_patch_target(id: Variant) -> Array:
+	if id is String:
+		var reg: Dictionary = _registry_registered.get("recipes", {})
+		if reg.has(id):
+			return [reg[id]["recipe"], id]
+		push_warning("[Registry] patch('recipes', '%s'): no registered handle with that id (register first, or pass a RecipeData Resource ref directly)" % id)
+		return [null, null]
+	if id is Resource and _looks_like_recipe_data(id):
+		return [id, "ref:%d" % id.get_instance_id()]
+	push_warning("[Registry] patch('recipes', ...): id must be a String handle or a RecipeData Resource")
+	return [null, null]
+
+func _patch_recipe(id: Variant, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('recipes', ...): empty fields dict is a no-op")
+		return false
+	var resolved := _resolve_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	var patched: Dictionary = _registry_patched.get("recipes", {})
+	var stash: Dictionary = patched.get(key, {})
+	for field in fields.keys():
+		var fname := String(field)
+		if not _resource_has_property(target, fname):
+			push_warning("[Registry] patch('recipes'): field '%s' doesn't exist on RecipeData" % fname)
+			continue
+		if not stash.has(fname):
+			stash[fname] = target.get(fname)
+		target.set(fname, fields[field])
+	patched[key] = stash
+	_registry_patched["recipes"] = patched
+	_log_debug("[Registry] patched recipe (key=%s) fields %s" % [key, fields.keys()])
+	return true
+
+func _remove_recipe(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("recipes", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('recipes', '%s'): not a mod recipe registration" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("recipes", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('recipes', '%s'): entry is an override, use revert instead" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var category: String = entry["category"]
+	var recipe: Resource = entry["recipe"]
+	var recipes := _recipes_resource()
+	if recipes != null:
+		var arr = recipes.get(category)
+		if arr is Array:
+			var idx: int = arr.find(recipe)
+			if idx >= 0:
+				arr.remove_at(idx)
+			else:
+				push_warning("[Registry] remove('recipes', '%s'): recipe not found in %s; tracking cleared" % [id, category])
+	reg.erase(id)
+	_registry_registered["recipes"] = reg
+	_log_debug("[Registry] removed recipe '%s'" % id)
+	return true
+
+func _revert_recipe(id: Variant, fields: Array) -> bool:
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("recipes", {})
+	var patched: Dictionary = _registry_patched.get("recipes", {})
+	# Patch key computation matches _resolve_patch_target so we find the same
+	# stash entry regardless of whether the caller patches by handle or by ref.
+	var patch_key = null
+	var patch_target: Resource = null
+	if id is String:
+		patch_key = id
+		var reg: Dictionary = _registry_registered.get("recipes", {})
+		if reg.has(id):
+			patch_target = reg[id]["recipe"]
+	elif id is Resource and _looks_like_recipe_data(id):
+		patch_key = "ref:%d" % id.get_instance_id()
+		patch_target = id
+	# Full revert: patches first (so stash restores onto current entry),
+	# then override (swaps back to the vanilla recipe instance).
+	if fields.is_empty():
+		if patch_key != null and patched.has(patch_key):
+			if patch_target != null:
+				var stash: Dictionary = patched[patch_key]
+				for fname in stash.keys():
+					patch_target.set(fname, stash[fname])
+			patched.erase(patch_key)
+			_registry_patched["recipes"] = patched
+			did_something = true
+		if id is String and ov.has(id):
+			var entry: Dictionary = ov[id]
+			var recipes := _recipes_resource()
+			if recipes != null:
+				var arr = recipes.get(entry["category"])
+				if arr is Array:
+					var current_idx: int = arr.find(entry["recipe"])
+					if current_idx >= 0:
+						arr[current_idx] = entry["replaced"]
+					else:
+						push_warning("[Registry] revert('recipes', '%s'): override's recipe missing from %s, appending original at end" % [id, entry["category"]])
+						arr.append(entry["replaced"])
+			ov.erase(id)
+			_registry_overridden["recipes"] = ov
+			var reg2: Dictionary = _registry_registered.get("recipes", {})
+			reg2.erase(id)
+			_registry_registered["recipes"] = reg2
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('recipes'): nothing to revert for that id")
+		return did_something
+	# Per-field revert: only operates on patch stashes.
+	if patch_key == null or not patched.has(patch_key):
+		push_warning("[Registry] revert('recipes'): no patches found for that id")
+		return false
+	if patch_target == null:
+		push_warning("[Registry] revert('recipes'): patch target no longer resolves")
+		return false
+	var stash2: Dictionary = patched[patch_key]
+	for field in fields:
+		var fname := String(field)
+		if not stash2.has(fname):
+			push_warning("[Registry] revert('recipes'): field '%s' wasn't patched" % fname)
+			continue
+		patch_target.set(fname, stash2[fname])
+		stash2.erase(fname)
+		did_something = true
+	if stash2.is_empty():
+		patched.erase(patch_key)
+	else:
+		patched[patch_key] = stash2
+	_registry_patched["recipes"] = patched
+	return did_something

--- a/src/registry/resources.gd
+++ b/src/registry/resources.gd
@@ -1,5 +1,4 @@
 ## ----- registry/resources.gd -----
-## Section 12 (final): resources -- the raw-Resource escape hatch.
 ##
 ## Patches arbitrary field values on any vanilla .tres file. Intended as the
 ## generic fallback for Resources that don't have a dedicated registry: stat
@@ -14,7 +13,7 @@
 ## The `id` is the absolute res:// path to the .tres. Godot's Resource cache
 ## ensures every `load()` of that path returns the same instance, so
 ## mutating fields on the loaded Resource propagates to all game-side
-## holders. No register/override/remove -- vanilla already defines the
+## holders. No register/override/remove; vanilla already defines the
 ## Resource; we only mutate fields and track rollback.
 ##
 ## Field stash keys per path, so the same path can be patched multiple

--- a/src/registry/resources.gd
+++ b/src/registry/resources.gd
@@ -1,0 +1,95 @@
+## ----- registry/resources.gd -----
+## Section 12 (final): resources -- the raw-Resource escape hatch.
+##
+## Patches arbitrary field values on any vanilla .tres file. Intended as the
+## generic fallback for Resources that don't have a dedicated registry: stat
+## tuning files, config-like .tres, anything a mod author wants to tweak
+## without us building a purpose-built registry.
+##
+## Usage:
+##   lib.patch(RESOURCES, "res://Resources/GameData.tres", {"walk_speed": 5.0})
+##   lib.revert(RESOURCES, "res://Resources/GameData.tres", ["walk_speed"])
+##   lib.revert(RESOURCES, "res://Resources/GameData.tres")  # full revert
+##
+## The `id` is the absolute res:// path to the .tres. Godot's Resource cache
+## ensures every `load()` of that path returns the same instance, so
+## mutating fields on the loaded Resource propagates to all game-side
+## holders. No register/override/remove -- vanilla already defines the
+## Resource; we only mutate fields and track rollback.
+##
+## Field stash keys per path, so the same path can be patched multiple
+## times without losing the pre-first-patch value.
+
+func _load_resource_at(path: String, verb: String) -> Resource:
+	if path == "" or not path.begins_with("res://"):
+		push_warning("[Registry] %s('resources', '%s'): id must be an absolute res:// path" % [verb, path])
+		return null
+	var res = load(path)
+	if res == null:
+		push_warning("[Registry] %s('resources', '%s'): couldn't load resource at path" % [verb, path])
+		return null
+	if not (res is Resource):
+		push_warning("[Registry] %s('resources', '%s'): path doesn't resolve to a Resource" % [verb, path])
+		return null
+	return res
+
+func _patch_resource(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('resources', '%s'): empty fields is a no-op" % id)
+		return false
+	var res := _load_resource_at(id, "patch")
+	if res == null:
+		return false
+	var patched: Dictionary = _registry_patched.get("resources", {})
+	var stash: Dictionary = patched.get(id, {})
+	var any_applied := false
+	for field in fields.keys():
+		var fname := String(field)
+		if not _resource_has_property(res, fname):
+			push_warning("[Registry] patch('resources', '%s'): field '%s' doesn't exist on %s" % [id, fname, res.get_class()])
+			continue
+		# First-write-wins stash so subsequent patches to the same field
+		# don't overwrite the original value.
+		if not stash.has(fname):
+			stash[fname] = res.get(fname)
+		res.set(fname, fields[field])
+		any_applied = true
+	if not any_applied:
+		return false
+	patched[id] = stash
+	_registry_patched["resources"] = patched
+	_log_debug("[Registry] patched resource '%s' fields %s" % [id, fields.keys()])
+	return true
+
+func _revert_resource(id: String, fields: Array) -> bool:
+	var patched: Dictionary = _registry_patched.get("resources", {})
+	if not patched.has(id):
+		push_warning("[Registry] revert('resources', '%s'): no patches on this path" % id)
+		return false
+	var res := _load_resource_at(id, "revert")
+	if res == null:
+		return false
+	var stash: Dictionary = patched[id]
+	# Full revert: restore every stashed field, clear the stash.
+	if fields.is_empty():
+		for fname in stash.keys():
+			res.set(fname, stash[fname])
+		patched.erase(id)
+		_registry_patched["resources"] = patched
+		return true
+	# Per-field revert.
+	var did_something := false
+	for field in fields:
+		var fname := String(field)
+		if not stash.has(fname):
+			push_warning("[Registry] revert('resources', '%s'): field '%s' wasn't patched" % [id, fname])
+			continue
+		res.set(fname, stash[fname])
+		stash.erase(fname)
+		did_something = true
+	if stash.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = stash
+	_registry_patched["resources"] = patched
+	return did_something

--- a/src/registry/scenes.gd
+++ b/src/registry/scenes.gd
@@ -1,0 +1,94 @@
+## ----- registry/scenes.gd -----
+## Section 1: scenes on Database.
+##
+## The rewriter injects _rtv_mod_scenes + _rtv_override_scenes + _get() into
+## Database.gd at build time. Registration writes into those dicts on the
+## live Database autoload node. Vanilla game code doing Database.get(name)
+## hits the injected _get() and resolves through the mod dicts before falling
+## back to vanilla constants (now rewritten into _rtv_vanilla_scenes).
+
+func _database_node() -> Node:
+	var db = get_tree().root.get_node_or_null("Database")
+	if db == null:
+		push_warning("[Registry] Database autoload not in tree yet -- is the loader still booting?")
+	return db
+
+func _register_scene(id: String, data: Variant) -> bool:
+	if not (data is PackedScene):
+		push_warning("[Registry] register('scenes', '%s', ...) expects a PackedScene, got %s" % [id, typeof(data)])
+		return false
+	var db := _database_node()
+	if db == null:
+		return false
+	# Collision check: vanilla const, prior mod registration, or mod override.
+	if _scene_exists_in_vanilla(db, id):
+		push_warning("[Registry] register('scenes', '%s'): id collides with vanilla constant; use override instead" % id)
+		return false
+	if db._rtv_mod_scenes.has(id):
+		push_warning("[Registry] register('scenes', '%s'): already registered by a mod" % id)
+		return false
+	db._rtv_mod_scenes[id] = data
+	_track_registered("scenes", id)
+	_log_debug("[Registry] registered scene '%s'" % id)
+	return true
+
+func _override_scene(id: String, data: Variant) -> bool:
+	if not (data is PackedScene):
+		push_warning("[Registry] override('scenes', '%s', ...) expects a PackedScene, got %s" % [id, typeof(data)])
+		return false
+	var db := _database_node()
+	if db == null:
+		return false
+	# The rewriter converts Database's `const X = preload(...)` into entries
+	# in _rtv_vanilla_scenes, so db.get(id) routes through _get() -- which
+	# checks _rtv_override_scenes first. Writing to that dict is enough to
+	# replace the scene a vanilla id resolves to.
+	var original = db.get(id)
+	if original == null:
+		push_warning("[Registry] override('scenes', '%s'): no existing entry to override" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("scenes", {})
+	if not ov.has(id):
+		ov[id] = original
+		_registry_overridden["scenes"] = ov
+	db._rtv_override_scenes[id] = data
+	_log_debug("[Registry] overrode scene '%s'" % id)
+	return true
+
+func _remove_scene(id: String) -> bool:
+	var db := _database_node()
+	if db == null:
+		return false
+	if not db._rtv_mod_scenes.has(id):
+		push_warning("[Registry] remove('scenes', '%s'): not registered by a mod" % id)
+		return false
+	db._rtv_mod_scenes.erase(id)
+	var reg: Dictionary = _registry_registered.get("scenes", {})
+	reg.erase(id)
+	_registry_registered["scenes"] = reg
+	_log_debug("[Registry] removed scene '%s'" % id)
+	return true
+
+func _revert_scene(id: String) -> bool:
+	var db := _database_node()
+	if db == null:
+		return false
+	if not db._rtv_override_scenes.has(id):
+		push_warning("[Registry] revert('scenes', '%s'): no mod override to revert" % id)
+		return false
+	db._rtv_override_scenes.erase(id)
+	var ov: Dictionary = _registry_overridden.get("scenes", {})
+	ov.erase(id)
+	_registry_overridden["scenes"] = ov
+	_log_debug("[Registry] reverted scene '%s'" % id)
+	return true
+
+# A scene id collides with vanilla if Database's rewritten _rtv_vanilla_scenes
+# dict contains it. The rewriter moves every `const X = preload(...)` from
+# vanilla Database.gd into that dict -- it's the canonical source of truth
+# for "vanilla-shipped names."
+func _scene_exists_in_vanilla(db: Node, id: String) -> bool:
+	if not ("_rtv_vanilla_scenes" in db):
+		return false
+	var vs = db._rtv_vanilla_scenes as Dictionary
+	return vs.has(id)

--- a/src/registry/scenes.gd
+++ b/src/registry/scenes.gd
@@ -1,5 +1,4 @@
 ## ----- registry/scenes.gd -----
-## Section 1: scenes on Database.
 ##
 ## The rewriter injects _rtv_mod_scenes + _rtv_override_scenes + _get() into
 ## Database.gd at build time. Registration writes into those dicts on the
@@ -10,7 +9,7 @@
 func _database_node() -> Node:
 	var db = get_tree().root.get_node_or_null("Database")
 	if db == null:
-		push_warning("[Registry] Database autoload not in tree yet -- is the loader still booting?")
+		push_warning("[Registry] Database autoload not in tree yet; is the loader still booting?")
 	return db
 
 func _register_scene(id: String, data: Variant) -> bool:
@@ -40,17 +39,24 @@ func _override_scene(id: String, data: Variant) -> bool:
 	if db == null:
 		return false
 	# The rewriter converts Database's `const X = preload(...)` into entries
-	# in _rtv_vanilla_scenes, so db.get(id) routes through _get() -- which
+	# in _rtv_vanilla_scenes, so db.get(id) routes through _get(); which
 	# checks _rtv_override_scenes first. Writing to that dict is enough to
 	# replace the scene a vanilla id resolves to.
 	var original = db.get(id)
 	if original == null:
 		push_warning("[Registry] override('scenes', '%s'): no existing entry to override" % id)
 		return false
+	# Reject second override of the same scene id to match every other
+	# registry's behavior. Without this guard, a later mod silently displaces
+	# an earlier mod's override and the earlier mod has no signal that their
+	# work was clobbered. The second mod should revert first (if it wants to
+	# drop the earlier override) or target the registered id explicitly.
 	var ov: Dictionary = _registry_overridden.get("scenes", {})
-	if not ov.has(id):
-		ov[id] = original
-		_registry_overridden["scenes"] = ov
+	if ov.has(id):
+		push_warning("[Registry] override('scenes', '%s'): already overridden (revert first to re-override)" % id)
+		return false
+	ov[id] = original
+	_registry_overridden["scenes"] = ov
 	db._rtv_override_scenes[id] = data
 	_log_debug("[Registry] overrode scene '%s'" % id)
 	return true
@@ -85,7 +91,7 @@ func _revert_scene(id: String) -> bool:
 
 # A scene id collides with vanilla if Database's rewritten _rtv_vanilla_scenes
 # dict contains it. The rewriter moves every `const X = preload(...)` from
-# vanilla Database.gd into that dict -- it's the canonical source of truth
+# vanilla Database.gd into that dict; it's the canonical source of truth
 # for "vanilla-shipped names."
 func _scene_exists_in_vanilla(db: Node, id: String) -> bool:
 	if not ("_rtv_vanilla_scenes" in db):

--- a/src/registry/shared.gd
+++ b/src/registry/shared.gd
@@ -40,7 +40,7 @@ func _typed_array_accepts(arr: Array, item: Variant) -> bool:
 	# script. Walk item's script chain; any match means it's a valid subclass.
 	var required = arr.get_typed_script()
 	if required == null:
-		# Typed by built-in type, not a script class -- fall back to duck check.
+		# Typed by built-in type, not a script class; fall back to duck check.
 		return true
 	if not (item is Object):
 		return false

--- a/src/registry/shared.gd
+++ b/src/registry/shared.gd
@@ -1,0 +1,52 @@
+## ----- registry/shared.gd -----
+## Cross-section registry helpers. Used by more than one section handler, so
+## they live here instead of duplicating in each registry file.
+
+# Bump a reg's rollback-registered map with a bare marker entry. Section
+# handlers that need to store per-id payload (items, loot) write the payload
+# directly instead of calling this.
+func _track_registered(registry: String, id: String) -> void:
+	var reg: Dictionary = _registry_registered.get(registry, {})
+	reg[id] = true
+	_registry_registered[registry] = reg
+
+# True if `res` has a declared property named `prop`. Used by patch() to
+# reject typos and by shape-checks that test for a specific field.
+func _resource_has_property(res: Resource, prop: String) -> bool:
+	for p in res.get_property_list():
+		if p.get("name") == prop:
+			return true
+	return false
+
+# Heuristic: does this Resource carry the ItemData shape? We don't use `is
+# ItemData` because that requires the class_name to be registered in our
+# loader's script scope, which it isn't (ItemData is a game class). Instead
+# check for the canonical `file` field every ItemData (and subclass) defines.
+func _looks_like_item_data(res: Resource) -> bool:
+	return _resource_has_property(res, "file")
+
+# Typed-array validation. Array[ItemData] only accepts instances whose script
+# chain inherits from the ItemData script. Raw Resource + inline GDScript
+# won't pass. Walks item's script chain looking for a script whose resource
+# path matches the array's declared type.
+#
+# Returns true if either the array is untyped, or the item inherits from the
+# array's declared type. Lets handlers fail fast with a clear warning rather
+# than letting Godot spit cryptic TypedArray errors.
+func _typed_array_accepts(arr: Array, item: Variant) -> bool:
+	if not arr.is_typed():
+		return true
+	# For typed arrays of Objects, get_typed_script() returns the required
+	# script. Walk item's script chain; any match means it's a valid subclass.
+	var required = arr.get_typed_script()
+	if required == null:
+		# Typed by built-in type, not a script class -- fall back to duck check.
+		return true
+	if not (item is Object):
+		return false
+	var s = item.get_script()
+	while s != null:
+		if s == required:
+			return true
+		s = s.get_base_script()
+	return false

--- a/src/registry/sounds.gd
+++ b/src/registry/sounds.gd
@@ -1,0 +1,258 @@
+## ----- registry/sounds.gd -----
+## Section 4: sounds (AudioLibrary.tres @export AudioEvent fields).
+##
+## AudioLibrary is a plain Resource at res://Resources/AudioLibrary.tres, not
+## an autoload. Every script that uses audio does `preload("res://Resources/
+## AudioLibrary.tres")` and accesses events by direct property name, e.g.
+## `audioLibrary.knifeSlash`. Godot's Resource cache means every preload
+## returns the same instance, so mutating fields on that one instance
+## propagates to every holder.
+##
+## Data shape accepted by register/override:
+##   - AudioEvent Resource instance (direct)
+##   - AudioStream directly (wrapped in a default AudioEvent: volume=0, randomPitch=false)
+##   - Dictionary {audioClips: Array[AudioStream], volume: float, randomPitch: bool}
+##     (missing keys default sensibly)
+##
+## patch() takes {volume, randomPitch, audioClips} subset.
+##
+## register() limitation (mirrors scenes): registrations live in a mod-only
+## lookup dict. Vanilla scripts hardcode property names like `audioLibrary
+## .knifeSlash`, so a newly registered id isn't reachable from vanilla code.
+## Mods wanting to play their own sounds must fetch via
+## `lib.get_entry(lib.Registry.SOUNDS, "mymod_pickup")` or, equivalently,
+## `audioLibrary.get("mymod_pickup")` -- both resolve through the same
+## storage (see _lookup_sound). Use override to affect what vanilla plays.
+
+const _AUDIO_LIBRARY_PATH := "res://Resources/AudioLibrary.tres"
+
+var _audio_library_cache: Resource = null
+var _audio_library_warned: bool = false
+
+func _audio_library() -> Resource:
+	if _audio_library_cache != null:
+		return _audio_library_cache
+	var lib = load(_AUDIO_LIBRARY_PATH)
+	if lib == null:
+		if not _audio_library_warned:
+			push_warning("[Registry] sounds: AudioLibrary.tres missing at %s -- sounds registry is inert" % _AUDIO_LIBRARY_PATH)
+			_audio_library_warned = true
+		return null
+	_audio_library_cache = lib
+	return lib
+
+# Accept an AudioEvent, a bare AudioStream, or a Dictionary, and return an
+# AudioEvent Resource (or null with warning on bad input).
+#
+# AudioEvent's class script is loaded dynamically from the existing library
+# -- we don't know its res:// path up front and don't want to hardcode it.
+# Pull the class from any existing @export AudioEvent on the library. This
+# also tolerates the game renaming or moving AudioEvent.gd.
+func _coerce_audio_event(id: String, verb: String, data: Variant) -> Resource:
+	# Direct pass-through: already an AudioEvent-shaped Resource.
+	if data is Resource and _looks_like_audio_event(data):
+		return data
+	# Bare AudioStream: wrap in a default-constructed AudioEvent.
+	if data is AudioStream:
+		var ev_class := _audio_event_class()
+		if ev_class == null:
+			push_warning("[Registry] %s('sounds', '%s'): couldn't locate AudioEvent class (library may be empty or unmigrated)" % [verb, id])
+			return null
+		var ev = ev_class.new()
+		ev.set("audioClips", [data])
+		ev.set("volume", 0.0)
+		ev.set("randomPitch", false)
+		return ev
+	# Dictionary shorthand.
+	if data is Dictionary:
+		var d: Dictionary = data
+		var ev_class_d := _audio_event_class()
+		if ev_class_d == null:
+			push_warning("[Registry] %s('sounds', '%s'): couldn't locate AudioEvent class to construct from dict" % [verb, id])
+			return null
+		var ev = ev_class_d.new()
+		if d.has("audioClips"):
+			ev.set("audioClips", d["audioClips"])
+		else:
+			ev.set("audioClips", [])
+		ev.set("volume", float(d.get("volume", 0.0)))
+		ev.set("randomPitch", bool(d.get("randomPitch", false)))
+		return ev
+	push_warning("[Registry] %s('sounds', '%s', ...) expects AudioEvent / AudioStream / Dictionary, got %s" % [verb, id, typeof(data)])
+	return null
+
+# Walk the live AudioLibrary for the first non-null @export AudioEvent and
+# use its script as the AudioEvent class reference. Avoids hardcoding the
+# AudioEvent.gd path (which the game could move).
+func _audio_event_class() -> GDScript:
+	var lib := _audio_library()
+	if lib == null:
+		return null
+	for p in lib.get_property_list():
+		var pname = p.get("name")
+		if not (p.get("usage") & PROPERTY_USAGE_SCRIPT_VARIABLE):
+			continue
+		var val = lib.get(pname)
+		if val == null or not (val is Resource):
+			continue
+		var s = val.get_script()
+		if s != null:
+			return s
+	return null
+
+func _looks_like_audio_event(res: Resource) -> bool:
+	# AudioEvent is identified by its three canonical fields. Same heuristic
+	# shape as _looks_like_item_data for ItemData.
+	return _resource_has_property(res, "audioClips") \
+			and _resource_has_property(res, "volume") \
+			and _resource_has_property(res, "randomPitch")
+
+# True if the name is a declared @export property on AudioLibrary. Used to
+# distinguish "override vanilla sound" from "register new sound".
+func _sound_exists_in_vanilla(id: String) -> bool:
+	var lib := _audio_library()
+	if lib == null:
+		return false
+	return _resource_has_property(lib, id)
+
+# Lookup precedence: mod overrides > mod registrations > vanilla library
+# field. Overrides on vanilla names live as set() mutations on the library
+# itself; lookups via audioLibrary.get(id) would find them there. To keep
+# the registry self-contained and work for register-only ids too, we route
+# through _registry_registered first, falling back to the library.
+func _lookup_sound(id: String) -> Resource:
+	var reg: Dictionary = _registry_registered.get("sounds", {})
+	if reg.has(id):
+		return reg[id]
+	var lib := _audio_library()
+	if lib == null:
+		return null
+	if _resource_has_property(lib, id):
+		return lib.get(id)
+	return null
+
+func _register_sound(id: String, data: Variant) -> bool:
+	if _sound_exists_in_vanilla(id):
+		push_warning("[Registry] register('sounds', '%s'): id collides with vanilla AudioLibrary field; use override instead" % id)
+		return false
+	var reg: Dictionary = _registry_registered.get("sounds", {})
+	if reg.has(id):
+		push_warning("[Registry] register('sounds', '%s'): already registered by a mod" % id)
+		return false
+	var ev := _coerce_audio_event(id, "register", data)
+	if ev == null:
+		return false
+	reg[id] = ev
+	_registry_registered["sounds"] = reg
+	_log_debug("[Registry] registered sound '%s'" % id)
+	return true
+
+func _override_sound(id: String, data: Variant) -> bool:
+	var lib := _audio_library()
+	if lib == null:
+		return false
+	if not _sound_exists_in_vanilla(id):
+		# Mod-registered ids can't be overridden -- that's what a second
+		# register call would be conceptually, but we reject re-register.
+		# Force mods to revert first.
+		push_warning("[Registry] override('sounds', '%s'): no vanilla AudioLibrary field with that name (register can't be overridden; revert the register first)" % id)
+		return false
+	var ev := _coerce_audio_event(id, "override", data)
+	if ev == null:
+		return false
+	# First-write-wins stash so multiple overrides on the same id still
+	# restore to true vanilla on revert.
+	var ov: Dictionary = _registry_overridden.get("sounds", {})
+	if not ov.has(id):
+		ov[id] = lib.get(id)
+		_registry_overridden["sounds"] = ov
+	lib.set(id, ev)
+	_log_debug("[Registry] overrode sound '%s'" % id)
+	return true
+
+func _patch_sound(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('sounds', '%s', ...): empty fields dict is a no-op" % id)
+		return false
+	var target := _lookup_sound(id)
+	if target == null:
+		push_warning("[Registry] patch('sounds', '%s'): no sound with that id" % id)
+		return false
+	var patched: Dictionary = _registry_patched.get("sounds", {})
+	var stash: Dictionary = patched.get(id, {})
+	for field in fields.keys():
+		var field_name := String(field)
+		if not _resource_has_property(target, field_name):
+			push_warning("[Registry] patch('sounds', '%s'): field '%s' doesn't exist on AudioEvent (valid: audioClips, volume, randomPitch)" \
+					% [id, field_name])
+			continue
+		if not stash.has(field_name):
+			stash[field_name] = target.get(field_name)
+		target.set(field_name, fields[field])
+	patched[id] = stash
+	_registry_patched["sounds"] = patched
+	_log_debug("[Registry] patched sound '%s' fields %s" % [id, fields.keys()])
+	return true
+
+func _remove_sound(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("sounds", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('sounds', '%s'): not registered by a mod" % id)
+		return false
+	# Sounds don't have the items-style override-lives-in-registered dual
+	# storage -- overrides mutate the library directly, not this dict. So
+	# anything in reg is a plain register.
+	reg.erase(id)
+	_registry_registered["sounds"] = reg
+	_log_debug("[Registry] removed sound '%s'" % id)
+	return true
+
+func _revert_sound(id: String, fields: Array) -> bool:
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("sounds", {})
+	var patched: Dictionary = _registry_patched.get("sounds", {})
+	var lib := _audio_library()
+	# Full revert: undo override AND clear patches. Order: patches first
+	# (onto whatever's currently resolving, which may be an override), then
+	# override (replaces whole entry with the stashed vanilla).
+	if fields.is_empty():
+		if patched.has(id):
+			var target := _lookup_sound(id)
+			if target != null:
+				var stash: Dictionary = patched[id]
+				for fname in stash.keys():
+					target.set(fname, stash[fname])
+			patched.erase(id)
+			_registry_patched["sounds"] = patched
+			did_something = true
+		if ov.has(id) and lib != null:
+			lib.set(id, ov[id])
+			ov.erase(id)
+			_registry_overridden["sounds"] = ov
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('sounds', '%s'): nothing to revert" % id)
+		return did_something
+	# Per-field revert: only undo named fields on a patch.
+	if not patched.has(id):
+		push_warning("[Registry] revert('sounds', '%s', %s): no patches on this id" % [id, fields])
+		return false
+	var target := _lookup_sound(id)
+	if target == null:
+		push_warning("[Registry] revert('sounds', '%s', %s): id no longer resolves" % [id, fields])
+		return false
+	var stash: Dictionary = patched[id]
+	for field in fields:
+		var fname := String(field)
+		if not stash.has(fname):
+			push_warning("[Registry] revert('sounds', '%s'): field '%s' wasn't patched" % [id, fname])
+			continue
+		target.set(fname, stash[fname])
+		stash.erase(fname)
+		did_something = true
+	if stash.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = stash
+	_registry_patched["sounds"] = patched
+	return did_something

--- a/src/registry/sounds.gd
+++ b/src/registry/sounds.gd
@@ -1,5 +1,4 @@
 ## ----- registry/sounds.gd -----
-## Section 4: sounds (AudioLibrary.tres @export AudioEvent fields).
 ##
 ## AudioLibrary is a plain Resource at res://Resources/AudioLibrary.tres, not
 ## an autoload. Every script that uses audio does `preload("res://Resources/
@@ -21,7 +20,7 @@
 ## .knifeSlash`, so a newly registered id isn't reachable from vanilla code.
 ## Mods wanting to play their own sounds must fetch via
 ## `lib.get_entry(lib.Registry.SOUNDS, "mymod_pickup")` or, equivalently,
-## `audioLibrary.get("mymod_pickup")` -- both resolve through the same
+## `audioLibrary.get("mymod_pickup")`; both resolve through the same
 ## storage (see _lookup_sound). Use override to affect what vanilla plays.
 
 const _AUDIO_LIBRARY_PATH := "res://Resources/AudioLibrary.tres"
@@ -35,7 +34,7 @@ func _audio_library() -> Resource:
 	var lib = load(_AUDIO_LIBRARY_PATH)
 	if lib == null:
 		if not _audio_library_warned:
-			push_warning("[Registry] sounds: AudioLibrary.tres missing at %s -- sounds registry is inert" % _AUDIO_LIBRARY_PATH)
+			push_warning("[Registry] sounds: AudioLibrary.tres missing at %s; sounds registry is inert" % _AUDIO_LIBRARY_PATH)
 			_audio_library_warned = true
 		return null
 	_audio_library_cache = lib
@@ -45,7 +44,7 @@ func _audio_library() -> Resource:
 # AudioEvent Resource (or null with warning on bad input).
 #
 # AudioEvent's class script is loaded dynamically from the existing library
-# -- we don't know its res:// path up front and don't want to hardcode it.
+#; we don't know its res:// path up front and don't want to hardcode it.
 # Pull the class from any existing @export AudioEvent on the library. This
 # also tolerates the game renaming or moving AudioEvent.gd.
 func _coerce_audio_event(id: String, verb: String, data: Variant) -> Resource:
@@ -152,7 +151,7 @@ func _override_sound(id: String, data: Variant) -> bool:
 	if lib == null:
 		return false
 	if not _sound_exists_in_vanilla(id):
-		# Mod-registered ids can't be overridden -- that's what a second
+		# Mod-registered ids can't be overridden; that's what a second
 		# register call would be conceptually, but we reject re-register.
 		# Force mods to revert first.
 		push_warning("[Registry] override('sounds', '%s'): no vanilla AudioLibrary field with that name (register can't be overridden; revert the register first)" % id)
@@ -200,7 +199,7 @@ func _remove_sound(id: String) -> bool:
 		push_warning("[Registry] remove('sounds', '%s'): not registered by a mod" % id)
 		return false
 	# Sounds don't have the items-style override-lives-in-registered dual
-	# storage -- overrides mutate the library directly, not this dict. So
+	# storage; overrides mutate the library directly, not this dict. So
 	# anything in reg is a plain register.
 	reg.erase(id)
 	_registry_registered["sounds"] = reg

--- a/src/registry/traders.gd
+++ b/src/registry/traders.gd
@@ -1,0 +1,364 @@
+## ----- registry/traders.gd -----
+## Section 7: trader_pools + trader_tasks.
+##
+## Two related registries that both mutate trader-adjacent state:
+##
+## - trader_pools: enables an ItemData to appear in a named trader's supply
+##   bucket. Trader.FillTraderBucket() walks LT_Master and filters by
+##   boolean trader flags on each item (itemData.generalist / .doctor /
+##   .gunsmith / .grandma). So "register an item into the Doctor's pool" =
+##   set itemData.doctor = true. Register / remove only -- no override or
+##   patch (entries are single boolean flags, there's nothing to override).
+##
+## - trader_tasks: appends/overrides/patches TaskData entries in a
+##   TraderData.tasks array. Structurally identical to recipes: register
+##   adds, override swaps (requires `replaces`), patch mutates fields on a
+##   TaskData (String handle OR direct TaskData ref).
+##
+## Timing: same as loot/recipes/events. Trader.gd fills its local bucket in
+## _ready() from LT_Master's pre-mutated items and TraderData.tasks. Mods
+## must register during their own _ready() or changes won't propagate into
+## a trader that's already initialized.
+
+const _TRADER_POOL_FLAGS := {
+	"generalist": "generalist",
+	"doctor": "doctor",
+	"gunsmith": "gunsmith",
+	"grandma": "grandma",
+}
+
+# Known TraderData paths. Mods can also pass an absolute res:// path for a
+# custom trader (e.g., one added by another mod via a file-level addition).
+const _TRADER_PATHS := {
+	"Generalist": "res://Traders/Generalist/Generalist.tres",
+	"Doctor": "res://Traders/Doctor/Doctor.tres",
+	"Gunsmith": "res://Traders/Gunsmith/Gunsmith.tres",
+}
+
+# -------- trader_pools --------
+
+func _normalize_trader_flag(trader_name: String) -> String:
+	# Accepts "Generalist", "generalist", "GENERALIST" -> "generalist".
+	# The ItemData flags are lowercased; the TraderData.name fields are
+	# capitalized. trader_pools keys by the flag name.
+	var lower := trader_name.to_lower()
+	if _TRADER_POOL_FLAGS.has(lower):
+		return lower
+	return ""
+
+func _register_trader_pool(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("trader_pools", {})
+	if reg.has(id):
+		push_warning("[Registry] register('trader_pools', '%s'): already registered (pick a unique handle)" % id)
+		return false
+	if not (data is Dictionary):
+		push_warning("[Registry] register('trader_pools', '%s', ...) expects Dictionary {item, trader}, got %s" % [id, typeof(data)])
+		return false
+	var d: Dictionary = data
+	if not d.has("item") or not d.has("trader"):
+		push_warning("[Registry] register('trader_pools', '%s', ...) data dict missing 'item' or 'trader' key" % id)
+		return false
+	var item = d["item"]
+	if not (item is Resource) or not _looks_like_item_data(item):
+		push_warning("[Registry] register('trader_pools', '%s'): item is not an ItemData Resource" % id)
+		return false
+	var trader = d["trader"]
+	if not (trader is String):
+		push_warning("[Registry] register('trader_pools', '%s'): trader must be a String (e.g. 'Generalist')" % id)
+		return false
+	var flag := _normalize_trader_flag(trader)
+	if flag == "":
+		push_warning("[Registry] register('trader_pools', '%s'): unknown trader '%s' (valid: %s)" \
+				% [id, trader, _TRADER_POOL_FLAGS.keys()])
+		return false
+	if not _resource_has_property(item, flag):
+		push_warning("[Registry] register('trader_pools', '%s'): item has no '%s' flag field (not a standard ItemData?)" % [id, flag])
+		return false
+	# Stash the original flag value so remove/revert can restore it. Most
+	# items default to false for a given trader flag, but we don't assume.
+	var original_value = item.get(flag)
+	item.set(flag, true)
+	reg[id] = {
+		"item": item,
+		"trader": trader,
+		"flag": flag,
+		"original": original_value,
+	}
+	_registry_registered["trader_pools"] = reg
+	_log_debug("[Registry] registered trader_pool '%s' (%s item.%s=true, was %s)" \
+			% [id, item.get("file"), flag, original_value])
+	return true
+
+func _remove_trader_pool(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("trader_pools", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('trader_pools', '%s'): not registered by a mod" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var item: Resource = entry["item"]
+	var flag: String = entry["flag"]
+	item.set(flag, entry["original"])
+	reg.erase(id)
+	_registry_registered["trader_pools"] = reg
+	_log_debug("[Registry] removed trader_pool '%s'" % id)
+	return true
+
+# Revert on trader_pools is a straight alias for remove -- there's no
+# override layer. Accept it for API symmetry so mods can call revert
+# uniformly across registries.
+func _revert_trader_pool(id: String) -> bool:
+	return _remove_trader_pool(id)
+
+# -------- trader_tasks --------
+
+var _trader_data_cache: Dictionary = {}  # name -> Resource
+
+func _resolve_trader_data(trader_ref: String) -> Resource:
+	if trader_ref == "":
+		push_warning("[Registry] trader_tasks: empty trader name")
+		return null
+	if _trader_data_cache.has(trader_ref):
+		return _trader_data_cache[trader_ref]
+	var path := trader_ref
+	if _TRADER_PATHS.has(trader_ref):
+		path = _TRADER_PATHS[trader_ref]
+	elif not trader_ref.begins_with("res://"):
+		push_warning("[Registry] trader_tasks: unknown trader '%s' (valid: %s, or pass an absolute res:// path)" \
+				% [trader_ref, _TRADER_PATHS.keys()])
+		return null
+	var res = load(path)
+	if res == null:
+		push_warning("[Registry] trader_tasks: couldn't load TraderData at '%s'" % path)
+		return null
+	if not ("tasks" in res):
+		push_warning("[Registry] trader_tasks: resource at '%s' has no `tasks` array (not a TraderData?)" % path)
+		return null
+	_trader_data_cache[trader_ref] = res
+	return res
+
+# Shape check for TaskData.
+func _looks_like_task_data(res: Resource) -> bool:
+	return _resource_has_property(res, "trader") \
+			and _resource_has_property(res, "deliver") \
+			and _resource_has_property(res, "receive")
+
+# Validates {task, trader} payload. Returns [task, tasks_arr, trader_name]
+# or [null, null, ""] on error.
+func _validate_trader_task(id: String, verb: String, data: Variant) -> Array:
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('trader_tasks', '%s', ...) expects Dictionary {task, trader}, got %s" % [verb, id, typeof(data)])
+		return [null, null, ""]
+	var d: Dictionary = data
+	if not d.has("task") or not d.has("trader"):
+		push_warning("[Registry] %s('trader_tasks', '%s', ...) data dict missing 'task' or 'trader' key" % [verb, id])
+		return [null, null, ""]
+	var task = d["task"]
+	if not (task is Resource) or not _looks_like_task_data(task):
+		push_warning("[Registry] %s('trader_tasks', '%s'): task is not a TaskData Resource" % [verb, id])
+		return [null, null, ""]
+	var trader = d["trader"]
+	if not (trader is String):
+		push_warning("[Registry] %s('trader_tasks', '%s'): trader must be a String" % [verb, id])
+		return [null, null, ""]
+	var trader_res := _resolve_trader_data(trader)
+	if trader_res == null:
+		return [null, null, ""]
+	var arr = trader_res.get("tasks")
+	if not (arr is Array):
+		push_warning("[Registry] %s('trader_tasks', '%s'): %s.tasks is not an Array" % [verb, id, trader])
+		return [null, null, ""]
+	return [task, arr, String(trader)]
+
+func _register_trader_task(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+	if reg.has(id):
+		push_warning("[Registry] register('trader_tasks', '%s'): already registered (pick a unique handle)" % id)
+		return false
+	var parts := _validate_trader_task(id, "register", data)
+	var task = parts[0]
+	var arr = parts[1]
+	var trader: String = parts[2]
+	if task == null or arr == null:
+		return false
+	if not _typed_array_accepts(arr, task):
+		push_warning("[Registry] register('trader_tasks', '%s'): task type doesn't match %s.tasks typed array" % [id, trader])
+		return false
+	if task in arr:
+		push_warning("[Registry] register('trader_tasks', '%s'): task already in %s.tasks; use override to swap" % [id, trader])
+		return false
+	arr.append(task)
+	reg[id] = {"task": task, "trader": trader}
+	_registry_registered["trader_tasks"] = reg
+	_log_debug("[Registry] registered trader_task '%s' (trader=%s, name=%s)" % [id, trader, task.get("name")])
+	return true
+
+func _override_trader_task(id: String, data: Variant) -> bool:
+	var ov: Dictionary = _registry_overridden.get("trader_tasks", {})
+	if ov.has(id):
+		push_warning("[Registry] override('trader_tasks', '%s'): already overridden (revert first)" % id)
+		return false
+	if not (data is Dictionary) or not data.has("replaces"):
+		push_warning("[Registry] override('trader_tasks', '%s', ...) requires {task, trader, replaces: TaskData}" % id)
+		return false
+	var parts := _validate_trader_task(id, "override", data)
+	var new_task = parts[0]
+	var arr = parts[1]
+	var trader: String = parts[2]
+	if new_task == null or arr == null:
+		return false
+	var old_task = data["replaces"]
+	if not (old_task is Resource) or not _looks_like_task_data(old_task):
+		push_warning("[Registry] override('trader_tasks', '%s'): 'replaces' is not a TaskData Resource" % id)
+		return false
+	if not _typed_array_accepts(arr, new_task):
+		push_warning("[Registry] override('trader_tasks', '%s'): task type doesn't match %s.tasks typed array" % [id, trader])
+		return false
+	var idx: int = arr.find(old_task)
+	if idx < 0:
+		push_warning("[Registry] override('trader_tasks', '%s'): 'replaces' not present in %s.tasks" % [id, trader])
+		return false
+	if new_task in arr:
+		push_warning("[Registry] override('trader_tasks', '%s'): new task already in array -- would duplicate" % id)
+		return false
+	arr[idx] = new_task
+	ov[id] = {
+		"task": new_task,
+		"trader": trader,
+		"replaced": old_task,
+		"index": idx,
+	}
+	_registry_overridden["trader_tasks"] = ov
+	var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+	reg[id] = {"task": new_task, "trader": trader}
+	_registry_registered["trader_tasks"] = reg
+	_log_debug("[Registry] overrode trader_task '%s' in %s" % [id, trader])
+	return true
+
+# Resolve a patch target (String handle or TaskData ref) -> [task, key].
+func _resolve_trader_task_patch_target(id: Variant) -> Array:
+	if id is String:
+		var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+		if reg.has(id):
+			return [reg[id]["task"], id]
+		push_warning("[Registry] patch('trader_tasks', '%s'): no registered handle with that id (register first, or pass a TaskData Resource ref directly)" % id)
+		return [null, null]
+	if id is Resource and _looks_like_task_data(id):
+		return [id, "ref:%d" % id.get_instance_id()]
+	push_warning("[Registry] patch('trader_tasks', ...): id must be a String handle or a TaskData Resource")
+	return [null, null]
+
+func _patch_trader_task(id: Variant, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('trader_tasks', ...): empty fields dict is a no-op")
+		return false
+	var resolved := _resolve_trader_task_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	var patched: Dictionary = _registry_patched.get("trader_tasks", {})
+	var stash: Dictionary = patched.get(key, {})
+	for field in fields.keys():
+		var fname := String(field)
+		if not _resource_has_property(target, fname):
+			push_warning("[Registry] patch('trader_tasks'): field '%s' doesn't exist on TaskData" % fname)
+			continue
+		if not stash.has(fname):
+			stash[fname] = target.get(fname)
+		target.set(fname, fields[field])
+	patched[key] = stash
+	_registry_patched["trader_tasks"] = patched
+	_log_debug("[Registry] patched trader_task (key=%s) fields %s" % [key, fields.keys()])
+	return true
+
+func _remove_trader_task(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('trader_tasks', '%s'): not a mod registration" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("trader_tasks", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('trader_tasks', '%s'): entry is an override, use revert instead" % id)
+		return false
+	var entry: Dictionary = reg[id]
+	var trader: String = entry["trader"]
+	var task: Resource = entry["task"]
+	var trader_res := _resolve_trader_data(trader)
+	if trader_res != null:
+		var arr = trader_res.get("tasks")
+		if arr is Array:
+			var idx: int = arr.find(task)
+			if idx >= 0:
+				arr.remove_at(idx)
+			else:
+				push_warning("[Registry] remove('trader_tasks', '%s'): task not found in %s.tasks; tracking cleared" % [id, trader])
+	reg.erase(id)
+	_registry_registered["trader_tasks"] = reg
+	_log_debug("[Registry] removed trader_task '%s'" % id)
+	return true
+
+func _revert_trader_task(id: Variant, fields: Array) -> bool:
+	var did_something := false
+	var ov: Dictionary = _registry_overridden.get("trader_tasks", {})
+	var patched: Dictionary = _registry_patched.get("trader_tasks", {})
+	var patch_key = null
+	var patch_target: Resource = null
+	if id is String:
+		patch_key = id
+		var reg: Dictionary = _registry_registered.get("trader_tasks", {})
+		if reg.has(id):
+			patch_target = reg[id]["task"]
+	elif id is Resource and _looks_like_task_data(id):
+		patch_key = "ref:%d" % id.get_instance_id()
+		patch_target = id
+	if fields.is_empty():
+		if patch_key != null and patched.has(patch_key):
+			if patch_target != null:
+				var stash: Dictionary = patched[patch_key]
+				for fname in stash.keys():
+					patch_target.set(fname, stash[fname])
+			patched.erase(patch_key)
+			_registry_patched["trader_tasks"] = patched
+			did_something = true
+		if id is String and ov.has(id):
+			var entry: Dictionary = ov[id]
+			var trader_res := _resolve_trader_data(entry["trader"])
+			if trader_res != null:
+				var arr = trader_res.get("tasks")
+				if arr is Array:
+					var current_idx: int = arr.find(entry["task"])
+					if current_idx >= 0:
+						arr[current_idx] = entry["replaced"]
+					else:
+						push_warning("[Registry] revert('trader_tasks', '%s'): override's task missing from %s.tasks, appending original at end" % [id, entry["trader"]])
+						arr.append(entry["replaced"])
+			ov.erase(id)
+			_registry_overridden["trader_tasks"] = ov
+			var reg2: Dictionary = _registry_registered.get("trader_tasks", {})
+			reg2.erase(id)
+			_registry_registered["trader_tasks"] = reg2
+			did_something = true
+		if not did_something:
+			push_warning("[Registry] revert('trader_tasks'): nothing to revert for that id")
+		return did_something
+	if patch_key == null or not patched.has(patch_key):
+		push_warning("[Registry] revert('trader_tasks'): no patches found for that id")
+		return false
+	if patch_target == null:
+		push_warning("[Registry] revert('trader_tasks'): patch target no longer resolves")
+		return false
+	var stash2: Dictionary = patched[patch_key]
+	for field in fields:
+		var fname := String(field)
+		if not stash2.has(fname):
+			push_warning("[Registry] revert('trader_tasks'): field '%s' wasn't patched" % fname)
+			continue
+		patch_target.set(fname, stash2[fname])
+		stash2.erase(fname)
+		did_something = true
+	if stash2.is_empty():
+		patched.erase(patch_key)
+	else:
+		patched[patch_key] = stash2
+	_registry_patched["trader_tasks"] = patched
+	return did_something

--- a/src/registry/traders.gd
+++ b/src/registry/traders.gd
@@ -1,13 +1,11 @@
 ## ----- registry/traders.gd -----
-## Section 7: trader_pools + trader_tasks.
-##
 ## Two related registries that both mutate trader-adjacent state:
 ##
 ## - trader_pools: enables an ItemData to appear in a named trader's supply
 ##   bucket. Trader.FillTraderBucket() walks LT_Master and filters by
 ##   boolean trader flags on each item (itemData.generalist / .doctor /
 ##   .gunsmith / .grandma). So "register an item into the Doctor's pool" =
-##   set itemData.doctor = true. Register / remove only -- no override or
+##   set itemData.doctor = true. Register / remove only; no override or
 ##   patch (entries are single boolean flags, there's nothing to override).
 ##
 ## - trader_tasks: appends/overrides/patches TaskData entries in a
@@ -103,7 +101,7 @@ func _remove_trader_pool(id: String) -> bool:
 	_log_debug("[Registry] removed trader_pool '%s'" % id)
 	return true
 
-# Revert on trader_pools is a straight alias for remove -- there's no
+# Revert on trader_pools is a straight alias for remove; there's no
 # override layer. Accept it for API symmetry so mods can call revert
 # uniformly across registries.
 func _revert_trader_pool(id: String) -> bool:
@@ -218,7 +216,7 @@ func _override_trader_task(id: String, data: Variant) -> bool:
 		push_warning("[Registry] override('trader_tasks', '%s'): 'replaces' not present in %s.tasks" % [id, trader])
 		return false
 	if new_task in arr:
-		push_warning("[Registry] override('trader_tasks', '%s'): new task already in array -- would duplicate" % id)
+		push_warning("[Registry] override('trader_tasks', '%s'): new task already in array; would duplicate" % id)
 		return false
 	arr[idx] = new_task
 	ov[id] = {

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -741,7 +741,9 @@ func _rtv_inject_aispawner_registry(indent: String) -> String:
 	out += I1 + "var overrides: Dictionary = Engine.get_meta(\"_rtv_ai_overrides\", {})\n"
 	out += I1 + "if overrides.is_empty():\n"
 	out += I1 + I1 + "return vanilla\n"
-	out += I1 + "var key := Zone.keys()[z]\n"
+	# Zone.keys() returns Array (untyped), so `:=` can't infer. Type
+	# explicitly for strict-mode GDScript parsers.
+	out += I1 + "var key: String = Zone.keys()[z]\n"
 	out += I1 + "if overrides.has(key):\n"
 	out += I1 + I1 + "return overrides[key]\n"
 	out += I1 + "return vanilla\n"

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -366,13 +366,29 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 		_log_info("[Autofix] %s: %d bodyless, %d @tool, %d @onready, %d @export, %d base()->super -- legacy syntax normalized" \
 				% [parsed.get("filename", "?"), autofix["bodyless"], autofix["tool"], autofix["onready"], autofix["export"], autofix.get("base", 0)])
 
-	# Database-specific transform: convert `const X = preload("...")` lines
-	# into a _rtv_vanilla_scenes dictionary. This makes Database.get(name)
-	# go through _get() (which checks mod overrides first) instead of
-	# resolving via direct const lookup -- mods can then override the
-	# scene returned for any vanilla name.
-	if parsed.get("filename", "") == "Database.gd":
-		src = _rtv_rewrite_database_constants(src)
+	# Per-script declaration-level transforms. Both cases make otherwise-
+	# compile-time-immutable declarations runtime-mutable so the registry
+	# can swap them under the hood.
+	if rename_prefix == "_rtv_vanilla_":
+		var fn: String = parsed.get("filename", "")
+		# Database.gd: convert `const X = preload("...")` -> _rtv_vanilla_scenes
+		# dict entries so Database.get(name) flows through _get() and sees mod
+		# overrides instead of resolving via direct const lookup.
+		if fn == "Database.gd":
+			src = _rtv_rewrite_database_constants(src)
+		# Loader.gd: convert `const shelters = [...]` -> var so the registry
+		# can append mod shelter names. Scene-path consts (const Cabin = "..."
+		# etc.) stay consts because LoadScene references them directly inside
+		# its body; we inject a mod-lookup prelude into LoadScene instead.
+		elif fn == "Loader.gd":
+			src = _rtv_rewrite_loader_shelters(src)
+		# AISpawner.gd: the vanilla if-elif that maps Zone -> agent is rewritten
+		# so each `agent = <name>` becomes `agent = _rtv_resolve_ai_type(zone,
+		# <name>)`. The helper (appended as part of registry injection) checks
+		# the override dict and returns that or the vanilla scene. Lets mods
+		# swap the agent spawned in any vanilla zone without touching _ready.
+		elif fn == "AISpawner.gd":
+			src = _rtv_rewrite_aispawner_agent_assignments(src)
 
 	# Pass 1: rename top-level "func <name>(" to "func _rtv_vanilla_<name>("
 	# AND rewrite bare super() calls inside that body to super.<name>().
@@ -416,6 +432,14 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 			continue
 		lines[i] = _rewrite_bare_super(line, current_hooked_method)
 
+	# Pass 1.5: function-body prelude injection. Some registries need a
+	# check at the TOP of a specific vanilla function body (e.g., Loader's
+	# LoadScene needs to consult _rtv_mod_scene_paths before the if-elif
+	# chain fires). The function was just renamed to _rtv_vanilla_<Name>,
+	# so we inject right after its signature line.
+	if rename_prefix == "_rtv_vanilla_":
+		lines = _rtv_apply_prelude_injections(parsed.get("filename", ""), lines, rename_prefix)
+
 	# Pass 2: append dispatch wrappers at EOF. Match the source's indent
 	# style -- GDScript rejects tab/space mixing in a single file. IXP uses
 	# 4-space indent; vanilla RTV uses tabs.
@@ -442,6 +466,14 @@ func _rtv_registry_injection(filename: String, indent: String) -> String:
 	match filename:
 		"Database.gd":
 			var inj := _rtv_inject_database_registry(indent)
+			_log_info("[RTVCodegen] Injected registry into %s (%d chars)" % [filename, inj.length()])
+			return inj
+		"Loader.gd":
+			var inj := _rtv_inject_loader_registry(indent)
+			_log_info("[RTVCodegen] Injected registry into %s (%d chars)" % [filename, inj.length()])
+			return inj
+		"AISpawner.gd":
+			var inj := _rtv_inject_aispawner_registry(indent)
 			_log_info("[RTVCodegen] Injected registry into %s (%d chars)" % [filename, inj.length()])
 			return inj
 		_:
@@ -520,6 +552,200 @@ func _rtv_rewrite_database_constants(source: String) -> String:
 	var before := out_lines.slice(0, insert_at)
 	var after := out_lines.slice(insert_at)
 	return "\n".join(before) + "\n" + dict_block + "\n" + "\n".join(after)
+
+# Loader.gd transform: `const shelters = [...]` -> `var shelters = [...]`.
+# GDScript consts can't be mutated, but the registry needs to append mod
+# shelter names at runtime. Only the one shelters line is affected; the
+# scene-path consts (const Cabin = "...", etc.) stay consts because
+# LoadScene's body references them by name directly. The prelude injection
+# handles mod scene paths without touching those consts.
+#
+# Also stashes a snapshot var `_rtv_vanilla_shelters` so the registry can
+# compute "what's vanilla vs mod" for integrity checks / revert.
+func _rtv_rewrite_loader_shelters(source: String) -> String:
+	var lines: PackedStringArray = source.split("\n")
+	var re := RegEx.new()
+	# Match: optional leading whitespace (shouldn't happen at top level but
+	# tolerate), "const shelters" followed by the rest of the declaration.
+	re.compile('^(\\s*)const\\s+shelters\\s*(=.*)$')
+	var changed := false
+	for i in lines.size():
+		var line: String = lines[i]
+		var m := re.search(line)
+		if m == null:
+			continue
+		lines[i] = m.get_string(1) + "var shelters " + m.get_string(2)
+		changed = true
+	if not changed:
+		return source
+	return "\n".join(lines)
+
+# Function-body prelude injection dispatcher. Returns lines array (may be
+# unchanged). Called after the rename pass -- the target function has
+# already been renamed to _rtv_vanilla_<Name>, so we look for the renamed
+# signature.
+func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, rename_prefix: String) -> PackedStringArray:
+	match filename:
+		"Loader.gd":
+			return _rtv_inject_prelude(lines, rename_prefix + "LoadScene", _rtv_loader_loadscene_prelude())
+		"FishPool.gd":
+			return _rtv_inject_prelude(lines, rename_prefix + "_ready", _rtv_fishpool_ready_prelude())
+		_:
+			return lines
+
+# Finds `func <func_name>(` at top level and inserts `prelude_lines` right
+# after its signature (before any body code). The function was already
+# renamed by the rewriter's pass 1, so callers pass the renamed name.
+# If the function has multiple blank lines at the top of its body, the
+# prelude slots in before them.
+func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_lines: PackedStringArray) -> PackedStringArray:
+	var needle := "func " + func_name + "("
+	var target := -1
+	for i in lines.size():
+		var line: String = lines[i]
+		if line.begins_with(needle):
+			target = i
+			break
+	if target < 0:
+		_log_info("[RTVCodegen] prelude injection: func %s not found (was it not parsed as hookable?)" % func_name)
+		return lines
+	var out: Array = []
+	for i in lines.size():
+		out.append(lines[i])
+		if i == target:
+			for pl in prelude_lines:
+				out.append(pl)
+	var result := PackedStringArray()
+	result.resize(out.size())
+	for k in out.size():
+		result[k] = out[k]
+	return result
+
+# The LoadScene prelude. Checks the mod + override scene-path dicts at
+# the top of the function; on match, sets `scenePath` and applies the
+# mod's gameData flag overrides. Does NOT early-return.
+#
+# Design rationale: vanilla LoadScene's structure is:
+#     FadeInLoading(); gameData.freeze = true
+#     <label visibility setup>
+#     if scene == "Cabin": scenePath = Cabin; <flags>
+#     elif ...
+#     <tail> await timer; get_tree().change_scene_to_file(scenePath)
+#
+# We insert right after the func signature, so our prelude runs BEFORE
+# the fade/label setup AND the if-elif. If the scene name is a mod
+# registration, we set scenePath + flags here. The if-elif then falls
+# through with no match (mod names aren't vanilla), and the tail code
+# picks up our scenePath for change_scene_to_file. Vanilla fade/label
+# setup still runs (harmless side-effects we want).
+#
+# This means mod scene_paths registrations:
+#   - reuse vanilla's full loading flow (fade, label, timer, scene change)
+#   - can override vanilla scenes (override takes precedence in the check)
+#   - don't need to replicate any vanilla scene-change logic
+func _rtv_loader_loadscene_prelude() -> PackedStringArray:
+	var p := PackedStringArray()
+	p.append("\t# --- Metro mod loader: scene_paths registry prelude ---")
+	p.append("\tvar _rtv_scene_entry: Dictionary = {}")
+	p.append("\tif _rtv_override_scene_paths.has(scene):")
+	p.append("\t\t_rtv_scene_entry = _rtv_override_scene_paths[scene]")
+	p.append("\telif _rtv_mod_scene_paths.has(scene):")
+	p.append("\t\t_rtv_scene_entry = _rtv_mod_scene_paths[scene]")
+	p.append("\tif not _rtv_scene_entry.is_empty():")
+	p.append("\t\tscenePath = _rtv_scene_entry.get(\"path\", \"\")")
+	# Apply gameData flags if the mod specified them. Defaults favor a
+	# generic non-shelter non-tutorial non-permadeath zone.
+	p.append("\t\tgameData.menu = _rtv_scene_entry.get(\"menu\", false)")
+	p.append("\t\tgameData.shelter = _rtv_scene_entry.get(\"shelter\", false)")
+	p.append("\t\tgameData.permadeath = _rtv_scene_entry.get(\"permadeath\", false)")
+	p.append("\t\tgameData.tutorial = _rtv_scene_entry.get(\"tutorial\", false)")
+	p.append("\t# Fall through: vanilla if-elif won't match mod names; the tail")
+	p.append("\t# runs change_scene_to_file(scenePath) with our path set above.")
+	return p
+
+func _rtv_inject_loader_registry(indent: String) -> String:
+	# Loader.gd registry appendix. Adds the two mod-scene-path dicts and a
+	# snapshot of the vanilla shelters list for integrity/revert.
+	#
+	# Note: _rtv_vanilla_shelters is captured at @onready time from the
+	# shelters var (which the const->var rewrite left populated with the
+	# vanilla list). The registry can diff shelters against this snapshot
+	# to tell vanilla entries apart from mod additions.
+	var I1 := indent
+	return "\n\n# --- Metro mod loader: Loader registry state ---\n" \
+		+ "var _rtv_mod_scene_paths: Dictionary = {}\n" \
+		+ "var _rtv_override_scene_paths: Dictionary = {}\n" \
+		+ "@onready var _rtv_vanilla_shelters: Array = shelters.duplicate()\n"
+
+# AISpawner.gd transform: rewrite each `agent = <name>` inside _ready() so
+# the assignment goes through the _rtv_resolve_ai_type helper (defined in
+# the registry appendix). That helper reads Engine.get_meta(
+# "_rtv_ai_overrides", {}) to decide between the vanilla scene and any
+# mod-registered replacement for the current zone.
+#
+# Pattern matched: the exact 5-line block `if zone == Zone.Foo: agent = bar`
+# -- we search for leading-whitespace + `agent =` and rewrite it. Only
+# vanilla fields (bandit/guard/military/punisher) should trigger this; any
+# other `agent = <literal>` outside those cases is left alone.
+func _rtv_rewrite_aispawner_agent_assignments(source: String) -> String:
+	var lines: PackedStringArray = source.split("\n")
+	# Regex: optional indent, "agent" "=" then an identifier (the vanilla
+	# preloaded name) with optional trailing comment/whitespace.
+	var re := RegEx.new()
+	re.compile('^(\\s*)agent\\s*=\\s*(\\w+)\\s*(#.*)?$')
+	for i in lines.size():
+		var line: String = lines[i]
+		var m := re.search(line)
+		if m == null:
+			continue
+		var indent := m.get_string(1)
+		var name := m.get_string(2)
+		# Leave numeric / keyword RHS alone (won't happen in vanilla but be safe).
+		if name in ["true", "false", "null"]:
+			continue
+		lines[i] = "%sagent = _rtv_resolve_ai_type(zone, %s)" % [indent, name]
+	return "\n".join(lines)
+
+# FishPool._ready() prelude: appends mod-registered species to the local
+# `species: Array[PackedScene]` var BEFORE vanilla's random-spawn loop
+# picks from it. The registry stores a flat list in Engine meta; each
+# FishPool instance filters by its own node name (or "all" as a wildcard).
+#
+# Dedupe: if a mod registers the same scene twice (or another mod does too),
+# we don't re-append. Keeps the random-pick weight stable when the same
+# scene would otherwise multiply.
+func _rtv_fishpool_ready_prelude() -> PackedStringArray:
+	var p := PackedStringArray()
+	p.append("\t# --- Metro mod loader: fish_species registry prelude ---")
+	p.append("\tvar _rtv_mod_fish: Array = Engine.get_meta(\"_rtv_fish_species\", [])")
+	p.append("\tfor _rtv_fe in _rtv_mod_fish:")
+	p.append("\t\tif _rtv_fe.pool_id == \"all\" or _rtv_fe.pool_id == name:")
+	p.append("\t\t\tif not (_rtv_fe.scene in species):")
+	p.append("\t\t\t\tspecies.append(_rtv_fe.scene)")
+	return p
+
+func _rtv_inject_aispawner_registry(indent: String) -> String:
+	# AISpawner.gd registry appendix. Adds the resolver helper used by the
+	# rewritten `agent = _rtv_resolve_ai_type(zone, vanilla)` assignments.
+	# The override lookup goes through Engine metadata rather than node
+	# instance state because AISpawner is a per-scene Node3D -- there are
+	# multiple instances, and mods write to one shared registry that every
+	# spawner reads on _ready.
+	#
+	# Zone keys are the string form of the Zone enum (e.g. "Area05"). The
+	# resolver uses Zone.keys()[zone_int] to convert the enum value to its
+	# declared name, matching what the registry stores.
+	var I1 := indent
+	var out := "\n\n# --- Metro mod loader: AI type override resolver ---\n"
+	out += "func _rtv_resolve_ai_type(z: int, vanilla: Variant) -> Variant:\n"
+	out += I1 + "var overrides: Dictionary = Engine.get_meta(\"_rtv_ai_overrides\", {})\n"
+	out += I1 + "if overrides.is_empty():\n"
+	out += I1 + I1 + "return vanilla\n"
+	out += I1 + "var key := Zone.keys()[z]\n"
+	out += I1 + "if overrides.has(key):\n"
+	out += I1 + I1 + "return overrides[key]\n"
+	out += I1 + "return vanilla\n"
+	return out
 
 # Rewrite bare `super(` / `super (` in a line to `super.<method>(`. Preserves
 # the rest of the line verbatim. Skips `super.<something>(` (already explicit),


### PR DESCRIPTION
Registry system: 12 new kinds, 4 new verbs per kind, full docs

Expands the registry from scenes-only to 15 registered content kinds covering almost every vanilla
data store mods currently have to hack around. Adds consistent
register/override/patch/remove/revert/get_entry verbs (where meaningful) with per-kind validation and
rollback tracking.

  Bug fixes

- AISpawner rewriter: var key := Zone.keys()[z] changed to var key: String = ... (strict-mode GDScript
   couldn't infer the Array element type, parse failed at load).
- hook_pack.gd sibling reads: switched from VFS to direct ZIPReader on each mod archive. VFS was
  routing through a previous-session hook pack still mounted at boot, so mod source edits weren't taking
   effect between sessions until the stale pack was cleaned up.
- scenes override: now rejects second override instead of silently replacing (was the only registry
  that didn't, caused invisible cross-mod conflicts).

  Docs
 - docs/wiki/Registry.md full wiki page: opt-in gate, verb matrix, per-kind minimal example for every
   supported verb, per-kind conflict notes, troubleshooting section.
- Sidebar link added.
