### PR TITLE
fix: lock profile schema + explicit import manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Delete `override.cfg` and `modloader.gd` from the game folder. The `mods/` folde
 - Conflict log (Developer Mode only): `%APPDATA%\Road to Vostok\modloader_conflicts.txt`
 - Hook pack cache: `%APPDATA%\Road to Vostok\modloader_hooks\` (regenerated on each launch)
 
+Full breakdown of every config file, profile key format, sentinel files, and what's safe to delete: [Config-Files wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Config-Files).
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/docs/wiki/Config-Files.md
+++ b/docs/wiki/Config-Files.md
@@ -1,0 +1,206 @@
+# Config Files
+
+Where your mod setup lives on disk. This page answers "what's enabled?", "how do I back up my setup?", "what's safe to delete?", and "how do I recover from a bad state?".
+
+## Where to find them
+
+Godot's `user://` paths resolve to a per-user state dir. Road to Vostok uses a custom project name for this dir, so the path is:
+
+| Platform | Path |
+|---|---|
+| Windows | `%APPDATA%\Road to Vostok\` |
+| Linux | `~/.local/share/Road to Vostok/` |
+| macOS | `~/Library/Application Support/Road to Vostok/` |
+
+Paste the Windows path into File Explorer's address bar to jump there directly.
+
+Three sentinel files live in the **game's install directory** (next to the `.exe`), not under `user://`. Those are covered separately below.
+
+## `mod_config.cfg` -- your profiles and settings
+
+This is the user-facing config. The pre-launch UI reads and writes it. Plain INI, safe to inspect or edit by hand.
+
+### Shape
+
+```ini
+[settings]
+active_profile="Default"
+developer_mode=false
+
+[profile.Default.enabled]
+rtvcoop@1.2.3=true
+immersivexp@0.4.1=true
+customhud@2.0.0=false
+zip:SomeMod.vmz=true
+
+[profile.Default.priority]
+rtvcoop@1.2.3=100
+immersivexp@0.4.1=50
+customhud@2.0.0=0
+
+[profile.MyHardcoreBuild.enabled]
+rtvcoop@1.2.3=true
+harsherweather@1.0.0=true
+
+[profile.MyHardcoreBuild.priority]
+rtvcoop@1.2.3=100
+harsherweather@1.0.0=200
+```
+
+### Sections
+
+| Section | Meaning |
+|---|---|
+| `[settings]` | `active_profile` -- currently-selected profile. `developer_mode` -- enables dev-only UI (folder mods, conflict report, extra diagnostics). |
+| `[profile.<name>.enabled]` | `profile_key -> true\|false`. The list you see checked in the UI under that profile. One section per named profile. |
+| `[profile.<name>.priority]` | `profile_key -> int` in `[-999, 999]`. Higher number loads later -> wins file conflicts. |
+
+### Profile keys
+
+The left-hand identifier for each mod. Two shapes:
+
+- `<mod_id>@<version>` -- mods whose `mod.txt` declares `[mod] id=...`. Stable across `.vmz` renames.
+- `zip:<file_name>` -- mods without a declared `mod_id`. Identity is the archive filename; renaming the `.vmz` orphans the profile entry.
+
+See [Mod-Format](Mod-Format) for mod.txt schema. See [Profile-Format](Profile-Format) for the shareable export payload.
+
+### `active_profile` special values
+
+- `"Default"` -- the profile materialized on first launch. Persistent like every other profile.
+- `"__vanilla__"` -- the **Reset to Vanilla** sentinel. Loads with every mod off, without touching your stored profiles. Clicking any non-Vanilla profile in the dropdown switches back.
+
+### Common tasks
+
+**See what's enabled in your current profile**
+```bash
+# Windows (PowerShell)
+notepad "$env:APPDATA\Road to Vostok\mod_config.cfg"
+
+# Linux
+${EDITOR:-nano} "$HOME/.local/share/Road to Vostok/mod_config.cfg"
+```
+Find the `[profile.<active>.enabled]` section.
+
+**Back up / restore your setup**
+Copy `mod_config.cfg` somewhere safe. That one file contains all profiles and settings. Restoring: paste it back while the game isn't running.
+
+**Copy your setup to another install**
+Two ways:
+1. **Full config copy** -- copy `mod_config.cfg` and paste into the same path on the other machine. Carries every profile + settings.
+2. **Shareable profile payload** -- in-game, open the launcher, click **Share** on the profile, copy the `MTRPRF1....` string, paste into Discord / whatever, recipient clicks **Import** and pastes. Carries only that one profile. See [Profile-Format](Profile-Format) for the wire format.
+
+**Reset one profile to empty**
+Delete its two sections (`[profile.<name>.enabled]` and `[profile.<name>.priority]`). Keep your other profiles.
+
+**Reset everything to fresh-install state**
+Delete `mod_config.cfg`. Launcher materializes a new `Default` profile with every installed mod enabled on next launch.
+
+## `mod_pass_state.cfg` -- boot state (implementation detail)
+
+Tracks what modloader mounted last session so it can resume cleanly at static-init next session. Written by Pass 1 and the post-activation hook-pack persist step; read at boot before any archive mount.
+
+You generally shouldn't touch this file. It's regenerated each session. But if you want to understand it:
+
+| Key | Meaning |
+|---|---|
+| `archive_paths` | The `.vmz`/`.zip`/`.pck` paths that were mounted last session, in load order. |
+| `modloader_version` | The modloader version that wrote this state. Mismatch with current = state gets wiped. |
+| `exe_mtime` | Game `.exe` modification time at write. Change = hook cache gets wiped (vanilla scripts may have moved). |
+| `hook_pack_path` | `user://modloader_hooks/framework_pack_<timestamp>.zip` path to mount at static-init. |
+| `hook_pack_wrapped_paths` | List of `res://Scripts/<Name>.gd` paths in the pack; drives which scripts get `CACHE_MODE_IGNORE` preempt. |
+| `restart_count` | Pass-2-restart counter. Max 2; resets after a clean boot. Prevents infinite restart loops. |
+| `mods_hash` | Content hash of the enabled modlist. Unchanged hash + matching state = skip hook pack regeneration. |
+
+**Safe to delete.** Next launch rebuilds it. You'll pay a cold-boot cost (regenerate hook pack).
+
+## `override.cfg` -- Godot's autoload manifest
+
+This file lives in the **game's install directory** (next to the `.exe`), not `user://`. Godot reads it at engine startup to override `project.godot` autoload entries.
+
+Modloader writes it during Pass 1 and restores it to a clean single-entry state after Pass 2 completes. Shape during active mod session:
+
+```ini
+[autoload_prepend]
+SomeModEarly="*res://SomeMod/Early.gd"
+ModLoader="*res://modloader.gd"
+
+[autoload]
+SomeModRegular="*res://SomeMod/Main.gd"
+```
+
+Clean state (no mods queued):
+```ini
+[autoload_prepend]
+ModLoader="*res://modloader.gd"
+
+[autoload]
+```
+
+`[autoload_prepend]` entries load **before** the game's built-in autoloads. Modloader is always the **last** entry in `[autoload_prepend]` because Godot loads in reverse order (last listed = first loaded). See [Architecture](Architecture).
+
+**Editing this file by hand is risky.** If you corrupt it, the game fails to load autoloads and boots to a black screen. If that happens, delete it -- Godot will boot vanilla with no autoloads; then launch through Steam / your usual entry point and modloader will regenerate a clean version.
+
+## Sentinel files -- escape hatches
+
+These live in the **game's install directory** (next to the `.exe`), not `user://`. Create them as empty files to trigger behavior; delete them to revert.
+
+| File | Effect |
+|---|---|
+| `modloader_disabled` | Full bypass. Modloader's static-init exits early on detection; game boots 100% vanilla. No mods mount, no hook pack, nothing. Use when modloader itself is broken or you want to confirm a problem is mod-related. |
+| `modloader_safe_mode` | Boots modloader + the UI, but skips archive mount + hook pack. Lets you change profiles / disable a bad mod without loading it. Useful when a mod is crashing at autoload time. |
+
+On Windows: right-click the game folder -> New -> Text Document -> rename to `modloader_disabled` (no extension). Or run `echo. > modloader_disabled` in `cmd`.
+
+See [Stability-Canaries](Stability-Canaries) for the full crash-recovery + sentinel system.
+
+## Generated files -- safe to delete
+
+Everything under `user://modloader_hooks/` is regenerated on demand:
+
+| Path | Contents |
+|---|---|
+| `user://modloader_hooks/framework_pack_<timestamp>.zip` | The generated hook pack. Mounted at static-init. Regenerated by Pass 1 when mod state changes. |
+| `user://modloader_hooks/vanilla/` | Cached detokenized vanilla source, keyed by exe mtime. Speeds up subsequent hook-pack generation. |
+| `user://vmz_mount_cache/` | `.vmz -> .zip` copies so Godot's `load_resource_pack` can mount them. |
+| `user://modloader_early/` | Extracted copies of `!`-prefixed early-autoload scripts that live inside archives. |
+| `user://modloader_heartbeat.txt` | Crash-detection sentinel. Written each launch, deleted at clean boot. Presence on next launch = previous session crashed. |
+| `user://modloader_pass2_dirty` | Pass-2-in-progress marker. Presence on next launch = Pass 2 was interrupted mid-execution (crash, force-quit). Next launch wipes state and retries. |
+| `user://modloader_conflicts.txt` | Developer-mode only. Dumps the conflict report (which mods claim the same `res://` paths). |
+
+**Deleting any of these is safe.** Next launch regenerates whatever it needs. The "cost" is a slower cold boot because the hook pack has to rebuild.
+
+**When to delete them:**
+- Mod updates aren't taking effect -> delete the `framework_pack_*.zip`. (The 3.0.0 stale-pack bug is fixed in 3.0.1, but manual deletion is a safe workaround.)
+- Weird boot behavior after a game update -> delete the whole `user://modloader_hooks/` directory to force full regen.
+- Suspect cached state corruption -> delete `user://mod_pass_state.cfg`.
+
+## Frequently-asked
+
+**Q: Where is the list of mods I have enabled?**  
+A: `mod_config.cfg` -> section `[profile.<active_profile>.enabled]`. The name of your active profile is in `[settings] active_profile`. `true` = enabled, `false` = disabled.
+
+**Q: I edited `mod_config.cfg` by hand but the change didn't apply.**  
+A: Modloader reads it at launch and overwrites it on exit. Edit while the game is closed.
+
+**Q: I want to enable a mod without launching the UI.**  
+A: Add a line under `[profile.<active>.enabled]`: `<profile_key>=true`. Profile key is `<mod_id>@<version>` from the mod's `mod.txt`, or `zip:<filename>` if no `mod_id` is declared. Also add it to `[profile.<active>.priority]` with a value (0 if you don't care).
+
+**Q: How do I make modloader stop running entirely?**  
+A: Create a file named `modloader_disabled` (no extension) in the game's install directory.
+
+**Q: Everything broke after an update. How do I reset?**  
+A: 
+1. Delete `mod_config.cfg` (resets the UI / profiles to fresh-install state).
+2. Delete `user://mod_pass_state.cfg` (forces rebuild of boot state).
+3. Delete `user://modloader_hooks/` (forces hook pack regeneration).
+4. If the game won't launch at all, create `modloader_disabled` in the install dir, launch vanilla, then remove the sentinel and relaunch. Modloader rebuilds from scratch.
+
+**Q: What's the difference between the `user://` location and the game install dir?**  
+A: `user://` is per-user state (your profiles, generated caches) -- preserved across game updates. The game install dir is where the `.exe` + `.pck` live -- overwritten on game update. Sentinel files and `override.cfg` live there because they need to be visible to Godot before `user://` is even resolved.
+
+## Related
+
+- [Mod-Format](Mod-Format) -- `mod.txt` schema (what each mod declares)
+- [Profile-Format](Profile-Format) -- the shareable `MTRPRF1....` export payload
+- [Architecture](Architecture) -- two-pass boot flow, `override.cfg` lifecycle
+- [Stability-Canaries](Stability-Canaries) -- crash recovery, safe mode, sentinel files

