### PR TITLE
release: 3.1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,12 +37,18 @@ jobs:
           ./build.sh
 
       # Attach the freshly built modloader.gd + the repo's override.cfg to
-      # the release. The installers download from
-      # /releases/latest/download/<file>.
+      # the release, plus the installer scripts so users can grab them from
+      # /releases/latest/download/<file> the same way the installers
+      # themselves fetch modloader.gd / override.cfg.
       - name: Upload release assets
         if: ${{ steps.release.outputs.release_created }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag_name }}
         run: |
-          gh release upload "$TAG" modloader.gd override.cfg --clobber
+          gh release upload "$TAG" \
+            modloader.gd \
+            override.cfg \
+            windows-installer.bat \
+            linux-installer.sh \
+            --clobber

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ FILES=(
     "$SRC/registry/ai.gd"
     "$SRC/registry/fish.gd"
     "$SRC/registry/resources.gd"
+    "$SRC/registry/scene_nodes.gd"
     "$SRC/framework_wrappers.gd"
     # Codegen pipeline
     "$SRC/gdsc_detokenizer.gd"

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -449,8 +449,6 @@ func _collect_enabled_archive_paths() -> PackedStringArray:
 		candidates.append(entry.duplicate())
 	candidates.sort_custom(_compare_load_order)
 	for c in candidates:
-		if c["ext"] == "zip":
-			continue
 		if c["ext"] == "folder":
 			# Folder mods are zipped to a temp cache during load_all_mods().
 			# Store the temp zip path -- the folder itself can't be mounted.

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -101,6 +101,9 @@ var _ui_window: Window = null
 # Bottom-bar label used as a makeshift status hint because Godot's native
 # tooltips get layered behind our always_on_top launcher and aren't visible.
 var _ui_hint_label: Label = null
+# Launch button kept on self so refresh_launch_button_label can reach it
+# from the mod-enable toggle handler.
+var _ui_launch_btn: Button = null
 var _has_loaded := false
 var _last_mod_txt_status := "none"
 var _database_replaced_by := ""

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -30,6 +30,7 @@ func _register_rtv_modlib_meta() -> void:
 func _emit_frameworks_ready() -> void:
 	_is_ready = true
 	_register_core_hooks()
+	_scene_nodes_connect_listener()
 	frameworks_ready.emit()
 	_log_info("[RTVModLib] frameworks_ready emitted")
 	# All mod autoloads have now finished their _ready() calls, which is

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -43,9 +43,34 @@ func _modloader_restart(clean_pass1: bool) -> void:
 				args.append(a)
 	else:
 		args = Array(OS.get_cmdline_args())
+	# Godot's arg parser consumes --rendering-driver / --rendering-method
+	# (main.cpp:1272,1280) and does NOT push them back to main_args, so
+	# OS.get_cmdline_args() returns the stripped list. Without re-injecting,
+	# the relaunch loses the Steam launch option and Godot falls back to the
+	# default driver (D3D12 on Windows). Visible on fresh-install first
+	# launch; subsequent launches short-circuit on the mod-state hash and
+	# never restart.
+	_preserve_engine_driver_args(args)
+	if not clean_pass1:
 		args.append_array(["--", "--modloader-restart"])
 	OS.set_restart_on_exit(true, args)
 	get_tree().quit()
+
+func _preserve_engine_driver_args(args: Array) -> void:
+	# Scoped to the two flags RTV's Steam launch-option presets actually set
+	# ([DirectX] / [Vulkan] / [Compatibility] pick --rendering-driver and/or
+	# --rendering-method). If the user didn't pass a flag, querying returns
+	# Godot's default (no-op); if they did, we preserve their choice.
+	if not args.has("--rendering-driver"):
+		var driver := RenderingServer.get_current_rendering_driver_name()
+		if not driver.is_empty():
+			args.append("--rendering-driver")
+			args.append(driver)
+	if not args.has("--rendering-method"):
+		var method := RenderingServer.get_current_rendering_method()
+		if not method.is_empty():
+			args.append("--rendering-method")
+			args.append(method)
 
 # Public entry point for the main-menu "Mods" button. Re-shows the launcher UI
 # post-boot; if any mutation sets _dirty_since_boot, quits + restarts into a

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -167,16 +167,11 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		"priority": priority, "enabled": true,
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
 	}
