### PR TITLE
fix: discard stale VMZ cache when source archive is gone

### DIFF
--- a/src/boot.gd
+++ b/src/boot.gd
@@ -103,28 +103,29 @@ static func _mount_previous_session() -> Dictionary:
 
 	# Were any archives deleted since last session?
 	var any_missing := false
-	var any_stale := false
 	for path in paths:
 		var abs_path := path if not path.begins_with("res://") and not path.begins_with("user://") \
 				else ProjectSettings.globalize_path(path)
 		if FileAccess.file_exists(abs_path):
 			log_lines.append("[FileScope]   EXISTS: " + abs_path)
 			continue
-		# VMZ source gone -- check if the zip cache survived.
-		if abs_path.get_extension().to_lower() == "vmz":
-			var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
-			var cached := cache_dir.path_join(abs_path.get_file().get_basename() + ".zip")
-			if FileAccess.file_exists(cached):
-				log_lines.append("[FileScope]   STALE (vmz gone, cache ok): " + abs_path)
-				any_stale = true
-				continue
+		# Source gone -- treat as MISSING even if a same-basename cache zip
+		# survived. Mounting a stale cache here (for a deleted .vmz, or one
+		# replaced by a .zip of the same basename) lets Godot resolve the prior
+		# session's autoloads through old content before Pass 1 can mount the
+		# replacement. The any_missing branch below clears override.cfg +
+		# pass_state so this launch logs autoload-load failures and Pass 1
+		# rediscovers fresh state.
 		log_lines.append("[FileScope]   MISSING: " + abs_path)
 		any_missing = true
 
 	if any_missing:
 		log_lines.append("[FileScope] Archive(s) missing -- resetting to clean state")
-		# Archive gone, no cache. Wipe override.cfg autoload sections so the next
+		# Archive source gone. Wipe override.cfg autoload sections so the next
 		# boot is clean, but preserve any non-autoload settings ([display], etc.).
+		# Also fires when the source .vmz/.zip/.pck is gone but a same-basename
+		# cache survived -- we no longer honor that cache (see comment above the
+		# MISSING log) so the user's swap takes effect immediately.
 		var exe_dir := OS.get_executable_path().get_base_dir()
 		var cfg_path := exe_dir.path_join("override.cfg")
 		var preserved := _read_preserved_cfg_sections(cfg_path)
@@ -137,11 +138,6 @@ static func _mount_previous_session() -> Dictionary:
 			DirAccess.remove_absolute(state_path)
 		_write_filescope_log(log_lines)
 		return mounted
-
-	if any_stale:
-		# Source gone but cache works -- invalidate hash so Pass 1 rewrites state.
-		cfg.set_value("state", "mods_hash", "")
-		cfg.save(PASS_STATE_PATH)
 
 	for path in paths:
 		if ProjectSettings.load_resource_pack(path):

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -10,6 +10,12 @@ static func _static_vmz_to_zip(vmz_path: String) -> String:
 	var cache_dir := ProjectSettings.globalize_path(TMP_DIR)
 	if not DirAccess.dir_exists_absolute(cache_dir):
 		DirAccess.make_dir_recursive_absolute(cache_dir)
+	# Defensive: never return a stale cache pointer when the source is gone.
+	# Both current call sites verify existence first, so this is a no-op for
+	# the happy path; the guard prevents future callers from accidentally
+	# resurrecting deleted-source content via a same-basename cache hit.
+	if not FileAccess.file_exists(vmz_path):
+		return ""
 	var zip_name := vmz_path.get_file().get_basename() + ".zip"
 	var zip_path := cache_dir.path_join(zip_name)
 	if FileAccess.file_exists(zip_path):


### PR DESCRIPTION
## Summary
- Static-init's `_mount_previous_session` no longer mounts a same-basename cache zip when the pass-state source archive is gone. Reported by Sid: replacing `mods/MyMod.vmz` with `mods/MyMod.zip` made the modloader run the cached VMZ content instead of the new ZIP for at least one launch.
- Adds a defensive `FileAccess.file_exists(vmz_path)` guard in `_static_vmz_to_zip` so a deleted source can never resurrect via a basename collision.

## Root cause
`pass_state.cfg` from the prior session held `<mods>/MyMod.vmz`. After the user replaced it with `MyMod.zip`, static-init found the `.vmz` missing but fell back to mounting `user://vmz_mount_cache/MyMod.zip` (the old cache). Godot then resolved the prior session's `[autoload]` entries through that stale mount and instantiated autoloads with old code before Pass 1 could mount the replacement.

## Behavior change
- VMZ swap (`.vmz` -> `.zip` same basename) or pure deletion: filescope log shows `MISSING:` instead of `STALE (vmz gone, cache ok)`. `override.cfg` autoload sections + `pass_state.cfg` get wiped. The current launch logs autoload script-load failures (expected -- override.cfg was parsed before our static-init ran). Pass 1 rediscovers fresh state, writes new pass state, restarts. Post-restart is byte-identical to a fresh install.
- VMZ rename: one extra autoload-failure-then-restart cycle vs. before, then clean. Acceptable trade-off.

## Test plan
- [ ] Place a `.vmz` mod with an autoload that prints `OLD` in `_ready`. Launch + complete Pass 1/Pass 2 cycle.
- [ ] Quit. Replace `.vmz` with `.zip` (same basename) whose autoload prints `NEW`.
- [ ] Launch. Confirm `[FileScope] MISSING:` appears for the `.vmz` in `user://modloader_filescope.log` (not `STALE`), the launch restarts once, and post-restart prints `NEW`.
- [ ] Pure deletion: place `.vmz`, complete a cycle, quit, delete, launch. Confirm clean reset, no errors after restart.
- [ ] Verify `user://vmz_mount_cache/MyMod.zip` is absent after Pass 1 (cleaned up by existing `_clean_stale_cache`).