### PR TITLE
feat: add GDExtension / native mod support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ FILES=(
     "$SRC/security_scan.gd"
     "$SRC/mod_discovery.gd"
     "$SRC/mod_loading.gd"
+    "$SRC/native_extensions.gd"
     "$SRC/conflict_report.gd"
     # UI
     "$SRC/ui.gd"

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -142,6 +142,19 @@ Declaring an empty `[registry]` section tells the loader to wrap `Database.gd`, 
 
 You don't enumerate what you'll register here -- the section's presence alone enables the subsystem. Use the runtime API to add/override/patch individual entries.
 
+### `[gdextension]` section (native / GDExtension mods)
+
+Optional native-code support. Load one or more `.gdextension` files shipped inside the mod archive.
+
+```ini
+[gdextension]
+BetterBallistics="res://BetterBallistics/bin/better_ballistics.gdextension"
+```
+
+Native code runs with full process privileges and can't be sandboxed. The launcher pops a confirmation gate before launching with any native mod enabled, and shows a `native code` badge on the mod row. Hook surfaces for native callbacks have to be declared in `[hooks]` -- the source-rewrite scanner can't read compiled binaries.
+
+Schema, packaging layout, the GDScript bridge pattern, cache behavior, and limitations all live on the [Native-Mods](Native-Mods) page. For converting an existing GDScript mod to C++, see [VMZ-to-CPP](VMZ-to-CPP).
+
 ### `[rtvmodlib]` section
 
 ```ini

--- a/docs/wiki/Native-Mods.md
+++ b/docs/wiki/Native-Mods.md
@@ -1,0 +1,185 @@
+# Native / GDExtension Mods
+
+Optional native-code support. A mod can ship a `.gdextension` file plus its compiled libraries, and the loader hands it to `GDExtensionManager.load_extension()` after archive mount and before the mod's bridge autoload runs.
+
+This is an unofficial experimental fork feature. **Native mods can execute arbitrary machine code and cannot be sandboxed by this loader.** The launcher pops a confirmation gate every time you launch with a native mod enabled. Only enable native mods from authors you trust.
+
+## When to use it
+
+Most gameplay tweaks should stay in GDScript. It's faster to iterate on, the source-rewrite hook system catches more, and the loader's opt-in wrap surface composes naturally across mods.
+
+Reach for `[gdextension]` only when GDScript can't reasonably do what you need: heavy per-frame numerical work, integration with native libraries (audio engines, physics solvers, networking stacks), or existing C++ code you don't want to port.
+
+If you're carrying an existing GDScript mod that's pegging the frame budget on hot paths, see [VMZ-to-CPP](VMZ-to-CPP) for a step-by-step walkthrough of what changes.
+
+## `[gdextension]` schema
+
+```ini
+[gdextension]
+BetterBallistics="res://BetterBallistics/bin/better_ballistics.gdextension"
+```
+
+| Field | Meaning |
+|---|---|
+| key | Symbolic name shown in the launcher and log lines. No functional meaning |
+| value | Quoted `res://` path to a `.gdextension` file inside the mod archive |
+
+You can declare multiple entries under one mod. Each materializes and loads independently -- one failing doesn't block the others.
+
+### Path validation
+
+Each value must:
+
+- Begin with `res://`
+- End with `.gdextension`
+- Have no `..` segments, no leading slash, no drive letter (`C:`), no UNC (`//server/share`), no backslashes
+
+Invalid entries get an orange warning on the mod row and inside the `native code` modal. The remaining valid entries still load.
+
+## Packaging layout
+
+```text
+BetterBallistics.vmz
+  mod.txt
+  BetterBallistics/
+    bridge.gd
+    bin/
+      better_ballistics.gdextension
+      windows/
+        better_ballistics.dll
+      linux/
+        libbetter_ballistics.so
+      macos/
+        libbetter_ballistics.dylib
+```
+
+The `.gdextension` file is a standard Godot `ConfigFile` -- Godot parses it for `[configuration]` and `[libraries]`. Library entries inside it should reference the compiled binaries by either:
+
+- Absolute `res://` path inside the same archive (`res://BetterBallistics/bin/windows/better_ballistics.dll`), or
+- Path relative to the `.gdextension` file's own directory (`windows/better_ballistics.dll`).
+
+Library entries that resolve outside the mod archive, or that contain unsafe path segments, fail materialization and the extension is not loaded.
+
+## Bridge autoload pattern
+
+A native mod needs a small GDScript autoload to wire its native methods into the hook system. The loader can't scan compiled C++ for `.hook(...)` calls, so the bridge is what actually registers the callbacks.
+
+`mod.txt`:
+
+```ini
+[autoload]
+BetterBallisticsBridge="res://BetterBallistics/bridge.gd"
+
+[hooks]
+res://Scripts/WeaponRig.gd = shoot, reload
+res://Scripts/Projectile.gd = *
+```
+
+`BetterBallistics/bridge.gd`:
+
+```gdscript
+extends Node
+
+func _ready():
+    var lib = Engine.get_meta("RTVModLib")
+    if not lib._is_ready:
+        await lib.frameworks_ready
+
+    var native = BetterBallisticsNative.new()
+    lib.hook("weaponrig-shoot-pre", Callable(native, "on_shoot_pre"))
+    lib.hook("projectile-update-post", Callable(native, "on_projectile_update_post"))
+```
+
+`BetterBallisticsNative` is a `GDCLASS`-registered class exported by your `.gdextension`. It's available on the GDScript side once `GDExtensionManager.load_extension(...)` has run, which the loader does before instantiating any normal `[autoload]` declared by the mod.
+
+**The bridge has to be a normal `[autoload]`, not an early autoload (`!`-prefixed).** Early autoloads land in `override.cfg`'s `[autoload_prepend]` and run during engine boot, which is before the loader's `_ready` calls `GDExtensionManager.load_extension`. A native class referenced from an early-autoload bridge won't be found.
+
+## `[hooks]` is required for native hook surfaces
+
+The opt-in hook system in v3.0.1 enrolls a vanilla method in the wrap surface only when:
+
+- A mod calls `.hook("stem-method-variant", cb)` in its **GDScript** source -- the source-rewrite scanner picks the call up at pack generation time, OR
+- The mod declares the path in `[hooks]` in `mod.txt`.
+
+Native mods can't satisfy the first rule -- the call lives inside a `.dll` / `.so` / `.dylib` and is invisible to a source scanner. So **every vanilla method a native mod intends to hook MUST be listed in `[hooks]`**, by name or via `*`:
+
+```ini
+[hooks]
+res://Scripts/WeaponRig.gd = shoot, reload    # named methods
+res://Scripts/Projectile.gd = *                # whole script
+```
+
+Without the declaration, the dispatch wrappers don't exist, the bridge registers a hook name nothing calls, and your callback never fires.
+
+## Native cache layout
+
+The loader copies each `.gdextension` and every referenced library into a per-mod cache:
+
+```text
+user://modloader_native/<safe_id>/<version_or_mtime>/
+```
+
+`<safe_id>` is `mod_id` lowercased with anything outside `[a-z0-9_-.]` replaced by `_`. `<version_or_mtime>` is the mod's declared version when present, otherwise `mtime<N>` from the source archive. A re-packaged mod with the same version still gets a fresh cache because the mtime branch falls back automatically when the version dir already exists.
+
+Library paths inside the cached `.gdextension` get rewritten to `user://` paths into the cache. The original file inside the mounted archive is not what `dlopen` ends up loading -- it's the cache copy.
+
+The cache is regenerated on every launch. Wiping it manually (`rm -rf %APPDATA%\Road to Vostok\modloader_native`) is safe; the next launch re-materializes everything.
+
+`[icon]` sections get dropped during materialization. They're editor-only and frequently reference paths outside the mod archive.
+
+## Load order
+
+1. `_mount_previous_session()` (static-init): re-mounts archives from prior pass-state.
+2. `load_all_mods()`: mounts mod archives, parses each `mod.txt`, queues autoloads, builds the hook wrap mask.
+3. `_register_rtv_modlib_meta()` + `_generate_hook_pack()`: register `Engine.get_meta("RTVModLib")` and emit the dispatch wrappers.
+4. **`_load_native_extensions_for_enabled_mods()`**: for each enabled mod with a non-empty `[gdextension]`, materialize files into the cache and call `GDExtensionManager.load_extension(<cache_path>)`.
+5. `_instantiate_autoload(...)` per queued normal autoload: bridge `_ready` runs, awaits `frameworks_ready`, registers hooks via `lib.hook(...)`.
+6. `_emit_frameworks_ready()`.
+
+State-hash inputs include each native extension's `mod_id`, name, declared `res://` path, and the source archive's mtime. Toggling a native mod on or off changes the hash and triggers a Pass-2 restart so the freshly-materialized cache is the one the next engine session loads, not whatever Pass 1 saw.
+
+## Recovery and safe mode
+
+The existing recovery paths cover native mods:
+
+- **Reset to Vanilla** (UI button) wipes `override.cfg`, pass state, and the hook cache, then restarts. Native cache files persist on disk but no `load_extension` call fires for them on the next clean launch.
+- **`modloader_safe_mode` sentinel file**: same effect as Reset.
+- **`modloader_disabled` sentinel file**: skips the entire loader, including native materialization. The game starts vanilla.
+- **Crash recovery**: after `MAX_RESTART_COUNT` (2) crashes, the loader auto-resets state. A native binary that segfaults inside its own code can take down the process before this counter ticks; in practice the next launch still resets because `override.cfg` already references the broken setup.
+
+A native binary that segfaults inside its own code can crash the process before any of this fires. The loader can detect *broken materialization* (missing files, parse failures, unsafe paths -- all graceful) but cannot detect *broken native code*.
+
+## Diagnostics
+
+Boot log lines worth grepping for when debugging a native mod:
+
+| Line | Meaning |
+|---|---|
+| `[NativeExt] <mod> declares N native extension(s)` | Section parsed, at least one entry validated |
+| `[NativeExt] Loaded <name> -> <user_path>` | `load_extension` returned `LOAD_STATUS_OK` |
+| `[NativeExt] cannot read .gdextension via VFS: <res_path>` | Archive mount worked but the file inside is missing or empty |
+| `[NativeExt] failed to parse .gdextension: <res_path>` | Bad INI / not a real `.gdextension` file |
+| `[NativeExt] <res> [libraries] <key>: unsafe ...` | Path validation rejected a library entry |
+| `[NativeExt] <res> [libraries] <key>: library not packaged` | Feature-tag library missing on disk -- skipped, won't load |
+| `[NativeExt] needs an engine restart to fully activate` | `LOAD_STATUS_NEEDS_RESTART` -- the next Pass-2 cycle satisfies it |
+| `[NativeExt] GDExtensionManager.load_extension(...) returned status N` | Engine refused the load. N is a `GDExtensionManager.LoadStatus` enum value |
+
+Per-entry validation errors also show up on the mod row in the launcher (orange warning text) and inside the `native code` modal.
+
+## Known limitations
+
+- **No sandboxing.** Native code runs with the full privileges of the game process.
+- **No binary hook scanning.** Hook surfaces have to be declared in `[hooks]`; the loader can't read compiled C++.
+- **Bridges can't be early autoloads.** A `!`-prefixed bridge runs before `GDExtensionManager.load_extension` and won't be able to construct native classes.
+- **Process-level crashes are not catchable.** A segfault inside a native lib terminates the process. Restart-loop recovery eventually clears state but can't rescue an in-flight crash.
+- **Windows is the primary tested target.** Linux and macOS support hinges on the mod packaging the right platform binaries; the loader skips missing platform libraries (logged at debug level) rather than erroring out, but a Windows-only pack won't run anywhere else.
+- **`reloadable=true` extensions still cause a restart on toggle.** State-hash inputs treat any `[gdextension]` change as significant and force a Pass-2 restart.
+
+## Author checklist
+
+- `mod.txt` has both `[gdextension]` and a normal `[autoload]` bridge declaration
+- Bridge is **not** `!`-prefixed
+- Every vanilla method the native code touches is listed in `[hooks]`
+- Compiled libraries live inside the mod archive at the path the `.gdextension` references
+- No `..` / absolute / drive-letter / UNC paths anywhere inside the `.gdextension`
+- Launching pops the native-code warning before the game starts -- if it doesn't, the section didn't parse

--- a/docs/wiki/VMZ-to-CPP.md
+++ b/docs/wiki/VMZ-to-CPP.md
@@ -1,0 +1,316 @@
+# Converting a `.vmz` Mod to C++ / GDExtension
+
+This page walks through taking an existing GDScript `.vmz` mod and porting all or part of it to C++ via Godot 4.6's GDExtension. It assumes you already have a working GDScript mod, you've read [Native-Mods](Native-Mods), and you accept that native code can't be sandboxed and runs with the full privileges of the game process.
+
+Most mods don't need this. The opt-in hook system is fast enough for almost everything you'd want to do at the GDScript layer. If you're considering a port for "cleanliness," stop -- the loader has none of the cross-mod composition guarantees for native code that it has for GDScript, and you'll trade a friendly source-scan workflow for a build-and-redistribute-binaries workflow. Port when GDScript is genuinely the bottleneck, not before.
+
+## When porting is worth it
+
+Reasonable reasons:
+
+- **Hot per-frame numerical work.** Trajectory integration, large array transforms, dense physics math that profiles consistently as the dominant cost.
+- **Existing C++ you already have.** Audio engines, physics solvers, networking stacks, game-logic libraries you don't want to re-implement in GDScript.
+- **Tight bindings to native APIs.** OS-level features Godot doesn't expose, hardware access, etc.
+
+Bad reasons:
+
+- "GDScript is slower." It is, but in most mod hot paths the slowness is caller-driven (calling `lib.hook` 10k times a frame is the problem, not the language). Profile first.
+- "C++ is more professional." It's also more crashy, more annoying to redistribute, and harder for anyone but you to debug.
+- "I want to hide my source." `.gdc` bytecode + an obfuscated archive layout already makes casual inspection annoying. A native lib still shows symbols and string tables.
+
+## What carries over unchanged
+
+The archive (`.vmz`), the `mod.txt` schema, your `[hooks]` declarations, your `[autoload]` block, your `[script_extend]` overrides, and your `[registry]` data all behave exactly the same after a port. The native lib slots in alongside them; it doesn't replace them.
+
+In particular, you keep:
+
+- The `.vmz` extension and the rest of the existing packaging.
+- Every line of `mod.txt` you already had.
+- Any GDScript files you don't choose to port -- they keep working as autoloads, overrides, and so on.
+- The hook system. Native methods register through the same `Engine.get_meta("RTVModLib").hook(...)` API.
+
+What you add:
+
+- A `[gdextension]` section pointing at your new `.gdextension` file.
+- The compiled `.dll` / `.so` / `.dylib` for whatever platforms you're shipping.
+- A small GDScript "bridge" autoload that constructs the native class and registers its methods as hook callbacks.
+
+## Walkthrough -- a worked example
+
+Starting point: `BetterBallistics.vmz`, a GDScript mod that recomputes projectile drop in `_post` after `Projectile.update`. The hot path is the math; everything else (configuration, UI, save/load) is fine in GDScript.
+
+### Original `.vmz` layout
+
+```text
+BetterBallistics.vmz
+  mod.txt
+  BetterBallistics/
+    main.gd
+    config.gd
+```
+
+`mod.txt`:
+
+```ini
+[mod]
+name="Better Ballistics"
+id="better_ballistics"
+version="1.0.0"
+
+[autoload]
+BetterBallistics="res://BetterBallistics/main.gd"
+```
+
+`main.gd`:
+
+```gdscript
+extends Node
+
+var _lib = null
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready:
+            _on_lib_ready()
+        else:
+            lib.frameworks_ready.connect(_on_lib_ready)
+
+func _on_lib_ready():
+    _lib = Engine.get_meta("RTVModLib")
+    _lib.hook("projectile-update-post", _on_projectile_update)
+
+func _on_projectile_update(delta):
+    var p = _lib._caller
+    # 60+ lines of position integration, drag, wind, ...
+```
+
+The scanner sees `_lib.hook("projectile-update-post", ...)` in `main.gd` and auto-enrolls `Projectile.gd :: update`. No `[hooks]` section needed.
+
+### Step 1: install godot-cpp
+
+Clone the matching godot-cpp branch for your engine version. Road to Vostok ships on Godot 4.6, so:
+
+```bash
+git clone --branch 4.6 https://github.com/godotengine/godot-cpp
+cd godot-cpp
+scons platform=windows target=template_release
+```
+
+If you've never touched godot-cpp before, start at the [official GDExtension docs](https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/custom_modules_in_cpp.html) and the godot-cpp README. This page won't reproduce that setup -- it picks up after you have a working godot-cpp checkout building.
+
+### Step 2: write the native class
+
+Inside a separate working directory (NOT inside the eventual `.vmz`), set up a small SCons project that links against godot-cpp. The native class:
+
+```cpp
+// src/better_ballistics_native.h
+#pragma once
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+namespace godot {
+
+class BetterBallisticsNative : public RefCounted {
+    GDCLASS(BetterBallisticsNative, RefCounted)
+
+protected:
+    static void _bind_methods();
+
+public:
+    void on_projectile_update_post(double delta);
+};
+
+}
+```
+
+```cpp
+// src/better_ballistics_native.cpp
+#include "better_ballistics_native.h"
+#include <godot_cpp/classes/engine.hpp>
+
+using namespace godot;
+
+void BetterBallisticsNative::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("on_projectile_update_post", "delta"),
+                         &BetterBallisticsNative::on_projectile_update_post);
+}
+
+void BetterBallisticsNative::on_projectile_update_post(double delta) {
+    // The hook system stashes the receiver in lib._caller. Pull it back
+    // through the registered Engine meta so we can mutate it.
+    Variant lib_v = Engine::get_singleton()->get_meta("RTVModLib");
+    if (lib_v.get_type() != Variant::OBJECT) return;
+    Object *lib = Object::cast_to<Object>(lib_v);
+    if (!lib) return;
+    Object *p = Object::cast_to<Object>(lib->get("_caller"));
+    if (!p) return;
+
+    // ... the same math the GDScript version did, but in C++ ...
+}
+```
+
+`_bind_methods` is the part that makes `on_projectile_update_post` callable from a `Callable(native, "on_projectile_update_post")` on the GDScript side. Forget it and your hook will register but never fire.
+
+Build it:
+
+```bash
+scons platform=windows target=template_release
+# produces e.g. bin/windows/better_ballistics.dll
+```
+
+### Step 3: write the `.gdextension` descriptor
+
+```ini
+; bin/better_ballistics.gdextension
+[configuration]
+entry_symbol = "better_ballistics_library_init"
+compatibility_minimum = "4.4"
+
+[libraries]
+windows.x86_64 = "windows/better_ballistics.dll"
+linux.x86_64   = "linux/libbetter_ballistics.so"
+macos          = "macos/libbetter_ballistics.dylib"
+```
+
+Library values can be paths relative to this file's directory (preferred -- the loader's path validator is happiest with these) or absolute `res://` paths inside the same archive. The loader rejects anything with `..`, drive letters, leading slashes, UNC paths, or backslashes; see [Native-Mods#path-validation](Native-Mods#path-validation).
+
+The library `.gdextension` always references at registration time is the platform-tag match for your build, so a Windows-only release packaging only the `windows/` subdir is valid. The loader skips missing platform binaries with a debug-level log line; it does not error.
+
+### Step 4: write the bridge autoload
+
+The native class doesn't exist on the GDScript side until `GDExtensionManager.load_extension` has run. The loader runs that call after archive mount and **before** any normal `[autoload]` instantiates, so a normal autoload's `_ready` can `BetterBallisticsNative.new()` cleanly. Early autoloads (the `!`-prefixed ones) run too early -- the native class won't be there yet and the bridge will fail.
+
+`bridge.gd`:
+
+```gdscript
+extends Node
+
+var _native: RefCounted = null
+
+func _ready():
+    var lib = Engine.get_meta("RTVModLib")
+    if not lib._is_ready:
+        await lib.frameworks_ready
+
+    _native = BetterBallisticsNative.new()
+    lib.hook("projectile-update-post", Callable(_native, "on_projectile_update_post"))
+```
+
+Hold a strong reference to the native instance in a script-level var. `RefCounted` instances die the moment nothing references them, and a `Callable` does not count as a strong reference. If you only keep the native object alive through the `Callable`, your hook will fire once or twice and then start producing freed-instance errors.
+
+### Step 5: rewrite `mod.txt`
+
+```ini
+[mod]
+name="Better Ballistics"
+id="better_ballistics"
+version="2.0.0"
+
+[gdextension]
+BetterBallistics="res://BetterBallistics/bin/better_ballistics.gdextension"
+
+[autoload]
+BetterBallisticsBridge="res://BetterBallistics/bridge.gd"
+
+[hooks]
+res://Scripts/Projectile.gd = update
+```
+
+Three things changed from the original:
+
+- New `[gdextension]` block points at the descriptor inside the mod.
+- The autoload now points at `bridge.gd` (which is tiny) instead of `main.gd` (which had all the logic).
+- `[hooks]` is now mandatory. The original mod was auto-enrolled because the scanner saw `lib.hook("projectile-update-post", ...)` in `main.gd`. The compiled `.dll` is opaque to the scanner, so `Projectile.gd :: update` won't be wrapped unless you list it here.
+
+### Step 6: repackage
+
+```text
+BetterBallistics.vmz
+  mod.txt
+  BetterBallistics/
+    bridge.gd
+    bin/
+      better_ballistics.gdextension
+      windows/
+        better_ballistics.dll
+      linux/
+        libbetter_ballistics.so
+      macos/
+        libbetter_ballistics.dylib
+```
+
+Pack the directory the way you packed your original `.vmz`. On Windows, do not use the built-in "Send to compressed folder" or `ZipFile.CreateFromDirectory()` -- they write entries with `\` separators that Godot can't resolve. Use 7-Zip. See [Mod-Format#archive-packaging-gotchas](Mod-Format#archive-packaging-gotchas).
+
+Drop the `.vmz` into your mods folder, launch, click through the native-code confirmation dialog, and look for these lines in the boot log:
+
+```
+[NativeExt] Better Ballistics declares 1 native extension(s)
+[NativeExt] Loaded BetterBallistics -> user://modloader_native/better_ballistics/2.0.0/better_ballistics.gdextension [Better Ballistics]
+```
+
+If you don't see the confirmation dialog at launch, your `[gdextension]` section didn't parse -- check the mod row for an orange validation error.
+
+## Iterate loop
+
+Editing native code is slower than editing GDScript by a factor of a build step. The cycle that scales:
+
+1. Edit C++.
+2. `scons platform=windows target=template_release`.
+3. Replace the `.dll` inside your unpacked mod source tree.
+4. Repack `.vmz`. (Or: enable [Developer-Mode](Developer-Mode) and run from an unpacked folder; skip the repack.)
+5. Restart the game. Bump the mod version any time you ship -- `<version>` keys the cache dir, and unbumped reloads still get a fresh tree because the loader falls back to source-archive mtime.
+
+If you're iterating in developer mode, rebuilds of the same `.dll` get picked up automatically because the mtime fallback covers the case where `version` didn't change. The cache layout is documented at [Native-Mods#native-cache-layout](Native-Mods#native-cache-layout).
+
+## What to leave in GDScript
+
+A blanket "rewrite everything to C++" is the wrong shape. The hot path is one or two methods; the rest of the mod is configuration, UI, save/load glue, debug commands, and so on. All of those are easier to maintain in GDScript and don't profile out as bottlenecks.
+
+A reasonable split for the BetterBallistics example:
+
+| Concern | Language |
+|---|---|
+| Per-frame trajectory math | C++ |
+| Configuration parsing (read a `.ini` once at boot) | GDScript |
+| Optional debug HUD overlay | GDScript |
+| Save/load slot integration | GDScript |
+| Update checking (`[updates]` ModWorkshop block) | GDScript -- handled by the loader, no code needed |
+
+You can have multiple GDScript autoloads in the same mod alongside the bridge. Native code talks back to them through `Engine.get_singleton()` lookups by autoload name, the same way it talks to vanilla.
+
+## Common pitfalls
+
+**The bridge fires a freed-instance error after a few frames.** The native class is `RefCounted` and you only kept a reference through a `Callable`. Hold the instance in a script-level var on the bridge node.
+
+**Hook registers but the callback never fires.** Either the method isn't in `[hooks]` (the source scanner can't see your `.dll`), or `_bind_methods` doesn't expose the method, or your hook name is misspelled. Hook names are lowercase: `<scriptname>-<methodname>[-pre|-post|-callback]`. See [Hooks#hook-names](Hooks#hook-names).
+
+**Bridge is `!`-prefixed.** Early autoloads run before `GDExtensionManager.load_extension`, so the native class isn't registered yet when the bridge's `_init` / `_ready` runs. Strip the `!`. If you need something to happen at engine boot before mods finish loading, that thing has to stay in GDScript.
+
+**`load_extension` returns `LOAD_STATUS_NEEDS_RESTART`.** Some extensions can't be hot-loaded into an already-running engine. The two-pass restart flow already handles this: toggling the mod on changes the state hash, the loader restarts, and on Pass 2 the lib comes up clean. Users hit the warning once, not every launch.
+
+**The launcher doesn't show the native-code confirmation dialog, and the mod row has no badge.** The `[gdextension]` section didn't parse. Check `entry["gdextension_errors"]` -- they appear inline as orange warnings on the mod row. Common causes: forgot to quote the value (ConfigFile requires it), backslash in the path, missing `.gdextension` suffix.
+
+**Crash with no log line at the moment a hook fires.** The native lib is segfaulting inside its own code. The loader can detect *broken materialization* (missing files, bad paths, parse failures) but not *broken native code*. Run the game from a debugger or attach one post-hoc. After two crashes the loader auto-resets state via `MAX_RESTART_COUNT`, so you'll get a clean next-launch even from a hard fault loop.
+
+**Hooks silently stop firing on Linux/macOS even though the binaries are packaged.** Library entries inside the `.gdextension` are case-sensitive on those platforms. `Linux.x86_64` and `linux.x86_64` are different keys. Match the casing godot-cpp's example uses (`linux.x86_64`, `macos`, etc.).
+
+## Cross-platform builds
+
+The loader will skip platform binaries it can't find rather than failing the whole load. If you ship Windows-only:
+
+```ini
+[libraries]
+windows.x86_64 = "windows/better_ballistics.dll"
+```
+
+That's a valid `.gdextension`. Linux and macOS users will see the mod row, the badge, and the launch warning, but the native `[libraries]` entries simply won't resolve and the bridge's `BetterBallisticsNative.new()` will fail. Either gate the bridge body on `ClassDB.class_exists("BetterBallisticsNative")` and degrade gracefully, or document the platform limitation in your mod description.
+
+To ship cross-platform you compile godot-cpp on each target OS (Windows native, Linux native, macOS native) and produce a binary per platform. There's no realistic shortcut -- WSL works for Linux, but macOS builds genuinely need a Mac. Build farms / CI runners are the usual answer for serious mods.
+
+## Related
+
+- [Native-Mods](Native-Mods) -- schema, validation, cache layout, recovery
+- [Mod-Format](Mod-Format) -- full `mod.txt` schema, packaging gotchas
+- [Hooks](Hooks) -- hook names, dispatch semantics, the public API surface your bridge talks to
+- [Limitations](Limitations) -- known issues that affect both GDScript and native paths

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -7,6 +7,8 @@
 - [Hooks](Hooks)
 - [Registry](Registry)
 - [Mod-Format](Mod-Format)
+- [Native-Mods](Native-Mods)
+- [VMZ-to-CPP](VMZ-to-CPP)
 - [Profile-Format](Profile-Format)
 - [Config-Files](Config-Files)
 - [GDSC-Detokenizer](GDSC-Detokenizer)

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -559,6 +559,12 @@ func _compute_state_hash(archive_paths: PackedStringArray, prepend_autoloads: Ar
 				parts.append("v:%s=%s" % [entry["mod_id"], ver])
 	for entry in _pending_script_overrides:
 		parts.append("so:%s=%s" % [entry["vanilla_path"], entry["mod_script_path"]])
+	# Fold each enabled [gdextension] declaration into the hash. Without
+	# this, flipping a native mod on/off without touching the archive
+	# wouldn't change the hash -- and Pass 1 would short-circuit instead
+	# of restarting, leaving the next session looking at a stale cache.
+	for ge_part in _native_state_hash_parts():
+		parts.append(ge_part)
 	parts.append("ml:" + MODLOADER_VERSION)
 	# Include modloader.gd's mtime so any rebuild of the loader itself
 	# triggers a restart, even when the mod set is unchanged. Rationale:

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -28,6 +28,8 @@ const SAFE_MODE_FILE := "modloader_safe_mode"
 const DISABLED_FILE := "modloader_disabled"
 const MAX_RESTART_COUNT := 2
 
+const NATIVE_CACHE_DIR := "user://modloader_native"
+
 const HOOK_PACK_DIR := "user://modloader_hooks"
 # Hook pack filename: "<prefix>_<timestamp_ms>.zip". A fresh filename per
 # _generate_hook_pack call sidesteps ProjectSettings.load_resource_pack's
@@ -178,6 +180,13 @@ var _applied_script_overrides: Dictionary = {}         # vanilla_path -> true
 # the modlist behaves byte-identical to pre-hook-system (v2.1.0) behavior.
 var _hooked_methods: Dictionary = {}             # res_path -> {method_name: true}
 var _any_mod_declared_registry: bool = false     # set by [registry] parser
+
+# Cache paths we've already handed to GDExtensionManager.load_extension
+# this session. The single-pass finish and Pass-2 can both land in the
+# native loader for the same entry across a hot re-mount; without this,
+# the second call trips LOAD_STATUS_ALREADY_LOADED noise.
+# key: absolute user:// path. value: owning mod_name (for logs).
+var _loaded_native_extensions: Dictionary = {}
 
 var _re_take_over: RegEx
 var _re_extends: RegEx

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -173,6 +173,11 @@ func _finish_with_existing_mounts() -> void:
 	_boot_complete = true
 	_register_rtv_modlib_meta()
 	_generate_hook_pack()
+	# Native libs land between hook-pack generation and autoload
+	# instantiation: archives are already mounted (so .dll bytes are
+	# reachable through VFS) and the bridge's _ready hasn't run yet, so
+	# `Native.new()` resolves cleanly when it does.
+	_load_native_extensions_for_enabled_mods()
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
 			_log_info("  Autoload '%s' already in tree -- skipped" % entry["name"])
@@ -194,6 +199,7 @@ func _finish_single_pass() -> void:
 	_boot_complete = true
 	_register_rtv_modlib_meta()
 	_generate_hook_pack()
+	_load_native_extensions_for_enabled_mods()
 	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 	if _developer_mode:
@@ -243,6 +249,7 @@ func _run_pass_2() -> void:
 	load_all_mods("Pass 2")
 	_register_rtv_modlib_meta()
 	_generate_hook_pack()
+	_load_native_extensions_for_enabled_mods()
 	# After load_all_mods re-mounts mod archives (wiping our IXP/Controller
 	# override), remount the already-generated test pack to re-apply.
 	# NOTE: Godot dedupes load_resource_pack by path, so mounting the same

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -168,6 +168,10 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
 		"mod_txt_error": _last_mod_txt_error,
 	}
+	# Parse [gdextension] (optional). Attaches gdextension / *_errors /
+	# has_native onto entry. UI uses has_native for the badge + launch
+	# gate; the loader uses gdextension once archives are mounted.
+	_annotate_native_extensions(entry, cfg)
 	return entry
 
 func _build_entry_warnings(entry: Dictionary) -> Array[String]:
@@ -189,6 +193,12 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 			warnings.append("mod.txt parse error at " + detail)
 	elif status.begins_with("nested:"):
 		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
+	# Spill [gdextension] validation errors onto the mod row so authors
+	# can see the bad line without scrolling through the boot log. The
+	# native-code launch warning is a separate orange badge driven off
+	# entry["has_native"].
+	for ge_err: String in entry.get("gdextension_errors", []):
+		warnings.append(ge_err)
 	return warnings
 
 # Config persistence

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -18,6 +18,10 @@ func load_all_mods(pass_label: String = "") -> void:
 	_applied_script_overrides.clear()
 	_hooked_methods.clear()
 	_any_mod_declared_registry = false
+	# Reset the native-load dedup map -- in-memory only, no on-disk side.
+	# Stops a re-entry into _load_native_extensions_for_enabled_mods from
+	# replaying load_extension on a path that's already live.
+	_loaded_native_extensions.clear()
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 

--- a/src/native_extensions.gd
+++ b/src/native_extensions.gd
@@ -1,0 +1,329 @@
+## ----- native_extensions.gd -----
+## Optional GDExtension support. Parses [gdextension] in mod.txt, validates
+## paths, and at load time copies each .gdextension plus its referenced
+## libraries into user://modloader_native/<safe_id>/<key>/ so
+## GDExtensionManager.load_extension has a stable on-disk file to dlopen.
+## Materialize+load runs after archive mount and before bridge autoloads
+## instantiate, so the bridge's _ready can construct native classes and
+## register them through the normal hook API.
+##
+## Native code can't be sandboxed -- it runs as the game process, and it's
+## opaque to the source-rewrite scanner. Hook surfaces have to be declared
+## explicitly via [hooks], and the launcher gates Launch behind a
+## confirmation dialog whenever an enabled mod declares this section.
+
+# Parse the [gdextension] section into the entry. Always sets all three
+# keys so the UI / state hash / loader can read them without guarding:
+#   entry["gdextension"]        valid entries -> { name: res_path }
+#   entry["gdextension_errors"] human-readable messages, one per bad line
+#   entry["has_native"]         true if the section exists at all
+# An all-invalid section still flips has_native true so the launcher warns
+# and the row shows the badge -- the loader map just stays empty and
+# nothing materializes.
+func _annotate_native_extensions(entry: Dictionary, cfg: ConfigFile) -> void:
+	var ge: Dictionary = {}
+	var errors: Array[String] = []
+	var has_any := false
+	if cfg != null and cfg.has_section("gdextension"):
+		has_any = true
+		for key in cfg.get_section_keys("gdextension"):
+			var name := str(key).strip_edges()
+			if name.is_empty():
+				errors.append("[gdextension] empty key -- skipped")
+				continue
+			var raw_val: Variant = cfg.get_value("gdextension", key, "")
+			if not (raw_val is String):
+				errors.append("[gdextension] %s: value must be a quoted res:// path" % name)
+				continue
+			var val := str(raw_val).strip_edges()
+			var v := _validate_native_res_path(val)
+			if not v["ok"]:
+				errors.append("[gdextension] %s: %s" % [name, v["error"]])
+				continue
+			ge[name] = val
+	entry["gdextension"] = ge
+	entry["gdextension_errors"] = errors
+	entry["has_native"] = has_any
+
+# Validate one [gdextension] value. Returns {"ok": bool, "error": String}.
+func _validate_native_res_path(p: String) -> Dictionary:
+	if p.is_empty():
+		return {"ok": false, "error": "empty path"}
+	if "\\" in p:
+		return {"ok": false, "error": "backslash in path -- use forward slashes"}
+	if not p.begins_with("res://"):
+		return {"ok": false, "error": "must be a res:// path inside the mod archive (got '%s')" % p}
+	if not p.to_lower().ends_with(".gdextension"):
+		return {"ok": false, "error": ".gdextension suffix required (got '%s')" % p.get_file()}
+	return _validate_safe_relative_path(p.substr(6))
+
+# Block any pattern that could escape the archive or the cache root. Reused
+# by the .gdextension path check and by every [libraries] entry inside it.
+func _validate_safe_relative_path(rel: String) -> Dictionary:
+	if rel.is_empty():
+		return {"ok": false, "error": "empty path after res://"}
+	if "\\" in rel:
+		return {"ok": false, "error": "backslash in path -- use forward slashes"}
+	if rel.begins_with("/"):
+		return {"ok": false, "error": "leading slash"}
+	if rel.length() >= 2 and rel.substr(1, 1) == ":":
+		return {"ok": false, "error": "drive letter ('%s')" % rel.substr(0, 2)}
+	if rel.begins_with("//"):
+		return {"ok": false, "error": "UNC/network path"}
+	for seg in rel.split("/"):
+		if seg == "..":
+			return {"ok": false, "error": "'..' segment"}
+		if seg.begins_with("~"):
+			return {"ok": false, "error": "tilde-prefixed segment ('%s')" % seg}
+	return {"ok": true, "error": ""}
+
+# Squash an arbitrary string into something safe to use as a cache dir
+# name. Keeps [a-z0-9_-.], replaces the rest with "_". Empty in -> "_".
+func _safe_native_id(raw: String) -> String:
+	var out := ""
+	for ch in raw:
+		var lower := ch.to_lower()
+		if (lower >= "a" and lower <= "z") or (lower >= "0" and lower <= "9") \
+				or lower == "_" or lower == "-" or lower == ".":
+			out += lower
+		else:
+			out += "_"
+	return out if not out.is_empty() else "_"
+
+# Per-mod cache dir: NATIVE_CACHE_DIR/<safe_id>/<cache_key>/. Prefer the
+# declared mod version for cache_key; fall back to "mtime<N>" so a rebuilt
+# mod with no version bump still gets a fresh tree on disk.
+func _native_cache_dir_for(mod_id: String, version: String, archive_full_path: String) -> String:
+	var key := version
+	if key.strip_edges().is_empty():
+		key = "mtime%d" % FileAccess.get_modified_time(archive_full_path)
+	return NATIVE_CACHE_DIR.path_join(_safe_native_id(mod_id)).path_join(_safe_native_id(key))
+
+# Copy one .gdextension and its libraries into the per-mod cache, rewriting
+# [libraries] entries to user:// so dlopen reads from the cache rather than
+# the mounted archive. Returns the user:// path of the cached .gdextension,
+# or "" if anything failed.
+func _materialize_native_extension(res_path: String, mod_id: String, version: String,
+		archive_full_path: String, mod_name: String) -> String:
+	var bytes := FileAccess.get_file_as_bytes(res_path)
+	if bytes.is_empty():
+		_log_critical("[NativeExt] cannot read .gdextension via VFS: %s [%s]" % [res_path, mod_name])
+		return ""
+	var src_text := bytes.get_string_from_utf8()
+	var src_cfg := ConfigFile.new()
+	if src_cfg.parse(src_text) != OK:
+		_log_critical("[NativeExt] failed to parse .gdextension: %s [%s]" % [res_path, mod_name])
+		return ""
+
+	var cache_dir := _native_cache_dir_for(mod_id, version, archive_full_path)
+	var cache_dir_abs := ProjectSettings.globalize_path(cache_dir)
+	# Wipe any leftover partial materialization from a prior run -- the dir
+	# only holds files we put there, so this is safe.
+	_wipe_native_cache_dir(cache_dir_abs)
+	if DirAccess.make_dir_recursive_absolute(cache_dir_abs) != OK \
+			and not DirAccess.dir_exists_absolute(cache_dir_abs):
+		_log_critical("[NativeExt] cannot create cache dir: %s [%s]" % [cache_dir_abs, mod_name])
+		return ""
+
+	var gdext_dir := res_path.get_base_dir()  # e.g. res://BetterBallistics/bin
+	if src_cfg.has_section("libraries"):
+		for key in src_cfg.get_section_keys("libraries"):
+			var raw_lib_val: Variant = src_cfg.get_value("libraries", key, "")
+			if not (raw_lib_val is String):
+				_log_critical("[NativeExt] %s [libraries] %s: non-string value [%s]" \
+						% [res_path, key, mod_name])
+				return ""
+			var lib_val := str(raw_lib_val).strip_edges()
+			if lib_val.is_empty():
+				continue
+			var lib_res_path := lib_val
+			if not lib_res_path.begins_with("res://"):
+				while lib_res_path.begins_with("./"):
+					lib_res_path = lib_res_path.substr(2)
+				var rel_check := _validate_safe_relative_path(lib_res_path)
+				if not rel_check["ok"]:
+					_log_critical("[NativeExt] %s [libraries] %s: unsafe relative path '%s' (%s) [%s]" \
+							% [res_path, key, lib_val, rel_check["error"], mod_name])
+					return ""
+				lib_res_path = gdext_dir.path_join(lib_res_path)
+			else:
+				var abs_check := _validate_safe_relative_path(lib_res_path.substr(6))
+				if not abs_check["ok"]:
+					_log_critical("[NativeExt] %s [libraries] %s: unsafe path '%s' (%s) [%s]" \
+							% [res_path, key, lib_val, abs_check["error"], mod_name])
+					return ""
+
+			# Mirror the lib's offset from the .gdextension's dir into the
+			# cache: "windows/foo.dll" -> <cache>/windows/foo.dll. Libs
+			# that live above the .gdextension dir flatten to basename.
+			var rel_in_cache := _path_relative_to_dir(lib_res_path, gdext_dir)
+			if rel_in_cache.is_empty():
+				rel_in_cache = lib_res_path.get_file()
+			var out_user := cache_dir.path_join(rel_in_cache)
+			var out_abs := ProjectSettings.globalize_path(out_user)
+			# Final containment check after path_join normalizes the path.
+			# Catches anything pathological that slipped through the
+			# per-segment validator above.
+			if not _path_is_within(out_abs, cache_dir_abs):
+				_log_critical("[NativeExt] %s [libraries] %s: cache path escapes root: %s [%s]" \
+						% [res_path, key, out_abs, mod_name])
+				return ""
+
+			var lib_bytes := FileAccess.get_file_as_bytes(lib_res_path)
+			if lib_bytes.is_empty():
+				# Mods often ship only their host-platform binary, so the
+				# Linux/macOS entries simply don't exist on a Windows-only
+				# pack. Drop the missing entry and keep loading -- the
+				# feature tag for an absent OS won't fire anyway.
+				_log_debug("[NativeExt] %s [libraries] %s: library not packaged (%s) -- skipping entry [%s]" \
+						% [res_path, key, lib_res_path, mod_name])
+				src_cfg.erase_section_key("libraries", key)
+				continue
+			DirAccess.make_dir_recursive_absolute(out_abs.get_base_dir())
+			var f := FileAccess.open(out_abs, FileAccess.WRITE)
+			if f == null:
+				_log_critical("[NativeExt] failed to open cache file for write: %s [%s]" \
+						% [out_abs, mod_name])
+				return ""
+			f.store_buffer(lib_bytes)
+			f.close()
+			src_cfg.set_value("libraries", key, out_user)
+
+	# [icon] is editor-only and frequently points at paths outside the mod
+	# (icon=res://addons/...). Just drop it -- runtime doesn't care.
+	if src_cfg.has_section("icon"):
+		src_cfg.erase_section("icon")
+
+	var out_gdext := cache_dir.path_join(res_path.get_file())
+	var out_gdext_abs := ProjectSettings.globalize_path(out_gdext)
+	if not _path_is_within(out_gdext_abs, cache_dir_abs):
+		_log_critical("[NativeExt] cached .gdextension path escapes root: %s [%s]" \
+				% [out_gdext_abs, mod_name])
+		return ""
+	if src_cfg.save(out_gdext) != OK:
+		_log_critical("[NativeExt] failed to save cached .gdextension: %s [%s]" \
+				% [out_gdext, mod_name])
+		return ""
+	return out_gdext
+
+# Walk enabled mods, materialize every declared .gdextension, hand each
+# cached path to GDExtensionManager.load_extension. Has to run after
+# load_all_mods (archive contents reachable via VFS) and before bridge
+# autoloads instantiate (so the bridge can `Native.new()` in _ready).
+func _load_native_extensions_for_enabled_mods() -> void:
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(NATIVE_CACHE_DIR))
+	for entry in _ui_mod_entries:
+		if not entry.get("enabled", false):
+			continue
+		var ge: Dictionary = entry.get("gdextension", {})
+		if ge.is_empty():
+			continue
+		var mod_name: String = entry["mod_name"]
+		var mod_id: String = entry["mod_id"]
+		var version: String = entry.get("version", "")
+		var full_path: String = entry["full_path"]
+		_log_info("[NativeExt] %s declares %d native extension(s)" % [mod_name, ge.size()])
+		for ext_name: String in ge:
+			var res_path: String = ge[ext_name]
+			var cache_path := _materialize_native_extension(res_path, mod_id, version,
+					full_path, mod_name)
+			if cache_path.is_empty():
+				_log_critical("[NativeExt] %s: %s failed to materialize -- extension NOT loaded" \
+						% [mod_name, ext_name])
+				continue
+			var abs_cache := ProjectSettings.globalize_path(cache_path)
+			if _loaded_native_extensions.has(abs_cache):
+				_log_debug("[NativeExt] %s: %s already loaded this session -- skipping" \
+						% [mod_name, ext_name])
+				continue
+			var status := GDExtensionManager.load_extension(cache_path)
+			if status == GDExtensionManager.LOAD_STATUS_OK \
+					or status == GDExtensionManager.LOAD_STATUS_ALREADY_LOADED:
+				_loaded_native_extensions[abs_cache] = mod_name
+				_log_info("[NativeExt] Loaded %s -> %s [%s]" \
+						% [ext_name, cache_path, mod_name])
+			elif status == GDExtensionManager.LOAD_STATUS_NEEDS_RESTART:
+				# Engine wants a hard restart before this lib is fully
+				# wired in. The two-pass flow already restarts whenever
+				# the state hash changes, so users hit this once and the
+				# extension comes up clean on the next launch.
+				_log_warning("[NativeExt] %s: %s needs an engine restart to fully activate (LOAD_STATUS_NEEDS_RESTART) [%s]" \
+						% [mod_name, ext_name, cache_path])
+				_loaded_native_extensions[abs_cache] = mod_name
+			else:
+				_log_critical("[NativeExt] %s: GDExtensionManager.load_extension('%s') returned status %d [%s]" \
+						% [mod_name, cache_path, status, ext_name])
+
+# Sorted "ge:" parts for boot.gd's _compute_state_hash. The archive mtime
+# is already in the "a:" parts, but mixing the declared res:// path back
+# in here means flipping a [gdextension] line on/off -- without touching
+# the archive -- still changes the hash and forces a Pass-2 restart.
+func _native_state_hash_parts() -> PackedStringArray:
+	var parts := PackedStringArray()
+	for entry in _ui_mod_entries:
+		if not entry.get("enabled", false):
+			continue
+		var ge: Dictionary = entry.get("gdextension", {})
+		if ge.is_empty():
+			continue
+		var mod_id: String = entry["mod_id"]
+		var full_path: String = entry["full_path"]
+		var archive_mt := FileAccess.get_modified_time(full_path)
+		for ext_name: String in ge:
+			var res_path: String = ge[ext_name]
+			parts.append("ge:%s/%s=%s@%d" % [mod_id, ext_name, res_path, archive_mt])
+	parts.sort()
+	return parts
+
+# Drive the launcher's native-code confirmation gate and the per-row badge.
+func _any_enabled_native_mods() -> bool:
+	for entry in _ui_mod_entries:
+		if entry.get("enabled", false) and entry.get("has_native", false):
+			return true
+	return false
+
+func _enabled_native_mods() -> Array:
+	var out: Array = []
+	for entry in _ui_mod_entries:
+		if entry.get("enabled", false) and entry.get("has_native", false):
+			out.append(entry)
+	return out
+
+# Strip `dir/` off the front of `p` if it's there. Returns "" otherwise.
+func _path_relative_to_dir(p: String, dir: String) -> String:
+	var d := dir
+	if not d.ends_with("/"):
+		d += "/"
+	if p.begins_with(d):
+		return p.substr(d.length())
+	return ""
+
+# Is `p` under `root`? Normalizes slashes first so a Windows mix of `/`
+# and `\` can't fool the prefix check.
+func _path_is_within(p: String, root: String) -> bool:
+	var pp := p.replace("\\", "/")
+	var rr := root.replace("\\", "/")
+	if not rr.ends_with("/"):
+		rr += "/"
+	return (pp + "/").begins_with(rr) or pp == rr.trim_suffix("/")
+
+# Recursive rm of a native-cache subdir. Only called on paths under
+# NATIVE_CACHE_DIR before re-materialization -- nothing else.
+func _wipe_native_cache_dir(abs_dir: String) -> void:
+	if not DirAccess.dir_exists_absolute(abs_dir):
+		return
+	var dir := DirAccess.open(abs_dir)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	while true:
+		var entry := dir.get_next()
+		if entry == "":
+			break
+		var full := abs_dir.path_join(entry)
+		if dir.current_is_dir():
+			_wipe_native_cache_dir(full)
+			DirAccess.remove_absolute(full)
+		else:
+			DirAccess.remove_absolute(full)
+	dir.list_dir_end()

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -624,6 +624,118 @@ func _show_security_findings_dialog(entry: Dictionary) -> void:
 	d.close_requested.connect(d.queue_free)
 	d.popup_centered()
 
+# Opened by clicking the orange "native code" badge on a mod row. Lists
+# what the mod declares plus the warning text so the user can read the
+# damage they're about to authorize before hitting Launch.
+func _show_native_extensions_dialog(entry: Dictionary) -> void:
+	var d := AcceptDialog.new()
+	var mod_name := str(entry.get("mod_name", "?"))
+	d.title = "Native code in " + mod_name
+	d.ok_button_text = "Close"
+	d.min_size = Vector2(560, 320)
+
+	var body := VBoxContainer.new()
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	body.add_theme_constant_override("separation", 10)
+	d.add_child(body)
+
+	var intro := Label.new()
+	intro.text = "Native code warning: this mod loads a GDExtension/native library. " \
+			+ "Native mods can execute arbitrary machine code and cannot be sandboxed " \
+			+ "by this loader. Only enable this mod if you trust the author."
+	intro.modulate = Color(1.0, 0.7, 0.45)
+	intro.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	intro.add_theme_font_size_override("font_size", 11)
+	body.add_child(intro)
+
+	body.add_child(HSeparator.new())
+
+	var ge: Dictionary = entry.get("gdextension", {})
+	if ge.is_empty():
+		var none := Label.new()
+		none.text = "(no valid [gdextension] entries -- see warnings on the mod row)"
+		none.modulate = Color(0.7, 0.7, 0.7)
+		none.add_theme_font_size_override("font_size", 11)
+		body.add_child(none)
+	else:
+		for ext_name: String in ge:
+			var row := VBoxContainer.new()
+			row.add_theme_constant_override("separation", 2)
+			body.add_child(row)
+			var n_lbl := Label.new()
+			n_lbl.text = ext_name
+			n_lbl.add_theme_font_size_override("font_size", 13)
+			row.add_child(n_lbl)
+			var p_lbl := Label.new()
+			p_lbl.text = str(ge[ext_name])
+			p_lbl.modulate = Color(0.78, 0.85, 0.6)
+			p_lbl.add_theme_font_size_override("font_size", 11)
+			row.add_child(p_lbl)
+
+	var errors: Array = entry.get("gdextension_errors", [])
+	if not errors.is_empty():
+		body.add_child(HSeparator.new())
+		var hdr := Label.new()
+		hdr.text = "Validation errors:"
+		hdr.modulate = Color(0.95, 0.5, 0.5)
+		body.add_child(hdr)
+		for err_text: String in errors:
+			var e_lbl := Label.new()
+			e_lbl.text = "  " + err_text
+			e_lbl.modulate = Color(0.95, 0.5, 0.5)
+			e_lbl.add_theme_font_size_override("font_size", 11)
+			e_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+			body.add_child(e_lbl)
+
+	_attach_ui_dialog(d)
+	d.confirmed.connect(d.queue_free)
+	d.close_requested.connect(d.queue_free)
+	d.popup_centered()
+
+# Launch gate when any enabled mod declares [gdextension]. Returns true to
+# proceed, false to bounce back to the launcher. Always pops -- "remember
+# this choice" was deliberately not added; native code never gets a quiet
+# pass.
+func _confirm_native_launch(native_mods: Array) -> bool:
+	var d := ConfirmationDialog.new()
+	d.title = "Native code -- mods loading machine code"
+	d.ok_button_text = "Launch with native mods"
+	d.cancel_button_text = "Go back"
+	d.dialog_autowrap = true
+	d.min_size = Vector2(580, 160)
+
+	var lines := PackedStringArray()
+	lines.append("The following mod(s) load a GDExtension/native library. " \
+			+ "Native mods can execute arbitrary machine code and cannot be sandboxed " \
+			+ "by this loader. Only continue if you trust their authors.")
+	lines.append("")
+	for entry: Dictionary in native_mods:
+		var ge: Dictionary = entry.get("gdextension", {})
+		var names: Array = ge.keys()
+		var suffix := ""
+		if not names.is_empty():
+			suffix = " -- " + ", ".join(names)
+		lines.append("    " + str(entry.get("mod_name", "?")) + suffix)
+	d.dialog_text = "\n".join(lines)
+
+	_attach_ui_dialog(d)
+	d.exclusive = true
+	d.always_on_top = true
+	d.get_ok_button().modulate = Color(1.0, 0.7, 0.45)
+
+	var state := [false, false]
+	d.confirmed.connect(func():
+		state[0] = true
+		state[1] = true)
+	d.canceled.connect(func(): state[0] = true)
+	d.close_requested.connect(func(): state[0] = true)
+	d.popup_centered()
+	d.grab_focus()
+	while not state[0]:
+		await get_tree().process_frame
+	d.queue_free()
+	return state[1]
+
 # Mod entries that are currently enabled AND scored RED by the scanner.
 # Used to gate Launch when the user has any of these toggled on.
 func _enabled_red_mods() -> Array:
@@ -1039,12 +1151,18 @@ func show_mod_ui() -> void:
 
 	refresh_launch_button_label()
 
-	# Launch loop. If any enabled mod has the scanner's RED risk_level,
-	# show a confirmation dialog before proceeding. Cancel returns the
-	# user to the launcher so they can disable the flagged mod or
-	# reconsider; confirm proceeds. No gate when no red mods are enabled.
+	# Launch loop. Two confirmation gates can fire independently:
+	#  - native code      -- any enabled [gdextension] declaration
+	#  - RED scanner risk -- patterns nearly diagnostic of malware
+	# Native runs first so the user sees the louder warning up front.
+	# Cancel from either bounces back to the launcher.
 	while true:
 		await launch_btn.pressed
+		var native_mods := _enabled_native_mods()
+		if not native_mods.is_empty():
+			var proceed_native: bool = await _confirm_native_launch(native_mods)
+			if not proceed_native:
+				continue
 		var red_mods := _enabled_red_mods()
 		if red_mods.is_empty():
 			break
@@ -1629,6 +1747,23 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			name_col.add_child(sec_btn)
 			var captured_entry := entry
 			sec_btn.pressed.connect(func(): _show_security_findings_dialog(captured_entry))
+
+		# Native-code badge. Independent from the scanner badge -- a mod
+		# can be perfectly clean GDScript and still load a DLL, and the
+		# user should see that fact either way. The badge plus the launch
+		# gate (_confirm_native_launch) is the entire UX between the user
+		# and arbitrary machine code.
+		if entry.get("has_native", false):
+			var nat_btn := Button.new()
+			nat_btn.text = "native code"
+			nat_btn.flat = true
+			nat_btn.modulate = Color(1.0, 0.55, 0.35)
+			nat_btn.add_theme_font_size_override("font_size", 11)
+			nat_btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+			nat_btn.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+			name_col.add_child(nat_btn)
+			var native_entry := entry
+			nat_btn.pressed.connect(func(): _show_native_extensions_dialog(native_entry))
 
 		# Vanilla has no stored profile; disable editing so auto-save can't
 		# create a ghost `profile.__vanilla__.*` section.


### PR DESCRIPTION
Introduce support for optional native (GDExtension) mods. Adds a new native_extensions.gd implementing parsing/validation of [gdextension], packaging/materialization into a per-mod user:// cache, safe-path checks, and calling GDExtensionManager.load_extension with per-session deduping. Integrates native state into the loader lifecycle and state-hash (boot.gd), loads native extensions before autoload bridges (lifecycle.gd), and clears the in-memory load map during mod reloads (mod_loading.gd). UI changes include a native-code confirmation gate and a per-mod native details dialog (ui.gd); mod discovery now annotates entries with gdextension info and validation errors (mod_discovery.gd). Adds constants for the native cache dir and a loaded-extensions map (constants.gd), includes the new module in the build script (build.sh), and updates documentation and sidebar with Native-Mods and VMZ-to-CPP guides explaining schema, packaging, bridge pattern, and security/limitations.