### PR TITLE
release: tolerant [hooks] parse + .hook() prefix resolution

### DIFF
--- a/src/constants.gd
+++ b/src/constants.gd
@@ -106,6 +106,11 @@ var _ui_hint_label: Label = null
 var _ui_launch_btn: Button = null
 var _has_loaded := false
 var _last_mod_txt_status := "none"
+# Detailed parse-failure diagnostic written by _parse_mod_txt when ConfigFile
+# rejects mod.txt. Plumbed into UI warnings + boot-log messages so authors
+# see *which* line/section broke instead of a generic "Invalid mod" prompt.
+# Empty when status != "parse_error".
+var _last_mod_txt_error := ""
 var _database_replaced_by := ""
 # Post-boot UI re-open state. _boot_complete flips true once Pass 1 / Pass 2 /
 # single-pass finish paths finalize. Once true, any mutation of mod_config.cfg

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -146,6 +146,11 @@ static func _static_resolve_remaps(archive_path: String) -> int:
 
 func read_mod_config(path: String) -> ConfigFile:
 	_last_mod_txt_status = "none"
+	# Reset diagnostic alongside status: paths below (empty mod.txt, missing
+	# mod.txt, ZIPReader open failure) set parse_error without going through
+	# _parse_mod_txt, so without this reset the prior mod's error message
+	# would leak into the next mod's launcher warning.
+	_last_mod_txt_error = ""
 	var zr := ZIPReader.new()
 	if zr.open(path) != OK:
 		return null
@@ -173,6 +178,7 @@ func read_mod_config(path: String) -> ConfigFile:
 
 func read_mod_config_folder(folder_path: String) -> ConfigFile:
 	_last_mod_txt_status = "none"
+	_last_mod_txt_error = ""  # see read_mod_config for rationale
 	var mod_txt_path := folder_path.path_join("mod.txt")
 	if not FileAccess.file_exists(mod_txt_path):
 		return null
@@ -189,10 +195,29 @@ func read_mod_config_folder(folder_path: String) -> ConfigFile:
 	return cfg
 
 func _parse_mod_txt(text: String) -> ConfigFile:
+	_last_mod_txt_error = ""
 	if text.begins_with("\uFEFF"):
 		text = text.substr(1)
+	# Tolerate the wiki-documented [hooks] form. The Hooks/Mod-Format wiki
+	# pages show entries like:
+	#     res://Scripts/Interface.gd = _ready, update_tooltip
+	#     res://Scripts/Controller.gd = *
+	# but Godot's ConfigFile uses the Variant parser for values, which
+	# rejects unquoted identifier lists, bare `*`, and top-level commas.
+	# Authors following the docs verbatim hit a parse_error and the generic
+	# "Invalid mod -- try re-downloading" prompt. Quote-wrapping the values
+	# before cfg.parse() lets the wiki form land as a string and downstream
+	# code (mod_loading.gd's [hooks] reader) handles the comma-split itself.
+	# Already-quoted entries pass through unchanged.
+	var preprocessed := _quote_unquoted_hooks_values(text)
 	var cfg := ConfigFile.new()
-	if cfg.parse(text) != OK:
+	if cfg.parse(preprocessed) != OK:
+		# The Variant-parser failure code from cfg.parse() doesn't carry the
+		# offending line number. Walk the source per-line to locate it; the
+		# diagnostic flows through _last_mod_txt_error -> mod_txt_error on
+		# the entry -> launcher warning + boot log so authors see the broken
+		# section/line instead of a generic "re-download" hint.
+		_last_mod_txt_error = _diagnose_parse_failure(preprocessed)
 		return null
 	# Godot's ConfigFile drops empty sections, so a bare `[registry]` header
 	# with no body gets silently dropped and cfg.has_section("registry") returns
@@ -206,6 +231,95 @@ func _parse_mod_txt(text: String) -> ConfigFile:
 			cfg.set_value("registry", "_modloader_header_present", true)
 			break
 	return cfg
