### PR TITLE
fix folder-mode wrapper + add [mod] author field

### DIFF
--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -332,9 +332,15 @@ func zip_folder_to_temp(folder_path: String) -> String:
 	if zp.open(tmp_zip_path) != OK:
 		_log_critical("Failed to create temp zip: " + tmp_zip_path)
 		return ""
-	# Zip contents without a top-level wrapper -- the folder's internal structure
-	# already mirrors the res:// paths the mod expects.
-	_zip_folder_recursive(zp, folder_path, "")
+	# Wrap zip entries under the folder name so res:// paths match what a
+	# conventionally-packed .zip mod produces. A folder at <mods>/MyMod/
+	# containing data/main.gd mounts as res://MyMod/data/main.gd, the same
+	# layout you'd get if MyMod/ were inside a .zip. Without this wrapper,
+	# folder mode dropped contents at res:// directly, so a mod.txt path of
+	# res://MyMod/data/main.gd worked from .zip but resolved nowhere from
+	# the folder. (Pre-v3.1.2 folder mods that relied on the unwrapped
+	# layout need their mod.txt paths re-prefixed with the folder name.)
+	_zip_folder_recursive(zp, folder_path, folder_name)
 	zp.close()
 	return tmp_zip_path
 

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -123,6 +123,7 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 	var mod_name := file_name
 	var mod_id   := file_name
 	var version  := ""
+	var author   := ""
 	var priority := 0
 	var has_mod_id := false
 
@@ -146,6 +147,7 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 			mod_id = str(cfg.get_value("mod", "id"))
 			has_mod_id = true
 		version = str(cfg.get_value("mod", "version", ""))
+		author = str(cfg.get_value("mod", "author", ""))
 		if cfg.has_section_key("mod", "priority"):
 			priority = int(str(cfg.get_value("mod", "priority")))
 		elif has_filename_priority:
@@ -163,6 +165,7 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 	var entry := {
 		"file_name": file_name, "full_path": full_path, "ext": ext,
 		"mod_name": mod_name, "mod_id": mod_id, "version": version,
+		"author": author,
 		"profile_key": profile_key,
 		"priority": priority, "enabled": true,
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,


### PR DESCRIPTION
Two requests from BrianMcBrian on Discord (2026-04-27).

## Summary

- **fix**: folder-mode mods now zip under their folder name as a wrapper, matching the convention for `.zip` mods. Without this, a folder at `<mods>/MyMod/` containing `data/main.gd` mounted at `res://data/main.gd` while the `.zip` form of the same mod mounted at `res://MyMod/data/main.gd` -- so a single `mod.txt` couldn't satisfy both layouts.
- **feat**: optional `author` string in `[mod]` of `mod.txt`. Parsed alongside `name`/`id`/`version`/`priority`; persisted on the entry dict as `author`. No UI yet.

## Breaking change

Folder mods that previously relied on the unwrapped layout will need their `mod.txt` paths re-prefixed with the folder name. Folder mode is dev-only (developer-mode toggle), the prior behavior wasn't documented, and the inconsistency between folder-mode and `.zip` was the actual bug. Worth a single mention in release notes; release-please will produce a patch bump.

## Test plan

- [ ] In dev mode, place a mod at `<game>/mods/TestMod/` with `mod.txt` declaring an autoload at `res://TestMod/Main.gd` and the script at `<game>/mods/TestMod/Main.gd`. Launch and confirm the autoload instantiates (previously: missing).
- [ ] Re-pack the same mod as `TestMod.zip` containing `TestMod/Main.gd` + `TestMod/mod.txt`. Confirm it loads identically (paths in `mod.txt` are unchanged).
- [ ] Add `author = "Brian"` to a `mod.txt`, confirm no parse warning. The field shows up on `entry["author"]` (no UI surface yet, so check via debug log if curious).

## Follow-ups (not in this PR)

- Wiki update to describe the new folder-mode contract and document the `author` field. The open docs PR ([#53](https://github.com/ametrocavich/vostok-mod-loader/pull/53)) needs a touch-up before merge so it reflects this.