--- a/docs/wiki/Config-Files.md
+++ b/docs/wiki/Config-Files.md
@@ -24,28 +24,38 @@ This is the user-facing config. The pre-launch UI reads and writes it. Plain INI
 
 ```ini
 [settings]
+
+developer_mode=true
 active_profile="Default"
-developer_mode=false
 
 [profile.Default.enabled]
-rtvcoop@1.2.3=true
-immersivexp@0.4.1=true
-customhud@2.0.0=false
-zip:SomeMod.vmz=true
+
+doinkoink-mcm@2.6.3=true
+rtv-coop@5.0.0=true
+item-spawner-ce@1.2.1=true
+immersive-xp@3.0.2=false
+xp-skills-system@2.5.6=true
 
 [profile.Default.priority]
-rtvcoop@1.2.3=100
-immersivexp@0.4.1=50
-customhud@2.0.0=0
+
+doinkoink-mcm@2.6.3=-100
+rtv-coop@5.0.0=10
+item-spawner-ce@1.2.1=1
+immersive-xp@3.0.2=0
+xp-skills-system@2.5.6=0
 
 [profile.MyHardcoreBuild.enabled]
-rtvcoop@1.2.3=true
-harsherweather@1.0.0=true
+
+rtv-coop@5.0.0=true
+harsher-weather@1.0.0=true
 
 [profile.MyHardcoreBuild.priority]
-rtvcoop@1.2.3=100
-harsherweather@1.0.0=200
+
+rtv-coop@5.0.0=10
+harsher-weather@1.0.0=200
 ```
