### PR TITLE
fix: dedupe same-id mods + auto-enable only on Default profile

### DIFF
--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -49,6 +49,7 @@ func collect_mod_metadata() -> Array[Dictionary]:
 		_log_debug("Skipped " + str(skipped_files.size()) + " non-mod file(s) in mods dir:")
 		for sf in skipped_files:
 			_log_debug("  " + sf + "  (not .vmz/.pck)")
+	entries = _dedupe_by_mod_id(entries)
 	if entries.size() == 0:
 		_log_warning("No mods found in: " + _mods_dir)
 	else:
@@ -219,6 +220,70 @@ func compare_versions(a: String, b: String) -> int:
 		if va < vb: return -1
 		if va > vb: return 1
 	return 0
+
+# Collapse same-id duplicates produced when an author publishes the same mod
+# under two filenames (e.g. CoolMod_v1.zip + CoolMod_v1.1.zip). Without this
+# the UI shows both rows and the load-time skip at _process_mod_candidate
+# silently drops one -- the user is left to figure out which to delete.
+#
+# Entries with no declared mod_id (profile_key "zip:<file>") and .pck files
+# are passed through untouched: their identity is the filename, which the
+# scan loop already deduped.
+func _dedupe_by_mod_id(entries: Array[Dictionary]) -> Array[Dictionary]:
+	var groups: Dictionary = {}
+	for e in entries:
+		var pk: String = str(e.get("profile_key", ""))
+		if e["ext"] == "pck" or pk.begins_with("zip:"):
+			continue
+		var mid: String = str(e["mod_id"])
+		if not groups.has(mid):
+			groups[mid] = []
+		(groups[mid] as Array).append(e)
+
+	var winners_by_id: Dictionary = {}
+	for mid in groups.keys():
+		var members: Array = groups[mid]
+		if members.size() == 1:
+			winners_by_id[mid] = members[0]
+			continue
+		members.sort_custom(_compare_dedup_priority)
+		var winner: Dictionary = members[0]
+		var hidden: Array[Dictionary] = []
+		var w_v: String = ("v" + str(winner["version"])) if str(winner["version"]) != "" else "(unversioned)"
+		for j in range(1, members.size()):
+			var loser: Dictionary = members[j]
+			hidden.append({"file_name": loser["file_name"], "version": loser["version"]})
+			var l_v: String = ("v" + str(loser["version"])) if str(loser["version"]) != "" else "(unversioned)"
+			_log_warning("Duplicate mod_id '" + mid + "' detected: keeping "
+					+ str(winner["file_name"]) + " (" + w_v + "), hiding "
+					+ str(loser["file_name"]) + " (" + l_v + ")")
+		winner["duplicates_hidden"] = hidden
+		winners_by_id[mid] = winner
+
+	var seen_ids: Dictionary = {}
+	var out: Array[Dictionary] = []
+	for e in entries:
+		var pk: String = str(e.get("profile_key", ""))
+		if e["ext"] == "pck" or pk.begins_with("zip:"):
+			out.append(e)
+			continue
+		var mid: String = str(e["mod_id"])
+		if seen_ids.has(mid):
+			continue
+		seen_ids[mid] = true
+		out.append(winners_by_id[mid])
+	return out
+
+# Higher version wins; tiebreak newer mtime, then alphabetically lower filename.
+func _compare_dedup_priority(a: Dictionary, b: Dictionary) -> bool:
+	var vc := compare_versions(str(a.get("version", "")), str(b.get("version", "")))
+	if vc != 0:
+		return vc > 0
+	var am: int = FileAccess.get_modified_time(str(a["full_path"]))
+	var bm: int = FileAccess.get_modified_time(str(b["full_path"]))
+	if am != bm:
+		return am > bm
+	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
 
 func fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 	var latest_versions := {}

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -106,7 +106,13 @@ func _apply_profile_to_entries(cfg: ConfigFile, profile: String) -> void:
 		elif resolved_key != "" and cfg.has_section_key(en_sec, resolved_key):
 			entry["enabled"] = bool(cfg.get_value(en_sec, resolved_key))
 		else:
