### PR TITLE
fix: enumerate vanilla scripts before .hook() prefix merge

### DIFF
--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -90,6 +90,13 @@ func _run_pass_1() -> void:
 	_check_safe_mode()
 	_compile_regex()
 	_build_class_name_lookup()
+	# Populate _all_game_script_paths NOW so the .hook() prefix resolver in
+	# _merge_hook_calls_into_wrap_mask (run from load_all_mods below) can
+	# fall back to filename-stem matches for vanilla scripts without
+	# class_name (Flashlight, NVG, Interface, ...). Previously this only
+	# ran inside _generate_hook_pack, so source-scanned hooks on
+	# class_name-less scripts were silently dropped.
+	_enumerate_game_scripts()
 	_load_developer_mode_setting()
 	_ui_mod_entries = collect_mod_metadata()
 	_clean_stale_cache()
@@ -226,6 +233,9 @@ func _run_pass_2() -> void:
 	_clear_restart_counter()
 	_compile_regex()
 	_build_class_name_lookup()
+	# See _run_pass_1: enumerate before load_all_mods so filename-stem
+	# fallback in _merge_hook_calls_into_wrap_mask is populated.
+	_enumerate_game_scripts()
 	_load_developer_mode_setting()
 	_ui_mod_entries = collect_mod_metadata()
 	_load_ui_config()

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -82,6 +82,13 @@ func _merge_hook_calls_into_wrap_mask() -> void:
 			var prefix: String = entry["prefix"]
 			var method: String = entry["method"]
 			if not prefix_to_path.has(prefix):
+				# Source-scan saw a .hook("<prefix>-<method>-...") call but
+				# we can't resolve <prefix> to any vanilla script. After the
+				# pass-1/pass-2 reorder this should only fire for genuine
+				# typos or hooks targeting a renamed/removed script -- log
+				# loudly so the mod author isn't debugging a silent miss.
+				_log_warning("[Hooks] %s calls .hook(\"%s-%s-...\") but no vanilla script matches prefix '%s' -- check spelling, or declare the path in [hooks] in mod.txt" \
+						% [mod_name, prefix, method, prefix])
 				continue
 			var path: String = prefix_to_path[prefix]
 			if not _hooked_methods.has(path):

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -93,6 +93,12 @@ func _get_hardcoded_class_map() -> Dictionary:
 	}
 
 func _enumerate_game_scripts() -> Array[String]:
+	# Memoized: PCK parsing is non-trivial and we call this from two sites
+	# now (early in pass 1/2 so the .hook() merge can resolve class_name-less
+	# stems, plus from _generate_hook_pack as before). Cache keeps the second
+	# call free without forcing the caller to track lookup state.
+	if not _all_game_script_paths.is_empty():
+		return _all_game_script_paths
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var candidates := ["RTV.pck", OS.get_executable_path().get_file().get_basename() + ".pck"]
 	for cand in candidates:


### PR DESCRIPTION
## Summary

Source-scanned `.hook("<prefix>-<method>-...")` calls in mod source were silently dropped for vanilla scripts without `class_name` (Flashlight, NVG, Interface, FishPool, Inputs, Character, Loader, Menu, ~80 others).

`_merge_hook_calls_into_wrap_mask` (called at the end of `load_all_mods`) resolves the `<prefix>` via `_class_name_to_path`, then falls back to a filename-stem match against `_all_game_script_paths`. That fallback was empty: `_all_game_script_paths` was only populated inside `_generate_hook_pack` -> `_enumerate_game_scripts`, which runs **after** the merge. So any `.hook()` targeting a class_name-less script silently went into `if not prefix_to_path.has(prefix): continue` with no log.

The wiki promises "If your mod calls `.hook(...)` directly in its source, you don't need any `mod.txt` declaration." That promise was broken for the majority of vanilla scripts.

### Repro

A mod whose source contains `.hook("flashlight-consumption-pre", cb)` and no `[hooks]` block in mod.txt. Loader log shows `Surface-skip Flashlight.gd (no mod extends/hooks/overrides)` despite the source containing the call.

### Fix

Three small changes:

- **`src/pck_enumeration.gd`** — memoize `_enumerate_game_scripts()` so the second call (from `_generate_hook_pack`) is a no-op
- **`src/lifecycle.gd`** — call `_enumerate_game_scripts()` in `_run_pass_1` and `_run_pass_2` right after `_build_class_name_lookup()`, before `load_all_mods`
- **`src/mod_loading.gd`** — log a warning at the dropped-prefix branch so genuine typos / hooks targeting renamed/removed scripts surface as actionable boot-log messages instead of silent misses

Surfaced when shipping a real mod (Configurable Battery Drain) that hooks `Flashlight.gd` and `NVG.gd`.

## Test plan

- [ ] Load a test mod calling `.hook("flashlight-consumption-pre", cb)` from `_on_lib_ready()`, with no `[hooks]` block in mod.txt.
- [ ] Boot log shows `Rewrote Scripts/Flashlight.gd (N hooks)` instead of `Surface-skip Flashlight.gd`.
- [ ] DISPATCH-COUNT table at 30s shows `flashlight-consumption` with non-zero count after triggering the in-game action.
- [ ] Verify a typo'd `.hook("flashligth-foo-pre", cb)` (with intentional misspelling) produces the new `[Hooks] mod calls .hook(...) but no vanilla script matches prefix 'flashligth'` warning instead of dying silently.
- [ ] Existing mods (AI Overhaul, MCM, IXP) that already work via class_name'd scripts still load identically (`_enumerate_game_scripts` memoized -- no extra PCK parses).