+
+Godot's `ConfigFile` writes a blank line after every section header, quotes String values (like `active_profile="Default"`), and emits bools/ints unquoted. Don't hand-edit the quotes -- the parser is strict about them.
 
 ### Sections
 
@@ -59,8 +69,8 @@ harsherweather@1.0.0=200
 
 The left-hand identifier for each mod. Two shapes:
 
-- `<mod_id>@<version>` -- mods whose `mod.txt` declares `[mod] id=...`. Stable across `.vmz` renames.
-- `zip:<file_name>` -- mods without a declared `mod_id`. Identity is the archive filename; renaming the `.vmz` orphans the profile entry.
+- `<mod_id>@<version>` -- mods whose `mod.txt` declares `[mod] id=...`. This is the normal case; every well-formed mod has one. Stable across `.vmz` renames. The version segment may be empty (`scantest_clean@=false`) if `mod.txt` has an `id` but no `version`.
+- `zip:<file_name>` -- fallback for mods without a declared `mod_id`. Identity is the archive filename; renaming the `.vmz` orphans the profile entry. Rare -- almost every mod in circulation has a proper `mod.txt`.
 
 See [Mod-Format](Mod-Format) for mod.txt schema. See [Profile-Format](Profile-Format) for the shareable export payload.
 
@@ -101,15 +111,33 @@ Tracks what modloader mounted last session so it can resume cleanly at static-in
 
 You generally shouldn't touch this file. It's regenerated each session. But if you want to understand it:
 
+```ini
+[state]
+
+restart_count=0
+mods_hash="d90eae97b1868a4e9051f17ced71b7a6"
+archive_paths=PackedStringArray("C:/Program Files (x86)/Steam/steamapps/common/Road to Vostok/mods/RTVCoopVMZ.vmz")
+modloader_version="3.0.1"
+exe_mtime=1776042534
+timestamp=1776897837.26
+script_overrides=[]
+hook_pack_path="user://modloader_hooks/framework_pack_5758.zip"
+hook_pack_wrapped_paths=PackedStringArray("res://Scripts/Menu.gd")
+hook_pack_exe_mtime=1776042534
+```
+
 | Key | Meaning |
 |---|---|
-| `archive_paths` | The `.vmz`/`.zip`/`.pck` paths that were mounted last session, in load order. |
+| `archive_paths` | The `.vmz`/`.zip`/`.pck` paths that were mounted last session, in load order. Stored as `PackedStringArray(...)`. |
 | `modloader_version` | The modloader version that wrote this state. Mismatch with current = state gets wiped. |
-| `exe_mtime` | Game `.exe` modification time at write. Change = hook cache gets wiped (vanilla scripts may have moved). |
-| `hook_pack_path` | `user://modloader_hooks/framework_pack_<timestamp>.zip` path to mount at static-init. |
-| `hook_pack_wrapped_paths` | List of `res://Scripts/<Name>.gd` paths in the pack; drives which scripts get `CACHE_MODE_IGNORE` preempt. |
+| `exe_mtime` | Game `.exe` modification time at write. Change = state gets wiped (vanilla scripts may have moved across a game update). |
+| `timestamp` | Unix epoch seconds when Pass 1 wrote the file. Informational; not used for invalidation. |
 | `restart_count` | Pass-2-restart counter. Max 2; resets after a clean boot. Prevents infinite restart loops. |
 | `mods_hash` | Content hash of the enabled modlist. Unchanged hash + matching state = skip hook pack regeneration. |
