### PR TITLE
perf: memoize scene_nodes patch validation

### DIFF
--- a/src/registry/scene_nodes.gd
+++ b/src/registry/scene_nodes.gd
@@ -46,6 +46,15 @@ var _scene_node_stash: Dictionary = {}
 # frameworks_ready emissions (shouldn't happen, but belt-and-suspenders).
 var _scene_nodes_listener_connected: bool = false
 
+# Memoizes successful probe validations keyed by
+# "<scene_path>#<node_path>|<sorted,field,names>". Keeps repeat patch()
+# calls with the same id + field set (e.g. recipes.gd auto-unlocking the
+# Equipment tab once per registered recipe) from instantiating +
+# free-ing Interface.tscn N times. Runtime safety is unchanged --
+# _apply_patches_for_scene_root still re-checks _node_has_property on
+# every live instance, so the cache is strictly additive.
+var _validated_patches: Dictionary = {}
+
 # Entry point invoked from hooks_api._register_core_hooks after frameworks_ready.
 # Idempotent.
 func _scene_nodes_connect_listener() -> void:
@@ -111,6 +120,13 @@ func _split_scene_node_id(id: String) -> Array:
 # Returns true if the (scene, node, props) triple is well-formed, false if
 # any piece doesn't resolve (with a warn on each failure).
 func _validate_scene_node_patch(scene_path: String, node_path: String, fields: Dictionary) -> bool:
+	var field_keys: Array = []
+	for k in fields.keys():
+		field_keys.append(String(k))
+	field_keys.sort()
+	var cache_key: String = "%s#%s|%s" % [scene_path, node_path, ",".join(field_keys)]
+	if _validated_patches.has(cache_key):
+		return true
 	var pscene := load(scene_path)
 	if pscene == null or not (pscene is PackedScene):
 		push_warning("[Registry] patch('scene_nodes'): scene '%s' failed to load (not a PackedScene)" % scene_path)
@@ -132,6 +148,7 @@ func _validate_scene_node_patch(scene_path: String, node_path: String, fields: D
 			probe.queue_free()
 			return false
 	probe.queue_free()
+	_validated_patches[cache_key] = true
 	return true
 
 # Does `node` have a declared property named `prop`? Mirrors


### PR DESCRIPTION
## Summary
- Cache successful `_validate_scene_node_patch` results keyed by `<scene>#<node>|<sorted,field,names>`.
- Drops Interface.tscn `instantiate()` + `queue_free()` from O(recipes) to 2 probes per boot for the recipes.gd auto-unlock path.

## Root cause
`_validate_scene_node_patch` in `src/registry/scene_nodes.gd` loads the PackedScene, instantiates a probe, walks `get_node_or_null(NodePath(node_path))`, checks each requested property via `_node_has_property`, and frees the probe. Cheap once, but `recipes.gd:_unlock_crafting_category_button_if_needed` runs inside `_register_recipe` for every recipe added to `equipment` or `misc`, always with the same id + same `{disabled, modulate}` fields. A mod adding N recipes to either category pays N full Interface.tscn instantiations at boot.

## Fix
Store successful validations in `_validated_patches`. Sort field keys before composing the cache key so `{disabled, modulate}` and `{modulate, disabled}` collapse into the same entry. Cache hit returns true immediately; cache miss runs the probe and inserts on success.

Only positive results are cached. Bad node path or missing property falls through and re-emits the warning on retry, so mods can't silently suppress validation errors.

## Why it's safe
- Runtime enforcement is unchanged. `_apply_patches_for_scene_root` still iterates `_node_has_property(target, fname)` on every live instance before calling `target.set`, so any probe/live divergence is caught at apply time regardless of cache state.
- PackedScenes are immutable within a session and the SCENE_NODES registry never mutates them (patches apply post-instantiation, see `_on_any_node_added`), so probe-once is semantically equivalent to probe-every-time.
- Cache key is derived from `scene_path`, `node_path`, and sorted field names only; property values aren't in the key because validation never inspected them.

## Validation
Verified on Godot 4.6.1 (the RTV engine version) via standalone harness replicating the cache key logic:
- 100 repeat calls with same `(scene, node, fields)` produce 1 probe
- Reordered field dict hits the same cache entry
- Different node path or field set correctly misses and re-probes
- Built `modloader.gd` parses cleanly after the change

## Test plan
- [ ] Launch with a mod that registers >=1 recipe in `equipment` and >=1 in `misc`. Confirm both tab buttons unlock and are clickable in the crafting UI.
- [ ] Launch with a mod that registers ~50 recipes across those categories. Confirm boot is noticeably quicker than pre-fix (Interface.tscn no longer instantiates per recipe).
- [ ] Malformed patch: `lib.patch(Registry.SCENE_NODES, "res://UI/Interface.tscn#DoesNotExist", {disabled = false})`. Confirm the warning still fires.
- [ ] Repeated malformed patch: same call twice. Confirm the warning fires both times (failed validations are not cached).