### PR TITLE
feat: allow .zip mods to load

### DIFF
--- a/src/boot.gd
+++ b/src/boot.gd
@@ -449,8 +449,6 @@ func _collect_enabled_archive_paths() -> PackedStringArray:
 		candidates.append(entry.duplicate())
 	candidates.sort_custom(_compare_load_order)
 	for c in candidates:
-		if c["ext"] == "zip":
-			continue
 		if c["ext"] == "folder":
 			# Folder mods are zipped to a temp cache during load_all_mods().
 			# Store the temp zip path -- the folder itself can't be mounted.

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -167,16 +167,11 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		"priority": priority, "enabled": true,
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
 	}
-	if ext == "zip":
-		entry["enabled"] = false
 	return entry
 
 func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 	var warnings: Array[String] = []
 	var ext: String = entry["ext"]
-	if ext == "zip":
-		warnings.append("Rename this file from .zip to .vmz to use it")
-		return warnings
 	if ext == "pck" or ext == "folder":
 		return warnings
 	var status: String = entry.get("mod_txt_status", "none")

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -102,10 +102,6 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	_log_info("--- [" + str(load_index + 1) + "] " + mod_name + " (" + file_name + ")")
 
-	if ext == "zip":
-		_log_warning("Skipping .zip file: " + file_name + " -- rename to .vmz to use")
-		return
-
 	if ext != "pck" and _loaded_mod_ids.has(mod_id):
 		_log_warning("Duplicate mod id '" + mod_id + "' -- skipped: " + file_name)
 		return

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -107,8 +107,6 @@ func _apply_profile_to_entries(cfg: ConfigFile, profile: String) -> void:
 			entry["enabled"] = bool(cfg.get_value(en_sec, resolved_key))
 		else:
 			entry["enabled"] = true
-		if entry["ext"] == "zip":
-			entry["enabled"] = false
 		if resolved_key != "" and cfg.has_section_key(pr_sec, resolved_key):
 			entry["priority"] = int(str(cfg.get_value(pr_sec, resolved_key)))
 
@@ -1611,7 +1609,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 		# Vanilla has no stored profile; disable editing so auto-save can't
 		# create a ghost `profile.__vanilla__.*` section.
-		if entry["ext"] == "zip" or on_vanilla:
+		if on_vanilla:
 			check.disabled = true
 
 		var spin := SpinBox.new()
@@ -1619,7 +1617,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
-		if entry["ext"] == "zip" or on_vanilla:
+		if on_vanilla:
 			spin.editable = false
 		row.add_child(spin)
 


### PR DESCRIPTION
## Summary
- Drop the `.zip`-specific force-disable, rename hint, mount skip, and UI edit lock so `.zip` archives are treated the same as `.vmz`.
- Behavior-only: no UI copy or README changes; `.vmz` remains the recommended format.
- `load_resource_pack` accepts `.zip` directly, and the `vmz->zip` cache path in `_try_mount_pack` only fires for `.vmz`, so raw `.zip` mods mount without new code paths.

## Test plan
- [ ] Drop a known-good `.vmz` mod into `mods/`, confirm it still loads.
- [ ] Copy the same mod with a `.zip` extension, confirm it appears enabled and loads.
- [ ] Confirm the UI row is editable (toggle + priority spinner) for the `.zip` entry.
- [ ] Confirm the "Rename this file from .zip to .vmz" warning no longer shows.