### PR TITLE
feat: add return mutation to post hooks

### DIFF
--- a/src/constants.gd
+++ b/src/constants.gd
@@ -160,6 +160,11 @@ var _is_ready: bool = false              # public: true once frameworks_ready ha
 # active and skips dispatch (just runs its body). Prevents double-fire when
 # rewritten subclass scripts chain into rewritten vanilla.
 var _wrapper_active: Dictionary = {}
+# Deprecation-warning suppression for legacy 2-arg post-hook callbacks.
+# Keyed by "<hook_name>::<callback object_id>" so we warn once per (hook,
+# callback) pair across the whole session. Without dedupe, a per-frame
+# wrapped method would spam the log thousands of times.
+var _post_legacy_warned: Dictionary = {}
 
 # Class + script enumeration state (populated from PCK parse at boot).
 var _class_name_to_path: Dictionary = {} # "Camera" -> "res://Scripts/Camera.gd"

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -153,6 +153,54 @@ func _dispatch(hook_name: String, args: Array) -> void:
 		var cb: Callable = entry["callback"]
 		cb.callv(args)
 
+# Post-hook chained dispatch for non-void wrapped methods. Each callback
+# may transform the running result by returning a non-null value.
+#
+# Callback signature (preferred): `func(<vanilla args>, _result)`. The
+# trailing `_result` is whatever the prior post hook (or vanilla body)
+# left behind. Returning non-null replaces _result for the next callback;
+# returning null is a pass-through ("I observed but don't want to change
+# anything"). Mods needing to actually return a literal null can't model
+# that here -- documented limitation.
+#
+# Backwards compat: callbacks declared with the old 2-arg shape (no
+# trailing _result) still work. The dispatcher detects arity via
+# Callable.get_argument_count() and routes to the appropriate call form.
+# A one-shot deprecation warning fires per (hook_name, callback) pair so
+# legacy mods keep running without log spam, but authors get a clear
+# nudge to update their signatures.
+#
+# Priority order matches _dispatch: ascending by `priority` field, ties
+# broken by registration order (Array iteration).
+func _dispatch_post(hook_name: String, args: Array, current_result: Variant) -> Variant:
+	if not _hooks.has(hook_name):
+		return current_result
+	# Snapshot before iterating: same rationale as _dispatch -- mid-dispatch
+	# hook()/unhook() calls don't disturb the in-flight pass.
+	var entries: Array = (_hooks[hook_name] as Array).duplicate()
+	var expected_with_result: int = args.size() + 1
+	for entry in entries:
+		_seq += 1
+		var cb: Callable = entry["callback"]
+		var argc: int = cb.get_argument_count()
+		var ret: Variant = null
+		if argc == expected_with_result:
+			# New 3-arg form: callback wants the result.
+			ret = cb.callv(args + [current_result])
+		else:
+			# Legacy 2-arg form (or anything else). Fire-and-forget on
+			# args only, ignore return. Warn once.
+			var warn_key: String = "%s::%d" % [hook_name, cb.get_object_id()]
+			if not _post_legacy_warned.has(warn_key):
+				_post_legacy_warned[warn_key] = true
+				_log_warning("[RTVModLib] post hook '%s' callback uses legacy %d-arg signature (expected %d for non-void wrapper). Add a trailing _result param to your callback to receive + optionally mutate the return value; the legacy form will be removed in a future major version." \
+						% [hook_name, argc, expected_with_result])
+			cb.callv(args)
+		# null is the pass-through sentinel: prior _result survives untouched.
+		if ret != null:
+			current_result = ret
+	return current_result
+
 func _dispatch_deferred(hook_name: String, args: Array) -> void:
 	if not _hooks.has(hook_name):
 		return

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -1122,7 +1122,13 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%selse:\n" % I1
 		out += "%s_result = %s%s\n" % [I2, aw, vanilla_call]
 		out += "%s_lib._caller = self\n" % I1
-		out += "%s_lib._dispatch(\"%s-post\", %s)\n" % [I1, hook_base, args_array]
+		# Post hooks for non-void methods get the chained-mutator dispatch:
+		# each callback receives args + [_result], returning non-null to
+		# replace _result for downstream callbacks. The 2-arg legacy form
+		# (callback declared without trailing _result) still works -- the
+		# dispatcher detects arity and calls the appropriate shape, with a
+		# one-shot deprecation warning. See hooks_api._dispatch_post.
+		out += "%s_result = _lib._dispatch_post(\"%s-post\", %s, _result)\n" % [I1, hook_base, args_array]
 		out += "%s_lib._dispatch_deferred(\"%s-callback\", %s)\n" % [I1, hook_base, args_array]
 		out += "%s_lib._wrapper_active.erase(\"%s\")\n" % [I1, hook_base]
 		out += "%s_lib._caller = _rtv_prev_caller\n" % I1


### PR DESCRIPTION
Add the ability to mutate the return value of methods inside of post hooks instead of just being observers. 

Change Summary:

 - _dispatch_post(hook_name, args, current_result) -> Variant — new arity-aware chained dispatcher in
  hooks_api.gd. Calls each post callback, prefers the 3-arg form (args + [_result]), falls back to 2-arg
   with a one-shot deprecation warning, propagates non-null returns through the chain.
  - Wrapper template (rewriter.gd, non-void branch) emits _result = _lib._dispatch_post(...) instead of
  _lib._dispatch(...) for the post phase.
  - Void wrappers untouched — they have no _result to mutate.
  - _post_legacy_warned: Dictionary on the modloader autoload tracks which (hook, callback) pairs
  already saw the warning, so log doesn't spam.

  Behavior summary
  - Existing 2-arg post hooks work as before; one-time warning per (hook, callback). No mutation
  possible.
  - New 3-arg post hooks receive _result, return non-null to replace, return null to pass through.
  - Multiple post hooks chain in priority order; each sees the running result.
  - Void methods: post hooks unchanged (no _result, no mutation).