-	if ext == "zip":
-		entry["enabled"] = false
 	return entry
 
 func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 	var warnings: Array[String] = []
 	var ext: String = entry["ext"]
-	if ext == "zip":
-		warnings.append("Rename this file from .zip to .vmz to use it")
-		return warnings
 	if ext == "pck" or ext == "folder":
 		return warnings
 	var status: String = entry.get("mod_txt_status", "none")

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -102,10 +102,6 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 
 	_log_info("--- [" + str(load_index + 1) + "] " + mod_name + " (" + file_name + ")")
 
-	if ext == "zip":
-		_log_warning("Skipping .zip file: " + file_name + " -- rename to .vmz to use")
-		return
-
 	if ext != "pck" and _loaded_mod_ids.has(mod_id):
 		_log_warning("Duplicate mod id '" + mod_id + "' -- skipped: " + file_name)
 		return

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -43,6 +43,7 @@ const Registry := {
 	AI_TYPES = "ai_types",
 	FISH_SPECIES = "fish_species",
 	RESOURCES = "resources",
+	SCENE_NODES = "scene_nodes",
 	# Future sections populate the rest:
 	# TRADER_POOLS = "trader_pools",
 	# TRADER_TASKS = "trader_tasks",
@@ -93,6 +94,9 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		"resources":
 			push_warning("[Registry] register: 'resources' doesn't support register (the target .tres already exists in vanilla; use patch to mutate its fields)")
 			return false
+		"scene_nodes":
+			push_warning("[Registry] register: 'scene_nodes' doesn't support register (nodes are positional inside a scene; use override('scenes', ...) to replace the whole scene or patch('scene_nodes', ...) to mutate node properties)")
+			return false
 		_:
 			push_warning("[Registry] register: unknown registry '%s'" % registry)
 			return false
@@ -128,6 +132,9 @@ func override(registry: String, id: String, data: Variant) -> bool:
 			return false
 		"resources":
 			push_warning("[Registry] override: 'resources' doesn't support override (vanilla .tres already exists; use patch to mutate fields)")
+			return false
+		"scene_nodes":
+			push_warning("[Registry] override: 'scene_nodes' doesn't support override (whole-scene swap goes through override('scenes', ...); scene_nodes is patch-only)")
 			return false
 		_:
 			push_warning("[Registry] override: unknown registry '%s'" % registry)
@@ -196,6 +203,11 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 				push_warning("[Registry] patch('resources', ...): id must be a res:// path String")
 				return false
 			return _patch_resource(id, fields)
+		"scene_nodes":
+			if not (id is String):
+				push_warning("[Registry] patch('scene_nodes', ...): id must be a String in the form '<scene_path>#<node_path>'")
+				return false
+			return _patch_scene_node(id, fields)
 		_:
 			push_warning("[Registry] patch: unknown registry '%s'" % registry)
 			return false
@@ -221,6 +233,9 @@ func remove(registry: String, id: String) -> bool:
 		"fish_species": return _remove_fish_species(id)
 		"resources":
 			push_warning("[Registry] remove: 'resources' doesn't support remove (use revert to undo patches)")
+			return false
+		"scene_nodes":
+			push_warning("[Registry] remove: 'scene_nodes' doesn't support remove (use revert to undo a property patch)")
 			return false
 		_:
 			push_warning("[Registry] remove: unknown registry '%s'" % registry)
@@ -298,6 +313,11 @@ func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 				push_warning("[Registry] revert('resources', ...): id must be a res:// path String")
 				return false
 			return _revert_resource(id, fields)
+		"scene_nodes":
+			if not (id is String):
+				push_warning("[Registry] revert('scene_nodes', ...): id must be a String in the form '<scene_path>#<node_path>'")
+				return false
+			return _revert_scene_node(id, fields)
 		_:
 			push_warning("[Registry] revert: unknown registry '%s'" % registry)
 			return false

--- a/src/registry/recipes.gd
+++ b/src/registry/recipes.gd
@@ -98,8 +98,35 @@ func _register_recipe(id: String, data: Variant) -> bool:
 	arr.append(recipe)
 	reg[id] = {"recipe": recipe, "category": category}
 	_registry_registered["recipes"] = reg
+	# Vanilla ships the Equipment and Misc category tabs disabled + faded
+	# (Interface.tscn:2591, 2668) because those recipe arrays are empty.
+	# Any mod adding a recipe to either category needs the tab clickable,
+	# so auto-patch the buttons via the scene_nodes registry. Idempotent:
+	# repeat calls from additional mods just re-set the same props.
+	_unlock_crafting_category_button_if_needed(category)
 	_log_debug("[Registry] registered recipe '%s' (category=%s, name=%s)" % [id, category, recipe.get("name")])
 	return true
+
+# Category -> node path inside Interface.tscn. Only equipment + misc ship
+# locked in vanilla; the other categories are always clickable.
+const _LOCKED_CATEGORY_BUTTONS := {
+	"equipment": "Tools/Crafting/Types/Margin/Buttons/Equipment",
+	"misc": "Tools/Crafting/Types/Margin/Buttons/Misc",
+}
+const _INTERFACE_SCENE_PATH := "res://UI/Interface.tscn"
+
+func _unlock_crafting_category_button_if_needed(category: String) -> void:
+	if not _LOCKED_CATEGORY_BUTTONS.has(category):
+		return
+	var node_path: String = _LOCKED_CATEGORY_BUTTONS[category]
+	var id: String = "%s#%s" % [_INTERFACE_SCENE_PATH, node_path]
+	# Reset the button's modulate to full alpha but leave the icon child
+	# alone at its vanilla 0.5 alpha icons ship faded on every category
+	# button, and matching sibling behavior is the right default.
+	_patch_scene_node(id, {
+		"disabled": false,
+		"modulate": Color(1.0, 1.0, 1.0, 1.0),
+	})
 
 func _override_recipe(id: String, data: Variant) -> bool:
 	var ov: Dictionary = _registry_overridden.get("recipes", {})

--- a/src/registry/scene_nodes.gd
+++ b/src/registry/scene_nodes.gd
@@ -46,6 +46,15 @@ var _scene_node_stash: Dictionary = {}
 # frameworks_ready emissions (shouldn't happen, but belt-and-suspenders).
 var _scene_nodes_listener_connected: bool = false
 
+# Memoizes successful probe validations keyed by
+# "<scene_path>#<node_path>|<sorted,field,names>". Keeps repeat patch()
+# calls with the same id + field set (e.g. recipes.gd auto-unlocking the
+# Equipment tab once per registered recipe) from instantiating +
+# free-ing Interface.tscn N times. Runtime safety is unchanged --
+# _apply_patches_for_scene_root still re-checks _node_has_property on
+# every live instance, so the cache is strictly additive.
+var _validated_patches: Dictionary = {}
+
 # Entry point invoked from hooks_api._register_core_hooks after frameworks_ready.
 # Idempotent.
 func _scene_nodes_connect_listener() -> void:
@@ -111,6 +120,13 @@ func _split_scene_node_id(id: String) -> Array:
 # Returns true if the (scene, node, props) triple is well-formed, false if
 # any piece doesn't resolve (with a warn on each failure).
 func _validate_scene_node_patch(scene_path: String, node_path: String, fields: Dictionary) -> bool:
+	var field_keys: Array = []
+	for k in fields.keys():
+		field_keys.append(String(k))
+	field_keys.sort()
+	var cache_key: String = "%s#%s|%s" % [scene_path, node_path, ",".join(field_keys)]
+	if _validated_patches.has(cache_key):
+		return true
 	var pscene := load(scene_path)
 	if pscene == null or not (pscene is PackedScene):
 		push_warning("[Registry] patch('scene_nodes'): scene '%s' failed to load (not a PackedScene)" % scene_path)
@@ -132,6 +148,7 @@ func _validate_scene_node_patch(scene_path: String, node_path: String, fields: D
 			probe.queue_free()
 			return false
 	probe.queue_free()
+	_validated_patches[cache_key] = true
 	return true
 
 # Does `node` have a declared property named `prop`? Mirrors

--- a/src/registry/scene_nodes.gd
+++ b/src/registry/scene_nodes.gd
@@ -1,0 +1,281 @@
+## ----- registry/scene_nodes.gd -----
+##
+## Patch-only registry for mutating node properties inside vanilla scenes
+## without shipping a full-scene override. Mod calls:
+##
+##   lib.patch(lib.Registry.SCENE_NODES,
+##             "res://UI/Interface.tscn#Tools/Crafting/Types/Margin/Buttons/Equipment",
+##             {disabled = false, modulate = Color(1,1,1,1)})
+##
+## Id format: "<scene_path>#<node_path>" where scene_path is the res:// path
+## of a PackedScene and node_path is relative to that scene's root. The two
+## are split on the FIRST '#' (scene paths don't legally contain #, node
+## names in Godot can't either).
+##
+## How it works: we subscribe to get_tree().node_added at frameworks_ready
+## time. Godot sets `node.scene_file_path` on the ROOT of an instantiated
+## scene (and only there); we use that as a cheap filter. When a match
+## fires, we walk our registered node_paths for that scene, resolve each via
+## get_node_or_null on the scene root, and apply the property patches. The
+## signal fires BEFORE the node's _ready, so @onready values that depend on
+## the patched props observe the patched state.
+##
+## The PackedScene resource is never mutated. Trade-off: patches apply per-instance at
+## instantiation, not at resource load. Code that calls
+## packed_scene.get_bundled_scene() directly still sees vanilla values
+## (doesn't come up in RTV vanilla).
+##
+## What this registry CAN'T do (by design):
+##   - Add or remove nodes (structural changes): use override('scenes', ...)
+##   - Patch sub-resources embedded inside the scene
+##   - Patch values on scenes loaded outside the tree (direct-load mutations)
+
+# Per-scene patch state, keyed by scene_path -> node_path -> {prop: value}.
+# Populated by _patch_scene_node, consumed by _apply_patches_for_scene_root.
+var _scene_node_patches: Dictionary = {}
+
+# Parallel stash for revert: same shape, holds the value the prop had BEFORE
+# the first patch on that (scene, node, prop) triple. Subsequent patches to
+# the same prop don't overwrite -- revert restores true original state.
+# Populated inside _apply_patches_for_scene_root the first time a live
+# instance gets a prop set, not at patch() call time (we don't hold the
+# instance yet at that point).
+var _scene_node_stash: Dictionary = {}
+
+# Guard against connecting the node_added signal twice across
+# frameworks_ready emissions (shouldn't happen, but belt-and-suspenders).
+var _scene_nodes_listener_connected: bool = false
+
+# Entry point invoked from hooks_api._register_core_hooks after frameworks_ready.
+# Idempotent.
+func _scene_nodes_connect_listener() -> void:
+	if _scene_nodes_listener_connected:
+		return
+	var tree := get_tree()
+	if tree == null:
+		_log_warning("[Registry] scene_nodes: no SceneTree at connect time; listener disabled")
+		return
+	tree.node_added.connect(_on_any_node_added)
+	_scene_nodes_listener_connected = true
+
+func _on_any_node_added(node: Node) -> void:
+	# Cheap filter: Godot only sets scene_file_path on the ROOT of an
+	# instantiated scene, so 99.9% of node_added events short-circuit here.
+	var scene_path: String = node.scene_file_path
+	if scene_path.is_empty():
+		return
+	if not _scene_node_patches.has(scene_path):
+		return
+	_apply_patches_for_scene_root(scene_path, node)
+
+func _apply_patches_for_scene_root(scene_path: String, scene_root: Node) -> void:
+	var per_node: Dictionary = _scene_node_patches[scene_path]
+	var stash_per_scene: Dictionary = _scene_node_stash.get(scene_path, {})
+	for node_path in per_node.keys():
+		var target: Node = scene_root.get_node_or_null(NodePath(node_path))
+		if target == null:
+			_log_warning("[Registry] scene_nodes: node '%s' not found in instantiated '%s'; patch skipped for this instance" \
+					% [node_path, scene_path])
+			continue
+		var props: Dictionary = per_node[node_path]
+		var stash_per_node: Dictionary = stash_per_scene.get(node_path, {})
+		for prop in props.keys():
+			var fname: String = String(prop)
+			if not _node_has_property(target, fname):
+				_log_warning("[Registry] scene_nodes: property '%s' not found on node '%s' in '%s'; skipped" \
+						% [fname, node_path, scene_path])
+				continue
+			if not stash_per_node.has(fname):
+				stash_per_node[fname] = target.get(fname)
+			target.set(fname, props[fname])
+		stash_per_scene[node_path] = stash_per_node
+	_scene_node_stash[scene_path] = stash_per_scene
+
+# Split 'scene#node' id on the first '#'. Returns [scene_path, node_path] or
+# [null, null] on malformed input.
+func _split_scene_node_id(id: String) -> Array:
+	var hash_idx: int = id.find("#")
+	if hash_idx <= 0 or hash_idx == id.length() - 1:
+		return [null, null]
+	var scene_path: String = id.substr(0, hash_idx)
+	var node_path: String = id.substr(hash_idx + 1)
+	if not scene_path.begins_with("res://"):
+		return [null, null]
+	return [scene_path, node_path]
+
+# Check property existence at patch-time against a freshly-instantiated
+# probe. We don't require the scene to be in the tree at patch() time
+# mods call this from _ready() before the UI scene loads. Instead we load
+# the PackedScene and peek at the target node by instantiating and freeing.
+# This is a per patch() call but only on cold paths (mod boot).
+# Returns true if the (scene, node, props) triple is well-formed, false if
+# any piece doesn't resolve (with a warn on each failure).
+func _validate_scene_node_patch(scene_path: String, node_path: String, fields: Dictionary) -> bool:
+	var pscene := load(scene_path)
+	if pscene == null or not (pscene is PackedScene):
+		push_warning("[Registry] patch('scene_nodes'): scene '%s' failed to load (not a PackedScene)" % scene_path)
+		return false
+	var probe: Node = (pscene as PackedScene).instantiate()
+	if probe == null:
+		push_warning("[Registry] patch('scene_nodes'): scene '%s' failed to instantiate for validation" % scene_path)
+		return false
+	var target: Node = probe.get_node_or_null(NodePath(node_path))
+	if target == null:
+		push_warning("[Registry] patch('scene_nodes', '%s#%s'): node path doesn't resolve in the scene; check node hierarchy" \
+				% [scene_path, node_path])
+		probe.queue_free()
+		return false
+	for prop in fields.keys():
+		if not _node_has_property(target, String(prop)):
+			push_warning("[Registry] patch('scene_nodes', '%s#%s'): property '%s' not found on node (class=%s)" \
+					% [scene_path, node_path, prop, target.get_class()])
+			probe.queue_free()
+			return false
+	probe.queue_free()
+	return true
+
+# Does `node` have a declared property named `prop`? Mirrors
+# _resource_has_property from shared.gd but for Node. (Nodes expose both
+# class properties and script properties through get_property_list.)
+func _node_has_property(node: Node, prop: String) -> bool:
+	for p in node.get_property_list():
+		if p.get("name") == prop:
+			return true
+	return false
+
+func _patch_scene_node(id: String, fields: Dictionary) -> bool:
+	if fields.is_empty():
+		push_warning("[Registry] patch('scene_nodes', '%s'): empty fields dict is a no-op" % id)
+		return false
+	var parts := _split_scene_node_id(id)
+	var scene_path = parts[0]
+	var node_path = parts[1]
+	if scene_path == null:
+		push_warning("[Registry] patch('scene_nodes', '%s'): id must be '<res://scene_path>#<node_path>'" % id)
+		return false
+	if not _validate_scene_node_patch(scene_path, node_path, fields):
+		return false
+	# Connect the listener lazily, in case a mod patches before
+	# frameworks_ready fires. Idempotent.
+	_scene_nodes_connect_listener()
+	var per_node: Dictionary = _scene_node_patches.get(scene_path, {})
+	var props: Dictionary = per_node.get(node_path, {})
+	for prop in fields.keys():
+		props[String(prop)] = fields[prop]
+	per_node[node_path] = props
+	_scene_node_patches[scene_path] = per_node
+	# Track into _registry_patched so the rest of the registry subsystem
+	# sees a consistent shape: scene_nodes -> {id -> {prop -> value}}.
+	# Note: the STASH (for revert) is populated at apply time, not here.
+	var patched: Dictionary = _registry_patched.get("scene_nodes", {})
+	var pat_entry: Dictionary = patched.get(id, {})
+	for prop in fields.keys():
+		pat_entry[String(prop)] = fields[prop]
+	patched[id] = pat_entry
+	_registry_patched["scene_nodes"] = patched
+	# Apply immediately to any scene instance already in the tree. Covers
+	# the case where a mod patches after the scene was instantiated (rare
+	# but legal -- e.g. a config-menu toggle flipping a UI property live).
+	_apply_patch_to_live_instances(scene_path)
+	_log_debug("[Registry] patched scene node '%s' (%d field(s))" % [id, fields.size()])
+	return true
+
+# Scan the current tree for any live instance of `scene_path`, re-applying
+# all registered patches for that scene. Called from _patch_scene_node so
+# late patches land on already-instantiated scenes.
+func _apply_patch_to_live_instances(scene_path: String) -> void:
+	var tree := get_tree()
+	if tree == null:
+		return
+	_walk_for_scene_roots(tree.root, scene_path)
+
+func _walk_for_scene_roots(node: Node, scene_path: String) -> void:
+	if node.scene_file_path == scene_path:
+		_apply_patches_for_scene_root(scene_path, node)
+		# Don't recurse into an already-matched root; its children can't
+		# have the SAME scene_file_path unless they're nested instances
+		# of the same scene, which is legal but exceedingly rare. A deeper
+		# nested instance will also surface via node_added on its own.
+		return
+	for child in node.get_children():
+		_walk_for_scene_roots(child, scene_path)
+
+# Revert. Fields-empty: revert every prop on the id. Fields-nonempty:
+# per-field revert. Restoration writes the stashed original value back to
+# every live instance (found via tree walk) AND erases the patch so future
+# instantiations see vanilla.
+func _revert_scene_node(id: String, fields: Array) -> bool:
+	var parts := _split_scene_node_id(id)
+	var scene_path = parts[0]
+	var node_path = parts[1]
+	if scene_path == null:
+		push_warning("[Registry] revert('scene_nodes', '%s'): id must be '<res://scene_path>#<node_path>'" % id)
+		return false
+	var patched: Dictionary = _registry_patched.get("scene_nodes", {})
+	if not patched.has(id):
+		push_warning("[Registry] revert('scene_nodes', '%s'): nothing patched at that id" % id)
+		return false
+	var pat_entry: Dictionary = patched[id]
+	var per_node: Dictionary = _scene_node_patches.get(scene_path, {})
+	var props: Dictionary = per_node.get(node_path, {})
+	var stash_per_scene: Dictionary = _scene_node_stash.get(scene_path, {})
+	var stash_per_node: Dictionary = stash_per_scene.get(node_path, {})
+	var targets: Array[String] = []
+	if fields.is_empty():
+		for k in pat_entry.keys():
+			targets.append(String(k))
+	else:
+		for k in fields:
+			targets.append(String(k))
+	# Restore stashed values on live instances.
+	var live_roots: Array[Node] = []
+	var tree := get_tree()
+	if tree != null:
+		_collect_scene_roots(tree.root, scene_path, live_roots)
+	for fname in targets:
+		if not stash_per_node.has(fname) and fields.is_empty() == false:
+			# Per-field revert for a field that was never applied to any
+			# live instance: it won't have a stashed original. We still
+			# want to drop the patch, but there's nothing to restore on
+			# live instances.
+			push_warning("[Registry] revert('scene_nodes', '%s'): field '%s' wasn't patched (or never observed on a live instance)" % [id, fname])
+			continue
+		if stash_per_node.has(fname):
+			for root in live_roots:
+				var target: Node = root.get_node_or_null(NodePath(node_path))
+				if target != null and _node_has_property(target, fname):
+					target.set(fname, stash_per_node[fname])
+			stash_per_node.erase(fname)
+		props.erase(fname)
+		pat_entry.erase(fname)
+	# Prune empty nested dicts to keep state clean.
+	if props.is_empty():
+		per_node.erase(node_path)
+	else:
+		per_node[node_path] = props
+	if per_node.is_empty():
+		_scene_node_patches.erase(scene_path)
+	else:
+		_scene_node_patches[scene_path] = per_node
+	if stash_per_node.is_empty():
+		stash_per_scene.erase(node_path)
+	else:
+		stash_per_scene[node_path] = stash_per_node
+	if stash_per_scene.is_empty():
+		_scene_node_stash.erase(scene_path)
+	else:
+		_scene_node_stash[scene_path] = stash_per_scene
+	if pat_entry.is_empty():
+		patched.erase(id)
+	else:
+		patched[id] = pat_entry
+	_registry_patched["scene_nodes"] = patched
+	_log_debug("[Registry] reverted scene_nodes '%s' (fields=%s)" % [id, targets])
+	return true
+
+func _collect_scene_roots(node: Node, scene_path: String, out: Array[Node]) -> void:
+	if node.scene_file_path == scene_path:
+		out.append(node)
+		return
+	for child in node.get_children():
+		_collect_scene_roots(child, scene_path, out)

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -510,6 +510,9 @@ func _rebuild_mods_tab(tabs: TabContainer) -> void:
 	tabs.add_child(new_tab)
 	tabs.move_child(new_tab, idx)
 	tabs.current_tab = idx
+	# Profile switches / dev-mode toggles change enable state without
+	# hitting the per-row checkbox handler.
+	refresh_launch_button_label()
 
 # Parent a dialog on the launcher window (fallback: tree root) so it layers
 # over our always_on_top Window, and copy our dark theme onto it since theme
@@ -1023,6 +1026,7 @@ func show_mod_ui() -> void:
 	launch_btn.add_theme_color_override("font_color", Color(0.88, 0.88, 0.88))
 	launch_btn.add_theme_color_override("font_hover_color", Color(1.0, 1.0, 1.0))
 	bottom.add_child(launch_btn)
+	_ui_launch_btn = launch_btn
 
 	# Closing the window with X should behave the same as clicking Launch.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
@@ -1034,6 +1038,8 @@ func show_mod_ui() -> void:
 	var updates_tab := build_updates_tab()
 	updates_tab.name = "Updates"
 	tabs.add_child(updates_tab)
+
+	refresh_launch_button_label()
 
 	# Launch loop. If any enabled mod has the scanner's RED risk_level,
 	# show a confirmation dialog before proceeding. Cancel returns the
@@ -1050,7 +1056,24 @@ func show_mod_ui() -> void:
 		# else: loop and wait for Launch again
 	_ui_window = null
 	_ui_hint_label = null
+	_ui_launch_btn = null
 	win.queue_free()
+
+# Pessimistic label: any enabled mod -> "(Restart)". Over-warn beats a
+# surprise close/reopen; the rare hash-match no-restart case just launches
+# faster than promised.
+func refresh_launch_button_label() -> void:
+	if not is_instance_valid(_ui_launch_btn):
+		return
+	var any_enabled := false
+	for entry in _ui_mod_entries:
+		if entry.get("enabled", false):
+			any_enabled = true
+			break
+	if any_enabled:
+		_ui_launch_btn.text = "  Launch with Mods (Restart)  "
+	else:
+		_ui_launch_btn.text = "  Launch Unmodded  "
 
 # Runtime-generated 16x16 pencil icon. Monochrome outline in button-text
 # gray so it matches the rest of the UI -- a colored pencil looks like an
@@ -1632,6 +1655,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			e["enabled"] = on
 			nlbl.modulate = Color(0.58, 0.82, 0.38) if on else Color(0.5, 0.5, 0.5)
 			refresh_order.call()
+			refresh_launch_button_label()
 			_save_ui_config()
 		)
 		spin.value_changed.connect(func(val: float):

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -107,8 +107,6 @@ func _apply_profile_to_entries(cfg: ConfigFile, profile: String) -> void:
 			entry["enabled"] = bool(cfg.get_value(en_sec, resolved_key))
 		else:
 			entry["enabled"] = true
-		if entry["ext"] == "zip":
-			entry["enabled"] = false
 		if resolved_key != "" and cfg.has_section_key(pr_sec, resolved_key):
 			entry["priority"] = int(str(cfg.get_value(pr_sec, resolved_key)))
 
@@ -1634,7 +1632,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 		# Vanilla has no stored profile; disable editing so auto-save can't
 		# create a ghost `profile.__vanilla__.*` section.
-		if entry["ext"] == "zip" or on_vanilla:
+		if on_vanilla:
 			check.disabled = true
 
 		var spin := SpinBox.new()
@@ -1642,7 +1640,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
-		if entry["ext"] == "zip" or on_vanilla:
+		if on_vanilla:
 			spin.editable = false
 		row.add_child(spin)
 


### PR DESCRIPTION
## 3.1.0 release PR

Merges 3.1.0 work from `development` into `master`. On merge, the release-please bot opens a `chore(master): release 3.1.0` PR that bumps `MODLOADER_VERSION` in `src/constants.gd` and cuts the `v3.1.0` tag + GitHub Release. The release workflow rebuilds `modloader.gd` from `src/` and uploads `modloader.gd`, `override.cfg`, `windows-installer.bat`, and `linux-installer.sh` as release assets.

## What's in 3.1.0

### Features

- **Scene Nodes registry** ([#44](https://github.com/ametrocavich/vostok-mod-loader/pull/44)) — new `lib.patch(SCENE_NODES, "<scene>#<node_path>", {...})` verb for mutating node properties inside vanilla scenes without shipping a full-scene override. Subscribes to `node_added` and applies patches before `_ready`, so `@onready` values observe the patched state. Patch-only (no register / override / remove); use `override('scenes', ...)` for structural changes. Also auto-unlocks the crafting Equipment / Misc tabs when a mod registers a recipe into either.

- **`.zip` mods load directly** ([#45](https://github.com/ametrocavich/vostok-mod-loader/pull/45)) — previously `.zip` files in `mods/` were discovered but force-disabled with a "rename to .vmz" hint. `.zip` is now treated identically to `.vmz`: no rename required, no UI edit lock, no mount-time skip. The `.vmz` extension stays supported for existing mods.

- **Dynamic Launch button label** ([#42](https://github.com/ametrocavich/vostok-mod-loader/pull/42)) — the launcher's Launch button now reads **Launch with Mods (Restart)** when any mod is enabled and **Launch Unmodded** otherwise. Warns users up front about the close/reopen that follows an enabled-mod launch. Refreshes on per-row toggles, profile switches, and dev-mode toggles.

### Bug Fixes

- **Preserve `--rendering-driver` / `--rendering-method` across modloader restart** ([#41](https://github.com/ametrocavich/vostok-mod-loader/pull/41)) — Godot's arg parser (`main.cpp:1272,1280`) consumes these flags and does **not** push them back to `main_args`, so `OS.get_cmdline_args()` returned the stripped list. Piping that into `set_restart_on_exit` dropped whatever Steam passed, so the relaunch fell back to the default driver (D3D12 on Windows). Only visible on fresh-install first launch; subsequent launches short-circuit on the mod-state hash and never restart. Re-injects the active driver/method by querying `RenderingServer` before appending the `--modloader-restart` separator. Scoped narrowly to the two flags RTV's Steam launch-option presets actually set.

### Performance

- **Memoize `scene_nodes` patch validation** ([#46](https://github.com/ametrocavich/vostok-mod-loader/pull/46)) — `_validate_scene_node_patch` instantiated + freed the PackedScene on every call. `recipes.gd:_unlock_crafting_category_button_if_needed` fires inside `_register_recipe` for every recipe added to equipment or misc, so a mod registering N recipes was paying N `Interface.tscn` instantiates at boot. Cache successful validations keyed by `<scene>#<node>|<sorted,field,names>`. Worst case drops from O(N) to 2 probes per boot. Only positive results cache; bad paths keep re-emitting the warning. Runtime `_node_has_property` enforcement is untouched.

## Release-please

- `.release-please-manifest.json` at `3.0.1` → next run parses 3 `feat:` + 1 `fix:` + 1 `perf:` since v3.0.1 and computes `3.1.0` (feat dominates, minor bump).
- `MODLOADER_VERSION` in `src/constants.gd` at `3.0.1`; release-please updates it when the chore PR merges.
- CHANGELOG.md regenerated automatically.

## Test plan

- [ ] Clean install: drop `modloader.gd` + `override.cfg` into the RTV folder; UI opens and Launch button reads "Launch Unmodded"
- [ ] Enable one mod: Launch button flips to "Launch with Mods (Restart)"
- [ ] Drop a `.zip` mod (no rename) into `mods/`: appears in the UI, enable + launch works, no "rename to .vmz" warning
- [ ] Steam launch option `--rendering-driver vulkan` persists across the modloader-triggered restart (`RenderingServer.get_current_rendering_driver_name()` returns `vulkan` in-game after restart)
- [ ] Scene Nodes patch: mod calls `lib.patch(lib.Registry.SCENE_NODES, "res://UI/Interface.tscn#Tools/Crafting/Types/Margin/Buttons/Equipment", {disabled = false})`; the Equipment tab is enabled at runtime
- [ ] Mod that registers recipes into equipment: Equipment + Misc tabs auto-unlock via scene_nodes patch; `_validate_scene_node_patch` cache hits on repeat registrations (no N x Interface.tscn instantiate at boot)
- [ ] Legacy modlist (no `.zip` mods, no scene_nodes patches) boots byte-identical to v3.0.1
- [ ] Release-please bot opens `chore(master): release 3.1.0` after merge; merging that PR cuts the `v3.1.0` tag and uploads assets