+| `script_overrides` | Array of dynamic `overrideScript()` targets declared by mods; used by the dev-mode conflict report. Empty `[]` on most installs. |
+| `hook_pack_path` | `user://modloader_hooks/framework_pack_<millis>.zip` path to mount at static-init next boot. Fresh filename per generation sidesteps Godot's `load_resource_pack` path-dedup. |
+| `hook_pack_wrapped_paths` | List of `res://Scripts/<Name>.gd` paths in the pack; drives which scripts get `CACHE_MODE_IGNORE` preempt at static-init. Often just `["res://Scripts/Menu.gd"]` for legacy loadouts (core hook only). |
+| `hook_pack_exe_mtime` | Exe mtime recorded at hook-pack-write. Separate from `exe_mtime` above so pack-only regenerations can happen without wiping the broader state. |
 
 **Safe to delete.** Next launch rebuilds it. You'll pay a cold-boot cost (regenerate hook pack).
 
@@ -159,7 +187,7 @@ Everything under `user://modloader_hooks/` is regenerated on demand:
 
 | Path | Contents |
 |---|---|
-| `user://modloader_hooks/framework_pack_<timestamp>.zip` | The generated hook pack. Mounted at static-init. Regenerated by Pass 1 when mod state changes. |
+| `user://modloader_hooks/framework_pack_<millis>.zip` | The generated hook pack. Mounted at static-init. Each Pass-1 generation picks a fresh timestamp suffix (sidesteps Godot's `load_resource_pack` path-dedup caching stale mount offsets). Old generations are cleaned up pre-mount. |
 | `user://modloader_hooks/vanilla/` | Cached detokenized vanilla source, keyed by exe mtime. Speeds up subsequent hook-pack generation. |
 | `user://vmz_mount_cache/` | `.vmz -> .zip` copies so Godot's `load_resource_pack` can mount them. |
 | `user://modloader_early/` | Extracted copies of `!`-prefixed early-autoload scripts that live inside archives. |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -21,6 +21,8 @@ End-user install instructions and mod-author quick-start live in the repo [READM
 - [Hooks](Hooks) -- RTVModLib API, opt-in wrap surface, source rewriter, hook pack generation + mount
 - [Registry](Registry) -- `lib.register` / `lib.override` / `lib.patch` for items, scenes, loot, sounds, recipes, events, traders, inputs, shelters, AI, fish, resources
 - [Mod-Format](Mod-Format) -- mod.txt schema, autoload `!` prefix, `[hooks]` / `[script_extend]` / `[registry]` declarations
+- [Profile-Format](Profile-Format) -- the shareable `MTRPRF1....` payload spec (wrapper, JSON, forward-compat rules)
+- [Config-Files](Config-Files) -- where profile state lives on disk, how to edit/back up/reset, sentinel files, generated caches
 - [GDSC-Detokenizer](GDSC-Detokenizer) -- binary token format v100/v101, vanilla source cache
 - [Stability-Canaries](Stability-Canaries) -- A/B/C runtime probes, safe-mode + crash-recovery sentinels
 - [Build](Build) -- `build.sh` concat order, release-please, version bump flow

--- a/docs/wiki/Profile-Format.md
+++ b/docs/wiki/Profile-Format.md
@@ -1,0 +1,89 @@
+# Profile Format
+
+Specification for the `metroprofile` payload that `Share` / `Import` use to move profiles between installs. Locked at v3.0.1 release. Payloads written against v1 must keep parsing correctly for the life of the 3.x line.
+
+Changing the shape of v1 would break every payload already pasted into Discord, forums, wiki, and mod READMEs. Breaking changes require bumping the schema version to `2`.
+
+## Wrapper format
+
+The clipboard-visible string:
+
+```
+MTRPRF1.<base64(utf8(JSON))>.<first 8 hex chars of SHA-256(base64 body)>
+```
+
+- `MTRPRF1` magic -- identifies this as a metroprofile v1 payload. Alternate magic means the parser rejects with `"Unknown payload type"`.
+- Base64 body -- UTF-8 JSON encoded via `Marshalls.utf8_to_base64`. The Base64 alphabet `[A-Za-z0-9+/=]` contains no dots, so `.` is safe as a delimiter between the three parts.
+- 8-hex checksum -- first 8 hex characters of SHA-256 over the base64 body bytes (not the decoded JSON). Detects clipboard / paste corruption. 32 bits, not a security boundary.
+
+Parser rejects with specific errors for: wrong part count, unknown magic, bad checksum, invalid base64, non-object JSON, unsupported `metroprofile` value, missing `name`, missing `enabled`.
+
+## JSON schema
+
+Inside the base64 body:
+
+```json
+{
+  "metroprofile":      1,
+  "name":              "My Build",
+  "modloader_version": "3.0.1",
+  "exported_at":       "2026-04-22T23:14:11",
+  "enabled": {
+    "rtvcoop@1.2.3":       true,
+    "immersivexp@0.4.1":   true,
+    "zip:CustomHUD.vmz":   false
+  },
+  "priority": {
+    "rtvcoop@1.2.3":       100,
+    "immersivexp@0.4.1":   50
+  }
+}
+```
+
+| Key | Required | Type | Meaning |
+|---|---|---|---|
+| `metroprofile` | yes | int | Schema version. Always `1` for v1 payloads. |
+| `name` | yes | String | Profile name. Sanitized on both export and import via `_sanitize_profile_name` (ASCII letters / digits / space / hyphen / underscore). |
+| `enabled` | yes | Dictionary | `profile_key -> bool`. Full manifest of every mod on the exporter's install, enabled or disabled. |
+| `priority` | no | Dictionary | `profile_key -> int`. Load-order priority in `[-999, 999]`. Absent entries default to 0 on import. |
+| `modloader_version` | no | String | Exporter's `MODLOADER_VERSION`. Advisory only. |
+| `exported_at` | no | String | ISO datetime when exported. Advisory only. |
+
+## Profile key format
+
+Profile keys identify mods across installs. Two shapes:
+
+- `"<mod_id>@<version>"` -- for mods whose `mod.txt` declares `[mod] id=...`. The version segment may be empty (`"foo@"`). Identity is stable across `.vmz` renames. See `_entry_from_config` in [mod_discovery.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd).
+- `"zip:<file_name>"` -- for mods without a declared `mod_id`. Identity is the archive filename. Renaming the `.vmz` orphans the profile entry.
+
+## Version-mismatch handling on import
+
+When a payload's profile key `foo@1.0` doesn't match any installed mod exactly, but the importer has `foo@2.0`, the importer uses id-prefix matching (first `@` splits the key) to apply the payload's enabled / priority state to the newer version. The UI flags this as `profile_version_mismatch` so the user sees the carry-over isn't silent.
+
+Mods without a declared `mod_id` (`zip:*` keys) don't participate in id-prefix matching; exact filename match only.
+
+## Round-trip guarantee
+
+For a profile with N declared mods, exporting then importing back into the same installation yields identical enabled + priority state. Keys absent from the payload default to their pre-import state -- except for `enabled`, where [`_import_profile_from_parsed`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd) writes `false` for every local mod that isn't in the payload (explicit-manifest semantics; prevents unshared local mods / dev folders from being silently enabled on import).
+
+## Forward-compatibility rules
+
+Importers written against v1 will exist in the wild indefinitely. Rules for keeping them parsing correctly:
+
+- v1 parsers MUST ignore unknown top-level JSON keys. Future additions can ship new optional fields without breaking v1 parsers.
+- v1 parsers MUST tolerate missing optional keys (`priority`, `modloader_version`, `exported_at`). Missing required keys -> reject with error.
+- Any change that adds a REQUIRED key, renames an existing key, or alters the value type of an existing key requires bumping `metroprofile` to `2`. Old parsers will correctly reject v2 with `"Unsupported metroprofile schema version"` rather than silently mis-applying.
+- Additive changes to optional fields stay on `metroprofile: 1`. Old parsers ignore the new key.
+
+## Defensive handling
+
+On import:
+
+- `name` is re-sanitized on the importer side (exporter-side sanitization is not trusted). An empty result rejects with `"Payload contains an invalid profile name."`
+- `priority` values are clamped to `[-999, 999]` to prevent a crafted payload from breaking load-order sort stability. The UI spinbox already enforces this range on save.
+- Checksum mismatch rejects before JSON parsing.
+
+## See also
+
+- [Mod-Format](Mod-Format) -- the `mod.txt` schema that generates `profile_key` identities.
+- [`_profile_to_payload`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd) + [`_parse_profile_payload`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd) -- the export / import code paths.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -7,6 +7,7 @@
 - [Hooks](Hooks)
 - [Registry](Registry)
 - [Mod-Format](Mod-Format)
+- [Profile-Format](Profile-Format)
 - [GDSC-Detokenizer](GDSC-Detokenizer)
 - [Stability-Canaries](Stability-Canaries)
 - [Build](Build)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -8,6 +8,7 @@
 - [Registry](Registry)
 - [Mod-Format](Mod-Format)
 - [Profile-Format](Profile-Format)
+- [Config-Files](Config-Files)
 - [GDSC-Detokenizer](GDSC-Detokenizer)
 - [Stability-Canaries](Stability-Canaries)
 - [Build](Build)

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -71,6 +71,12 @@ static func _mount_previous_session() -> Dictionary:
 	var saved_ver: String = cfg.get_value("state", "modloader_version", "")
 	if saved_ver != MODLOADER_VERSION:
 		log_lines.append("[FileScope] Version mismatch: saved=%s current=%s -- wiping" % [saved_ver, MODLOADER_VERSION])
+		# Wipe hook cache along with pass state. Rewriter output semantics
+		# may have changed across versions (e.g. 3.0.0 -> 3.0.1 changed the
+		# opt-in gate + per-method wrap mask shape); any stale framework_pack
+		# still on disk must not get mounted. Pass 1 regenerates a fresh
+		# pack from the current modlist. Mirrors the exe_mtime wipe below.
+		_static_wipe_hook_cache()
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		_static_reset_override_cfg(log_lines)
 		_write_filescope_log(log_lines)

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -130,6 +130,14 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# of their own source). When ANOTHER mod declares a hook on the same
 	# path, Godot's extends resolution still threads their mod through the
 	# wrapped vanilla naturally -- no mod-source rewrite required.
+	# Build a set of enumerated vanilla paths for declared-path validation.
+	# A mod declaring a path that doesn't correspond to any vanilla script
+	# (typo, bare-filename normalization mismatch in add_hook, path from a
+	# game version that renamed the file) would otherwise silently no-op
+	# at rewrite time. Warn once at enrollment so mod authors can fix.
+	var vanilla_path_set: Dictionary = {}
+	for sp: String in script_paths:
+		vanilla_path_set[sp] = true
 	var needed_paths: Dictionary = {}
 	# Per-path per-method mask. Keyed by res_path -> Dictionary[method_name, true].
 	# Populated from _hooked_methods (static [hooks] section + scanned .hook()).
@@ -143,6 +151,11 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		if not path.begins_with("res://Scripts/"):
 			_log_warning("[RTVCodegen] [hooks] declared for non-vanilla path '%s' -- only res://Scripts/*.gd is hookable; entry ignored" % path)
 			continue
+		if not vanilla_path_set.has(path):
+			_log_warning("[RTVCodegen] [hooks] declared path '%s' doesn't match any vanilla script -- check for typos or stale paths; entry will no-op" % path)
+			# Still enroll it so the path_mask iteration below logs per-method
+			# "declared method not found" diagnostics against the empty set --
+			# no wrapper will be generated but the logging chain stays consistent.
 		needed_paths[path] = true
 		hook_mask[path] = (_hooked_methods[path] as Dictionary).duplicate()
 	# Gate Database.gd on explicit [registry] opt-in. REGISTRY_TARGETS are

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -170,15 +170,30 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 				continue
 			if not _hooked_methods.has(script_path):
 				_hooked_methods[script_path] = {}
-			# Wildcard: "*" or empty value = wrap every hookable method.
-			# Leave the inner dict empty; hook_pack.gd treats that as wrap-all.
-			if methods_str == "" or methods_str == "*":
-				_log_info("  Hooks declared: %s :: * (all methods) [%s]" % [script_path, mod_name])
-				continue
-			for method_name in methods_str.split(","):
-				method_name = method_name.strip_edges()
-				if method_name.is_empty():
+			# Parse method list. "*" anywhere (including mixed with specific
+			# methods) promotes to whole-script wildcard -- the mixed form
+			# used to silently ignore the wildcard and wrap only the listed
+			# methods, a silent miss for mod authors who wanted "these for
+			# sure, plus anything else I might hook dynamically."
+			var specific_methods: Array[String] = []
+			var has_wildcard := methods_str == ""
+			for raw_method in methods_str.split(","):
+				var method_name: String = raw_method.strip_edges()
+				if method_name == "":
 					continue
+				if method_name == "*":
+					has_wildcard = true
+					continue
+				specific_methods.append(method_name)
+			if has_wildcard:
+				if not specific_methods.is_empty():
+					_log_warning("  [hooks] %s mixes '*' with specific methods (%s); '*' wins, all methods wrapped [%s]" \
+							% [script_path, ", ".join(specific_methods), mod_name])
+				else:
+					_log_info("  Hooks declared: %s :: * (all methods) [%s]" % [script_path, mod_name])
+				# Leave the inner dict empty; hook_pack.gd treats that as wrap-all.
+				continue
+			for method_name in specific_methods:
 				(_hooked_methods[script_path] as Dictionary)[method_name.to_lower()] = true
 				_log_info("  Hook declared: %s :: %s [%s]" % [script_path, method_name, mod_name])
 

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -911,19 +911,28 @@ func _rtv_find_matching_paren(s: String, open_idx: int) -> int:
 	if open_idx >= s.length() or s[open_idx] != "(":
 		return -1
 	var depth := 0
-	var in_string := false
+	var in_dq := false   # inside "..."
+	var in_sq := false   # inside '...'
 	var i := open_idx
 	while i < s.length():
 		var c := s[i]
-		if in_string:
+		if in_dq:
 			if c == "\\" and i + 1 < s.length():
 				i += 2
 				continue
 			if c == "\"":
-				in_string = false
+				in_dq = false
+		elif in_sq:
+			if c == "\\" and i + 1 < s.length():
+				i += 2
+				continue
+			if c == "'":
+				in_sq = false
 		else:
 			if c == "\"":
-				in_string = true
+				in_dq = true
+			elif c == "'":
+				in_sq = true
 			elif c == "(":
 				depth += 1
 			elif c == ")":

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -325,6 +325,27 @@ func _import_profile_from_parsed(parsed: Dictionary) -> void:
 	var priority_dict: Dictionary = parsed.get("priority", {})
 	for key in priority_dict.keys():
 		cfg.set_value(pr_sec, str(key), int(priority_dict[key]))
+	# Explicit manifest: any local mod NOT in the imported payload is written
+	# as disabled. Without this, _apply_profile_to_entries falls through to
+	# its default-true branch for unknown keys (ergonomic for "newly-dropped
+	# mod in existing profile") and imports would silently enable every
+	# local mod the exporter didn't have -- including dev folders, which is
+	# the opposite of what a shared profile means. Handles id-prefix matches
+	# (foo@2.0 local resolving to foo@1.0 in payload) so version bumps
+	# inherit the payload's state rather than getting disabled.
+	var payload_mod_ids: Dictionary = {}
+	for key in enabled_dict.keys():
+		var key_str := str(key)
+		var at := key_str.find("@")
+		if at > 0:
+			payload_mod_ids[key_str.substr(0, at)] = true
+	for entry in _ui_mod_entries:
+		var pk: String = entry["profile_key"]
+		if enabled_dict.has(pk):
+			continue
+		if not pk.begins_with("zip:") and payload_mod_ids.has(entry["mod_id"]):
+			continue
+		cfg.set_value(en_sec, pk, false)
 	_active_profile = name
 	cfg.set_value("settings", "active_profile", _active_profile)
 	cfg.save(UI_CONFIG_PATH)

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -358,67 +358,10 @@ func _import_profile_from_parsed(parsed: Dictionary) -> void:
 	if _boot_complete:
 		_dirty_since_boot = true
 
-# ============================================================================
-# METROPROFILE v1 -- SCHEMA LOCKED at 3.0.1 release.
-# ============================================================================
-# Do NOT add required fields, rename keys, or change value types in v1 without
-# bumping the schema version. Importers written against v1 are allowed to
-# exist in the wild (Discord pastes, forum attachments, wiki links) and must
-# keep parsing correctly for the life of the 3.x line.
-#
-# Wrapper format (the clipboard-visible string):
-#     "MTRPRF1.<base64(utf8(JSON))>.<first 8 hex chars of SHA-256(base64 body)>"
-#   - "MTRPRF1" magic: identifies this as a metroprofile v1 payload.
-#   - base64 body: UTF-8 JSON encoded via Marshalls.utf8_to_base64.
-#     Base64 alphabet [A-Za-z0-9+/=] contains no dots, so "." is a safe split
-#     delimiter.
-#   - 8-hex checksum: first 8 hex chars of SHA-256 over the base64 body bytes.
-#     Detects clipboard/paste corruption, not tampering (32 bits, not a
-#     security boundary).
-#
-# JSON schema (inside the base64 body):
-#     {
-#       "metroprofile":      1,                  // REQUIRED, int, always 1.
-#       "name":              "<profile name>",   // REQUIRED, String. Sanitized
-#                                                //   via _sanitize_profile_name
-#                                                //   on both export + import
-#                                                //   (ASCII letters/digits/
-#                                                //   space/hyphen/underscore).
-#       "enabled":           { key: bool, ... }, // REQUIRED, Dictionary.
-#                                                //   profile_key -> enabled.
-#       "priority":          { key: int, ... },  // OPTIONAL, Dictionary.
-#                                                //   profile_key -> priority
-#                                                //   int in [-999, 999].
-#                                                //   Absent => all default 0.
-#       "modloader_version": "<semver>",         // OPTIONAL, String, advisory.
-#       "exported_at":       "<iso datetime>"    // OPTIONAL, String, advisory.
-#     }
-#
-# Profile key format (LOCKED):
-#   "<mod_id>@<version>"  -- mods whose mod.txt declares [mod] id=... The
-#                            version segment may be empty ("foo@"). Identity
-#                            is stable across .vmz renames.
-#   "zip:<file_name>"     -- mods without a declared mod_id; identity is the
-#                            archive filename. Renaming the .vmz orphans the
-#                            profile entry.
-#   (See _entry_from_config in mod_discovery.gd for construction.)
-#
-# Forward compatibility rules:
-#   - v1 parsers MUST ignore unknown top-level JSON keys.
-#   - v1 parsers MUST tolerate missing optional keys (priority, modloader_version,
-#     exported_at). Required keys missing -> reject with error.
-#   - Any change that adds a REQUIRED key, renames an existing key, or alters
-#     the value type of an existing key requires bumping metroprofile to 2.
-#     Old parsers will correctly reject v2 ("Unsupported metroprofile schema
-#     version") rather than silently mis-applying.
-#   - Changes additive to optional fields (new optional top-level key) can
-#     stay on metroprofile=1. Old parsers ignore the new key.
-#
-# Round-trip guarantee: for a profile with N declared mods, export then import
-# into the same installation yields identical enabled+priority state. Missing
-# fields default: no priority entry => priority unchanged on existing local
-# mods (not reset to 0).
-# ============================================================================
+# Metroprofile v1 schema is LOCKED at 3.0.1. Full spec (wrapper format, JSON
+# shape, profile key format, forward-compat rules, round-trip guarantees) is
+# in the wiki: docs/wiki/Profile-Format.md. Changes to the export/import
+# shape require bumping the schema version so old parsers reject cleanly.
 
 # Build the shareable opaque payload for the given profile. Shape:
 #     MTRPRF1.<base64-encoded JSON>.<first 8 hex chars of SHA-256(body)>

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -324,7 +324,12 @@ func _import_profile_from_parsed(parsed: Dictionary) -> void:
 		cfg.set_value(en_sec, str(key), bool(enabled_dict[key]))
 	var priority_dict: Dictionary = parsed.get("priority", {})
 	for key in priority_dict.keys():
-		cfg.set_value(pr_sec, str(key), int(priority_dict[key]))
+		# Clamp defensively -- payload came from the clipboard and a crafted
+		# or corrupted entry could set an out-of-range priority that breaks
+		# load-order invariants (UI spinbox is [-999, 999]; anything outside
+		# that range couldn't have been authored through the UI anyway).
+		var pv := int(priority_dict[key])
+		cfg.set_value(pr_sec, str(key), clampi(pv, PRIORITY_MIN, PRIORITY_MAX))
 	# Explicit manifest: any local mod NOT in the imported payload is written
 	# as disabled. Without this, _apply_profile_to_entries falls through to
 	# its default-true branch for unknown keys (ergonomic for "newly-dropped
@@ -352,6 +357,68 @@ func _import_profile_from_parsed(parsed: Dictionary) -> void:
 	_apply_profile_to_entries(cfg, _active_profile)
 	if _boot_complete:
 		_dirty_since_boot = true
+
+# ============================================================================
+# METROPROFILE v1 -- SCHEMA LOCKED at 3.0.1 release.
+# ============================================================================
+# Do NOT add required fields, rename keys, or change value types in v1 without
+# bumping the schema version. Importers written against v1 are allowed to
+# exist in the wild (Discord pastes, forum attachments, wiki links) and must
+# keep parsing correctly for the life of the 3.x line.
+#
+# Wrapper format (the clipboard-visible string):
+#     "MTRPRF1.<base64(utf8(JSON))>.<first 8 hex chars of SHA-256(base64 body)>"
+#   - "MTRPRF1" magic: identifies this as a metroprofile v1 payload.
+#   - base64 body: UTF-8 JSON encoded via Marshalls.utf8_to_base64.
+#     Base64 alphabet [A-Za-z0-9+/=] contains no dots, so "." is a safe split
+#     delimiter.
+#   - 8-hex checksum: first 8 hex chars of SHA-256 over the base64 body bytes.
+#     Detects clipboard/paste corruption, not tampering (32 bits, not a
+#     security boundary).
+#
+# JSON schema (inside the base64 body):
+#     {
+#       "metroprofile":      1,                  // REQUIRED, int, always 1.
+#       "name":              "<profile name>",   // REQUIRED, String. Sanitized
+#                                                //   via _sanitize_profile_name
+#                                                //   on both export + import
+#                                                //   (ASCII letters/digits/
+#                                                //   space/hyphen/underscore).
+#       "enabled":           { key: bool, ... }, // REQUIRED, Dictionary.
+#                                                //   profile_key -> enabled.
+#       "priority":          { key: int, ... },  // OPTIONAL, Dictionary.
+#                                                //   profile_key -> priority
+#                                                //   int in [-999, 999].
+#                                                //   Absent => all default 0.
+#       "modloader_version": "<semver>",         // OPTIONAL, String, advisory.
+#       "exported_at":       "<iso datetime>"    // OPTIONAL, String, advisory.
+#     }
+#
+# Profile key format (LOCKED):
+#   "<mod_id>@<version>"  -- mods whose mod.txt declares [mod] id=... The
+#                            version segment may be empty ("foo@"). Identity
+#                            is stable across .vmz renames.
+#   "zip:<file_name>"     -- mods without a declared mod_id; identity is the
+#                            archive filename. Renaming the .vmz orphans the
+#                            profile entry.
+#   (See _entry_from_config in mod_discovery.gd for construction.)
+#
+# Forward compatibility rules:
+#   - v1 parsers MUST ignore unknown top-level JSON keys.
+#   - v1 parsers MUST tolerate missing optional keys (priority, modloader_version,
+#     exported_at). Required keys missing -> reject with error.
+#   - Any change that adds a REQUIRED key, renames an existing key, or alters
+#     the value type of an existing key requires bumping metroprofile to 2.
+#     Old parsers will correctly reject v2 ("Unsupported metroprofile schema
+#     version") rather than silently mis-applying.
+#   - Changes additive to optional fields (new optional top-level key) can
+#     stay on metroprofile=1. Old parsers ignore the new key.
+#
+# Round-trip guarantee: for a profile with N declared mods, export then import
+# into the same installation yields identical enabled+priority state. Missing
+# fields default: no priority entry => priority unchanged on existing local
+# mods (not reset to 0).
+# ============================================================================
 
 # Build the shareable opaque payload for the given profile. Shape:
 #     MTRPRF1.<base64-encoded JSON>.<first 8 hex chars of SHA-256(body)>


### PR DESCRIPTION
## Summary

Follow-up bug fix + pre-release hardening landed after PR #29 merged.

## Fixes

1. **Profile import no longer enables dev folders / unshared mods** (a8365e7) -- reported by Sid: importing a shared profile silently turned on every local mod the exporter didn't have, including dev folders. Fix writes explicit `false` for absent mods so imports behave as full manifests. Version-bump fallback (local `foo@2.0` vs payload `foo@1.0`) preserved via id-prefix match.

2. **Metroprofile v1 schema locked** (ee8833b) -- comment block over `_profile_to_payload` documents the export format as wire contract. Once users paste payloads into Discord / forums / wiki, we can't change the shape without breaking them. Also adds a defensive `clampi` on imported priority values to `[-999, 999]` (same range as the UI spinbox).

3. **Four hardening fixes from the pre-release audit** (54668da):
   - Version-mismatch wipes hook cache alongside pass_state (prevents stale 3.0.0 `framework_pack.zip` from lingering after upgrade).
   - `_rtv_find_matching_paren` tracks both `"..."` and `'...'` string literals (defensive; legacy Godot-3 mods using single-quoted strings with unbalanced parens).
   - `[hooks] = *, foo` wildcard promotion (mixed form used to silently ignore the wildcard and wrap only specific methods).
   - `[hooks]` declared paths are validated against enumerated vanilla scripts; typos and stale paths warn at pack-generation time instead of silently no-op'ing.

## Test plan

- [ ] Export from one install, import on a second install with more local mods. Confirm only payload's mods are enabled.
- [ ] Export, import on same install (round-trip). Confirm state identical.
- [ ] Version-bump: payload `foo@1.0=true`, local `foo@2.0`. Expect foo@2.0 enabled with version-mismatch flag.
- [ ] Empty payload (no enabled mods): expect all local mods disabled on import.
- [ ] Malformed payload strings: garbage, truncated, wrong magic, bad checksum -- each should show a specific error, not crash.
- [ ] Upgrade from 3.0.0 install: boot with a 3.0.0 `framework_pack.zip` still at `user://modloader_hooks/`. Expect `[FileScope] Version mismatch ... wiping`, stale pack gone, fresh pack generated by Pass 1.
- [ ] Declare `[hooks] res://Scripts/Typo.gd = foo` in a test mod; expect `[RTVCodegen] declared path ... doesn't match any vanilla script` warning.
- [ ] Declare `[hooks] res://Scripts/Foo.gd = bar, *`; expect `mixes '*' with specific methods; '*' wins, all methods wrapped` warning.

---

Release-As: 3.0.1