### PR TITLE
fix: preserve rendering-driver across modloader restart

### DIFF
--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -57,6 +57,14 @@ func _modloader_restart(clean_pass1: bool) -> void:
 	get_tree().quit()
 
 func _preserve_engine_driver_args(args: Array) -> void:
+	# Only the "set once at boot, immutable after" args are safe to re-inject
+	# from live state: if the user didn't pass a flag, querying returns Godot's
+	# default (no-op); if they did, we preserve their choice. Window mode,
+	# vsync, resolution, screen, position are deliberately excluded -- those
+	# are initial-state hints the user can change in-game, and re-injecting
+	# would fight the user's current setting. --gpu-index is consumed the same
+	# way but has no GDScript accessor (Engine.singleton->gpu_idx is unbound),
+	# so multi-GPU users on fresh-install first launch are still affected.
 	if not args.has("--rendering-driver"):
 		var driver := RenderingServer.get_current_rendering_driver_name()
 		if not driver.is_empty():
@@ -67,6 +75,20 @@ func _preserve_engine_driver_args(args: Array) -> void:
 		if not method.is_empty():
 			args.append("--rendering-method")
 			args.append(method)
+	if not args.has("--display-driver"):
+		# DisplayServer.get_name() returns the capitalized platform name
+		# ("Windows"), but the CLI matches against the lowercase
+		# register_create_function names ("windows", "headless", "wayland",
+		# "x11", "macos"). Lowercase so the comparison at main.cpp:1243 hits.
+		var dname := DisplayServer.get_name().to_lower()
+		if not dname.is_empty():
+			args.append("--display-driver")
+			args.append(dname)
+	if not args.has("--audio-driver"):
+		var adriver := AudioServer.get_driver_name()
+		if not adriver.is_empty():
+			args.append("--audio-driver")
+			args.append(adriver)
 
 # Public entry point for the main-menu "Mods" button. Re-shows the launcher UI
 # post-boot; if any mutation sets _dirty_since_boot, quits + restarts into a

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -43,9 +43,30 @@ func _modloader_restart(clean_pass1: bool) -> void:
 				args.append(a)
 	else:
 		args = Array(OS.get_cmdline_args())
+	# Godot's arg parser consumes --rendering-driver / --rendering-method
+	# (main.cpp:1272,1280) and does NOT push them back to main_args, so
+	# OS.get_cmdline_args() returns the stripped list. Without re-injecting,
+	# the relaunch loses the Steam launch option and Godot falls back to the
+	# default driver (D3D12 on Windows). Visible on fresh-install first
+	# launch; subsequent launches short-circuit on the mod-state hash and
+	# never restart.
+	_preserve_engine_driver_args(args)
+	if not clean_pass1:
 		args.append_array(["--", "--modloader-restart"])
 	OS.set_restart_on_exit(true, args)
 	get_tree().quit()
+
+func _preserve_engine_driver_args(args: Array) -> void:
+	if not args.has("--rendering-driver"):
+		var driver := RenderingServer.get_current_rendering_driver_name()
+		if not driver.is_empty():
+			args.append("--rendering-driver")
+			args.append(driver)
+	if not args.has("--rendering-method"):
+		var method := RenderingServer.get_current_rendering_method()
+		if not method.is_empty():
+			args.append("--rendering-method")
+			args.append(method)
 
 # Public entry point for the main-menu "Mods" button. Re-shows the launcher UI
 # post-boot; if any mutation sets _dirty_since_boot, quits + restarts into a

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -57,14 +57,10 @@ func _modloader_restart(clean_pass1: bool) -> void:
 	get_tree().quit()
 
 func _preserve_engine_driver_args(args: Array) -> void:
-	# Only the "set once at boot, immutable after" args are safe to re-inject
-	# from live state: if the user didn't pass a flag, querying returns Godot's
-	# default (no-op); if they did, we preserve their choice. Window mode,
-	# vsync, resolution, screen, position are deliberately excluded -- those
-	# are initial-state hints the user can change in-game, and re-injecting
-	# would fight the user's current setting. --gpu-index is consumed the same
-	# way but has no GDScript accessor (Engine.singleton->gpu_idx is unbound),
-	# so multi-GPU users on fresh-install first launch are still affected.
+	# Scoped to the two flags RTV's Steam launch-option presets actually set
+	# ([DirectX] / [Vulkan] / [Compatibility] pick --rendering-driver and/or
+	# --rendering-method). If the user didn't pass a flag, querying returns
+	# Godot's default (no-op); if they did, we preserve their choice.
 	if not args.has("--rendering-driver"):
 		var driver := RenderingServer.get_current_rendering_driver_name()
 		if not driver.is_empty():
@@ -75,20 +71,6 @@ func _preserve_engine_driver_args(args: Array) -> void:
 		if not method.is_empty():
 			args.append("--rendering-method")
 			args.append(method)
-	if not args.has("--display-driver"):
-		# DisplayServer.get_name() returns the capitalized platform name
-		# ("Windows"), but the CLI matches against the lowercase
-		# register_create_function names ("windows", "headless", "wayland",
-		# "x11", "macos"). Lowercase so the comparison at main.cpp:1243 hits.
-		var dname := DisplayServer.get_name().to_lower()
-		if not dname.is_empty():
-			args.append("--display-driver")
-			args.append(dname)
-	if not args.has("--audio-driver"):
-		var adriver := AudioServer.get_driver_name()
-		if not adriver.is_empty():
-			args.append("--audio-driver")
-			args.append(adriver)
 
 # Public entry point for the main-menu "Mods" button. Re-shows the launcher UI
 # post-boot; if any mutation sets _dirty_since_boot, quits + restarts into a


### PR DESCRIPTION
## Summary
- Re-inject `--rendering-driver` and `--rendering-method` into `set_restart_on_exit` args so Steam launch options survive the two-pass restart.
- Without this, a fresh-install first launch loses the driver arg and Godot falls back to its default (D3D12 on Windows), flipping users from Vulkan -> DirectX unexpectedly.

## Root cause
Godot's arg parser in `main.cpp` (lines ~1272/1280) consumes `--rendering-driver <name>` / `--rendering-method <name>` and does NOT push them back to `main_args`. `OS.get_cmdline_args()` returns the stripped list, and `_modloader_restart` piped that straight into `set_restart_on_exit`.

## Why fresh-install-only
On subsequent launches the mod-state hash matches, [src/lifecycle.gd:87-90](src/lifecycle.gd#L87-L90) takes the `_finish_with_existing_mounts` branch instead of restarting. Steam's launch option stays alive in the single process. Fresh install = no prior hash = forced restart = bug surfaces once.

## Fix
`_preserve_engine_driver_args()` queries `RenderingServer.get_current_rendering_driver_name()` / `get_current_rendering_method()` and appends them before the `--` separator. Only adds them if not already present; empty-string guard for headless/dummy servers.

## Test plan
- [ ] Set Steam launch option `--rendering-driver vulkan`
- [ ] Delete `%APPDATA%/Road to Vostok/mod_pass_state.cfg` to simulate fresh install
- [ ] Launch through Steam, go through Pass 1 UI, confirm restart
- [ ] After relaunch verify driver is Vulkan (check `%APPDATA%/Road to Vostok/logs/godot.log` for `Using "vulkan"` or inspect `RenderingServer.get_current_rendering_driver_name()` at runtime)
- [ ] Repeat with `--rendering-driver d3d12` to confirm no regression
- [ ] Sanity: launch without any Steam launch option, confirm default driver is preserved and nothing is logged weird