+
+# Quote the values of unquoted entries inside [hooks] sections. Wiki examples
+# document `path = method1, method2` / `path = *` / `path =` -- all rejected
+# by ConfigFile's Variant parser. Wrap unquoted right-hand-sides in double
+# quotes so they parse as plain strings; mod_loading.gd's [hooks] handler
+# already comma-splits and lowercases the result.
+#
+# Already-quoted values (the AI Overhaul pattern) pass through verbatim so
+# we don't change behavior for mods that got the syntax right. Inline
+# `# comment` / `; comment` on these lines is stripped before wrapping --
+# Variant parser eats it natively for raw values, but once we quote the
+# right-hand side a trailing comment becomes part of the string.
+func _quote_unquoted_hooks_values(text: String) -> String:
+	var lines := text.split("\n")
+	var out := PackedStringArray()
+	var in_hooks := false
+	for line in lines:
+		var stripped := line.strip_edges()
+		# Section header: track whether we just entered/left [hooks].
+		if stripped.begins_with("[") and stripped.ends_with("]"):
+			in_hooks = stripped.to_lower() == "[hooks]"
+			out.append(line)
+			continue
+		if not in_hooks:
+			out.append(line)
+			continue
+		if stripped.is_empty() or stripped.begins_with("#") or stripped.begins_with(";"):
+			out.append(line)
+			continue
+		var eq_pos := line.find("=")
+		if eq_pos < 0:
+			out.append(line)
+			continue
+		var key_part := line.substr(0, eq_pos)
+		var val_part := line.substr(eq_pos + 1)
+		if val_part.strip_edges(true, false).begins_with("\""):
+			# Already quoted -- ConfigFile + Variant parser handle it.
+			out.append(line)
+			continue
+		var comment := ""
+		var comment_pos := -1
+		for j in val_part.length():
+			var ch := val_part[j]
+			if ch == "#" or ch == ";":
+				comment_pos = j
+				break
+		if comment_pos >= 0:
+			comment = val_part.substr(comment_pos)
+			val_part = val_part.substr(0, comment_pos)
+		var val_trim := val_part.strip_edges()
+		var escaped := val_trim.replace("\\", "\\\\").replace("\"", "\\\"")
+		var rebuilt := "%s= \"%s\"" % [key_part, escaped]
+		if not comment.is_empty():
+			rebuilt += "  " + comment
+		out.append(rebuilt)
+	return "\n".join(out)
+
+# Locate the first line that ConfigFile.parse() would reject. Used only on
+# the failure path -- the per-line probe is O(N) parses but only fires when
+# the mod is already broken, and the result lets the launcher tell authors
+# *which* line/section to look at instead of "Invalid mod, re-download".
+func _diagnose_parse_failure(text: String) -> String:
+	var current_section := ""
+	var line_num := 0
+	for line in text.split("\n"):
+		line_num += 1
+		var stripped := line.strip_edges()
+		if stripped.is_empty() or stripped.begins_with("#") or stripped.begins_with(";"):
+			continue
+		if stripped.begins_with("[") and stripped.ends_with("]"):
+			current_section = stripped.substr(1, stripped.length() - 2)
+			continue
+		var probe := ConfigFile.new()
+		var header := ""
+		if current_section != "":
+			header = "[%s]\n" % current_section
+		if probe.parse(header + line + "\n") != OK:
+			var section_label := ("[%s]" % current_section) if current_section != "" else "(no section)"
+			return "line %d %s: %s" % [line_num, section_label, _truncate_for_log(stripped)]
+	# Fall-through: per-line probes all passed but the full parse failed.
+	# Could happen with a section-header / multi-line value interaction we
+	# don't model. Return a generic locator so the user at least knows we
+	# detected the failure but couldn't pin the line.
+	return "could not pin line (full parse failed but per-line probes passed)"
+
+func _truncate_for_log(s: String) -> String:
+	if s.length() <= 80:
+		return s
+	return s.substr(0, 77) + "..."
 
 # Folder -> temp zip (developer mode). Zips a mod's source folder to a temp
 # .zip in the cache dir so it can be mounted like any other archive.

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -90,6 +90,13 @@ func _run_pass_1() -> void:
 	_check_safe_mode()
 	_compile_regex()
 	_build_class_name_lookup()
+	# Populate _all_game_script_paths NOW so the .hook() prefix resolver in
+	# _merge_hook_calls_into_wrap_mask (run from load_all_mods below) can
+	# fall back to filename-stem matches for vanilla scripts without
+	# class_name (Flashlight, NVG, Interface, ...). Previously this only
+	# ran inside _generate_hook_pack, so source-scanned hooks on
+	# class_name-less scripts were silently dropped.
+	_enumerate_game_scripts()
 	_load_developer_mode_setting()
 	_ui_mod_entries = collect_mod_metadata()
 	_clean_stale_cache()