-			entry["enabled"] = true
+			# Auto-enable on Default only. On any other profile (named, renamed,
+			# imported), a freshly-discovered mod is treated as user opt-in --
+			# adding a mod meant for one profile shouldn't silently turn it on
+			# in every other profile. Imports already write explicit disables
+			# for unlisted local mods at import time; this catches the symmetric
+			# case where a user drops a new mod AFTER importing/creating.
+			entry["enabled"] = profile == "Default"
 		if resolved_key != "" and cfg.has_section_key(pr_sec, resolved_key):
 			entry["priority"] = int(str(cfg.get_value(pr_sec, resolved_key)))
 
@@ -1594,6 +1600,17 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			warn.modulate = Color(1.0, 0.6, 0.2)
 			warn.add_theme_font_size_override("font_size", 11)
 			name_col.add_child(warn)
+
+		# Older same-id archives the dedup pass hid. Surface the filename
+		# so the user knows which one to delete from the mods/ folder.
+		for dup: Dictionary in entry.get("duplicates_hidden", []):
+			var dup_v_raw: String = str(dup.get("version", ""))
+			var dup_v: String = ("v" + dup_v_raw) if dup_v_raw != "" else "(unversioned)"
+			var hide_lbl := Label.new()
+			hide_lbl.text = "older version hidden: " + str(dup["file_name"]) + " (" + dup_v + ")"
+			hide_lbl.modulate = Color(1.0, 0.6, 0.2)
+			hide_lbl.add_theme_font_size_override("font_size", 11)
+			name_col.add_child(hide_lbl)
 
 		# Profile was saved with a different version of this mod. Surface the
 		# change so the user knows their enabled/priority state was carried


### PR DESCRIPTION
Two related profile-quality fixes that came out of MWS feedback.

## Same-id dedup

When an author publishes the same mod under two filenames (`CoolMod_v1.0.zip` and `CoolMod_v1.1.zip` both declaring the same `[mod] id`), both rows previously showed in the launcher UI but the load loop at `_process_mod_candidate` silently dropped one -- the user was left to figure out which file to delete.

`_dedupe_by_mod_id` collapses the group: highest version wins, mtime breaks ties, alphabetical filename breaks the rest. Hidden filenames are stashed on the winner as `duplicates_hidden` so the UI can surface them. Entries without a declared mod_id (`profile_key` beginning `zip:`) and `.pck` files are passed through untouched -- their identity is the filename, which the scan loop already deduped.

## Default-only auto-enable

A freshly-discovered mod is now auto-enabled only on the `Default` profile. On any named or imported profile it stays disabled until the user opts in.

Direct response to wyldbylli's MWS feedback:
> is there a way to make it so when i add a new mod to the mod folder MML doesnt just add it to every profile? or maybe they are not active by default? I have to go into my saved profiles and turn off mods I didnt want in that profile.

Symmetric to the existing import-time behavior, where imports already write explicit disables for unlisted local mods. This catches the missing case: the user drops a new mod AFTER importing or creating a profile.

## UI surface

Each duplicate-suppressed entry now produces an orange "older version hidden: `<file>` (vX.Y)" row alongside the winning entry, so the user knows which archive in the mods folder to delete.

## Test plan

- [ ] Drop two `.zip` mods with the same `[mod] id` but different versions. Confirm only the higher-version row shows in the UI, with the lower-version filename surfaced as an orange "older version hidden" row.
- [ ] Tiebreak: two same-id, same-version archives. Confirm the newer-mtime one wins; if mtimes equal, alphabetically-lower filename wins.
- [ ] On `Default` profile: drop a new mod, confirm it auto-enables.
- [ ] On a named profile: drop a new mod, confirm it stays disabled until the user toggles it on.
- [ ] On an imported profile: same as named -- stays disabled.
- [ ] `.pck` mods and `[mod] id`-less zips bypass the dedup pass.