### PR TITLE
fix(linux-installer): verify mv operations land at destination

### DIFF
--- a/linux-installer.sh
+++ b/linux-installer.sh
@@ -66,7 +66,12 @@ MODLOADER_TMP="$MODLOADER_DEST.new"
 rm -f "$MODLOADER_TMP"
 echo "Downloading mod loader..."
 if download "$MODLOADER_URL" "$MODLOADER_TMP" && [[ -s "$MODLOADER_TMP" ]]; then
-    mv -f "$MODLOADER_TMP" "$MODLOADER_DEST"
+    if ! mv -f "$MODLOADER_TMP" "$MODLOADER_DEST" || [[ ! -f "$MODLOADER_DEST" ]]; then
+        echo "ERROR: Could not move modloader.gd to $MODLOADER_DEST"
+        echo "  Likely cause: missing write permission, destination on a read-only filesystem,"
+        echo "  or the file is locked by a running game process."
+        exit 1
+    fi
     echo "Downloaded modloader.gd to game folder"
 else
     rm -f "$MODLOADER_TMP"
@@ -213,7 +218,12 @@ if [[ -f "$OVERRIDE_PATH" ]]; then
     echo "Merging override.cfg (preserving user sections, updating template keys)"
     cp -f "$OVERRIDE_PATH" "$OVERRIDE_PATH.bak"
     if merge_override "$OVERRIDE_PATH" "$OVERRIDE_TMP" "$OVERRIDE_PATH.merged" && [[ -s "$OVERRIDE_PATH.merged" ]]; then
-        mv -f "$OVERRIDE_PATH.merged" "$OVERRIDE_PATH"
+        if ! mv -f "$OVERRIDE_PATH.merged" "$OVERRIDE_PATH"; then
+            echo "ERROR: Could not move merged override.cfg into place"
+            echo "  Your original is preserved at $OVERRIDE_PATH.bak"
+            rm -f "$OVERRIDE_PATH.merged"
+            exit 1
+        fi
         echo "Updated override.cfg"
     else
         echo "ERROR: merge failed. Your original is preserved at $OVERRIDE_PATH.bak"
@@ -222,7 +232,11 @@ if [[ -f "$OVERRIDE_PATH" ]]; then
         exit 1
     fi
 else
-    mv -f "$OVERRIDE_TMP" "$OVERRIDE_PATH"
+    if ! mv -f "$OVERRIDE_TMP" "$OVERRIDE_PATH" || [[ ! -f "$OVERRIDE_PATH" ]]; then
+        echo "ERROR: Could not install override.cfg at $OVERRIDE_PATH"
+        echo "  Likely cause: missing write permission, or destination on a read-only filesystem."
+        exit 1
+    fi
     echo "Installed override.cfg"
 fi
 rm -f "$OVERRIDE_TMP"


### PR DESCRIPTION
Linux equivalent of the move-verification fix in #55. Single commit, single file.

The three `mv -f` calls in `linux-installer.sh` (modloader.gd at line 69, merged override.cfg at line 216, first-install override.cfg at line 225) previously ran unchecked. Since the script uses `set -u` but not `set -e`, a failing move (missing write permission, read-only fs, locked file) silently let execution continue and the success message echoed regardless.

Each is now wrapped in an explicit check that aborts with a hint about the likely cause if the move didn't land.

## Why explicit checks instead of `set -e`

The merge_override path uses awk in a pipeline. A blanket `set -e` could mask intentional non-zero awk exits and is harder to reason about than three focused checks. Conservative choice.

## What's NOT in this PR

The Windows installer's v2-leftovers cleanup (PR #55, third commit) doesn't have a clean Linux equivalent because v2's Linux install path is ambiguous:

- Native Godot convention: `~/.local/share/<game>/`
- Proton-emulated Windows: `~/.steam/steam/steamapps/compatdata/<appid>/pfx/drive_c/users/steamuser/AppData/Roaming/Road to Vostok/`

Without confirmation of which path v2 actually wrote to on Linux, I'd rather not guess. Happy to add a cleanup commit if you can confirm the location.