### PR TITLE
fix(windows-installer): #54 + two related install-script issues

### DIFF
--- a/windows-installer.bat
+++ b/windows-installer.bat
@@ -131,6 +131,24 @@ if not exist "%MODS_PATH%" (
     echo Mods directory already exists
 )
 
+:: --- Clean up legacy v2 files ---
+:: Metro v2 used %APPDATA%\Road to Vostok\modloader.gd as the install
+:: location. v3 moved to the game folder. After a successful v3 install,
+:: the v2 files in appdata are orphans that do nothing functional but
+:: confuse users (and can mislead a v2-aware diagnostic into reporting
+:: an old install where the live one is now in the game folder).
+:: Run this only after the new files are confirmed in place above, so
+:: a failed v3 install never deletes a working v2 fallback.
+set "LEGACY_DIR=%APPDATA%\Road to Vostok"
+if exist "!LEGACY_DIR!\modloader.gd" (
+    del /f "!LEGACY_DIR!\modloader.gd" >nul 2>&1
+    echo Removed legacy v2 modloader.gd from !LEGACY_DIR!
+)
+if exist "!LEGACY_DIR!\override.cfg" (
+    del /f "!LEGACY_DIR!\override.cfg" >nul 2>&1
+    echo Removed legacy v2 override.cfg from !LEGACY_DIR!
+)
+
 :: --- Done ---
 echo.
 echo === Installation Complete ===

--- a/windows-installer.bat
+++ b/windows-installer.bat
@@ -64,6 +64,11 @@ if !DL_RC! equ 0 if exist "%MODLOADER_TMP%" (
 )
 if !DL_OK! equ 1 (
     move /y "%MODLOADER_TMP%" "%MODLOADER_DEST%" >nul
+    if not exist "%MODLOADER_DEST%" (
+        echo ERROR: Could not move modloader.gd into game folder.
+        echo   Likely cause: game is running, missing write permission, or AV quarantine.
+        goto :error
+    )
     echo Downloaded modloader.gd to game folder
 ) else (
     if exist "%MODLOADER_TMP%" del "%MODLOADER_TMP%" >nul 2>&1
@@ -109,6 +114,11 @@ if exist "%OVERRIDE_PATH%" (
     echo Updated override.cfg
 ) else (
     move /y "%OVERRIDE_TMP%" "%OVERRIDE_PATH%" >nul
+    if not exist "%OVERRIDE_PATH%" (
+        echo ERROR: Could not move override.cfg into game folder.
+        echo   Likely cause: missing write permission, or AV quarantine.
+        goto :error
+    )
     echo Installed override.cfg
 )
 if exist "%OVERRIDE_TMP%" del "%OVERRIDE_TMP%" >nul 2>&1

--- a/windows-installer.bat
+++ b/windows-installer.bat
@@ -72,9 +72,9 @@ if !DL_OK! equ 1 (
     ) else (
         echo ERROR: Failed to download modloader.gd
         echo You can manually download it from:
-        echo   %MODLOADER_URL%
+        echo   !MODLOADER_URL!
         echo And place it at:
-        echo   %MODLOADER_DEST%
+        echo   !MODLOADER_DEST!
         goto :error
     )
 )


### PR DESCRIPTION
Fixes the parse-time `(x86)` failure reported in #54, plus two related issues I noticed in the same install logic. Three small commits, each with its own focused message.

## What's in this PR

1. **#54 fix** — `windows-installer.bat` lines 75/77 use `!VAR!` instead of `%VAR%` so paths containing `(x86)` no longer break parse-time substitution inside the `if (...)` block.

   Verified with a minimal repro: `%VAR%` containing `(x86)` inside a block produces *exactly* the error pattern Dextofen reports (`<word> was unexpected at this time.`), `!VAR!` works clean. `setlocal enabledelayedexpansion` is already enabled on line 2.

2. **Move verification** — both `move /y` calls (modloader.gd and override.cfg) now check `if not exist "%DEST%"` afterward and bail to `:error` with a hint about the likely cause (file locked, permissions, AV quarantine). Previously the script unconditionally echoed success even when the move silently failed.

3. **Legacy v2 cleanup** — Metro v2 used `%APPDATA%\Road to Vostok\modloader.gd`. v3 moved to the game folder but the installer never cleaned up the old v2 files. New cleanup block runs *after* the v3 files are confirmed in place, so a partial install never deletes a working v2 fallback.

## Not in this PR

`linux-installer.sh` has the same patterns at its `mv` calls and lacks `~/.local/share/Road to Vostok/` cleanup. Happy to do that as a separate PR if you'd like — kept this one focused on the issue Dextofen reported and the immediately adjacent Windows-specific issues to keep the diff small and reviewable.

## Repro for #54

```bat
@echo off
setlocal enabledelayedexpansion
set "BAD=C:\Program Files (x86)\foo"
if 1 equ 1 (
    echo %BAD%
)
```

Errors with `\foo was unexpected at this time.` Same mechanism as #54.