@@ -226,6 +233,9 @@ func _run_pass_2() -> void:
 	_clear_restart_counter()
 	_compile_regex()
 	_build_class_name_lookup()
+	# See _run_pass_1: enumerate before load_all_mods so filename-stem
+	# fallback in _merge_hook_calls_into_wrap_mask is populated.
+	_enumerate_game_scripts()
 	_load_developer_mode_setting()
 	_ui_mod_entries = collect_mod_metadata()
 	_load_ui_config()

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -166,6 +166,7 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		"profile_key": profile_key,
 		"priority": priority, "enabled": true,
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
+		"mod_txt_error": _last_mod_txt_error,
 	}
 	return entry
 
@@ -178,7 +179,14 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 	if status == "none":
 		warnings.append("Invalid mod -- may not work correctly. Try re-downloading.")
 	elif status == "parse_error":
-		warnings.append("Invalid mod -- may not work correctly. Try re-downloading.")
+		# Surface the line/section the parser tripped on so authors can
+		# self-correct instead of staring at a generic "re-download" hint
+		# when the real problem is a typo in their own mod.txt.
+		var detail: String = entry.get("mod_txt_error", "")
+		if detail.is_empty():
+			warnings.append("Invalid mod -- mod.txt failed to parse. Try re-downloading.")
+		else:
+			warnings.append("mod.txt parse error at " + detail)
 	elif status.begins_with("nested:"):
 		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
 	return warnings

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -82,6 +82,13 @@ func _merge_hook_calls_into_wrap_mask() -> void:
 			var prefix: String = entry["prefix"]
 			var method: String = entry["method"]
 			if not prefix_to_path.has(prefix):
+				# Source-scan saw a .hook("<prefix>-<method>-...") call but
+				# we can't resolve <prefix> to any vanilla script. After the
+				# pass-1/pass-2 reorder this should only fire for genuine
+				# typos or hooks targeting a renamed/removed script -- log
+				# loudly so the mod author isn't debugging a silent miss.
+				_log_warning("[Hooks] %s calls .hook(\"%s-%s-...\") but no vanilla script matches prefix '%s' -- check spelling, or declare the path in [hooks] in mod.txt" \
+						% [mod_name, prefix, method, prefix])
 				continue
 			var path: String = prefix_to_path[prefix]
 			if not _hooked_methods.has(path):

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -145,7 +145,11 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 			if status.begins_with("nested:"):
 				_log_warning("  Invalid mod -- packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
 			elif status == "parse_error":
-				_log_warning("  Invalid mod -- mod.txt failed to parse")
+				var detail: String = c.get("mod_txt_error", "")
+				if detail.is_empty():
+					_log_warning("  Invalid mod -- mod.txt failed to parse")
+				else:
+					_log_warning("  Invalid mod -- mod.txt parse error at " + detail)
 			else:
 				_log_warning("  No mod.txt -- autoloads skipped")
 		return

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -93,6 +93,12 @@ func _get_hardcoded_class_map() -> Dictionary:
 	}
 
 func _enumerate_game_scripts() -> Array[String]:
+	# Memoized: PCK parsing is non-trivial and we call this from two sites
+	# now (early in pass 1/2 so the .hook() merge can resolve class_name-less
+	# stems, plus from _generate_hook_pack as before). Cache keeps the second
+	# call free without forcing the caller to track lookup state.
+	if not _all_game_script_paths.is_empty():
+		return _all_game_script_paths
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var candidates := ["RTV.pck", OS.get_executable_path().get_file().get_basename() + ".pck"]
 	for cand in candidates:


### PR DESCRIPTION
Bundles two bug fixes merged to `development`.

## Included

- [#49](https://github.com/ametrocavich/vostok-mod-loader/pull/49) fix: enumerate vanilla scripts before .hook() prefix merge
- [#50](https://github.com/ametrocavich/vostok-mod-loader/pull/50) fix: tolerantly parse [hooks] mod.txt + diagnose parse errors

## Test plan

- [ ] Smoke launch on RTV with a mix of mods declaring `[hooks]`
- [ ] Confirm a mod with a class_name-less hook target (e.g. Flashlight, NVG) resolves via stem fallback
- [ ] Confirm a malformed `[hooks]` block produces a diagnostic warning instead of silently dropping the mod