### PR TITLE
docs: clarify install instructions on MWS page

### DIFF
--- a/MWS_PAGE.md
+++ b/MWS_PAGE.md
@@ -1,0 +1,52 @@
+# Community Mod Loader
+
+Mod loader for Road to Vostok (Godot 4.6). Adds a full pre-game launcher UI for managing your mod loadout, and restores mod loading after the original --main-pack injector method stopped working in the current demo build.
+
+Back up your saves before installing any mods.
+
+# What you get
+
+Pre-game launcher. Mod profiles. ModWorkshop update checker. Malware scanner. Crash auto-recovery. Drop `.zip` or `.vmz` straight into the mods folder.
+
+# Installation
+
+The download contains four files: `modloader.gd`, `override.cfg`, `windows-installer.bat`, and `linux-installer.sh`. Only the first two go in the game folder. The two installer scripts are alternatives that automate the manual steps for you -- pick one path below.
+
+## Automated (recommended)
+
+* **Windows**: double-click `windows-installer.bat`. It locates the game folder, installs `modloader.gd` and `override.cfg`, and creates the `mods` directory.
+* **Linux**: run `./linux-installer.sh` from a terminal. Same flow.
+
+## Manual
+
+1. Right-click Road to Vostok in your Steam library and select `Manage > Browse local files`. Steam opens the game folder.
+2. Copy `modloader.gd` and `override.cfg` into that folder. Do not copy the installer scripts -- they are not needed for a manual install.
+3. If a `mods` folder does not already exist next to them, create one.
+
+## Upgrading from v2 or earlier
+
+Older versions installed the loader into `%APPDATA%\Road to Vostok` (Windows) instead of the game folder. The Windows installer cleans those leftovers up automatically. If you are installing manually, delete the old `modloader.gd` and `override.cfg` from `%APPDATA%\Road to Vostok` first, then copy the new files into the game folder.
+
+The mod loader is now installed. Launch the game normally -- no launch options required. The launcher UI appears before the main menu.
+
+# Installing mods
+
+Drop `.vmz` or `.zip` mod files into the `mods` folder inside the game directory. Unpacked folders work too if you enable Developer Mode in the launcher.
+
+Example:
+
+```
+Road to Vostok/mods/ItemSpawner.vmz
+Road to Vostok/mods/SomeOtherMod.zip
+```
+
+# How it works
+
+The original VostokMods injector used `--main-pack Injector.pck` as a launch option to take control before the game booted. The current demo no longer supports this.
+
+This loader uses `override.cfg` to register `modloader.gd` as an autoload that Godot runs at startup. It scans the mods folder, mounts archives via `ProjectSettings.load_resource_pack()`, reads each mod's `mod.txt`, shows you the launcher UI, and instantiates autoloads in the order you chose -- reproducing the original injector's behavior without modifying launch options.
+
+# Credits
+
+Original mod loader system: VostokMods by Ryhon0.
+Hook API and framework wrappers based on tetrahydroc's RTVModLib.


### PR DESCRIPTION
## Summary

The ModWorkshop install section was confusing users repeatedly:

- **Minohaji**: asked us to mention `windows-installer.bat` in the install guide.
- **Moradine**: put `modloader.gd` into `%APPDATA%\Road to Vostok` instead of the game folder, and did not know what the four files in the zip were for.
- **Quasar**: "What is the 'games' folder?" -- the old steps just said "the game folder" without explaining how to find it.
- **Lana** (on Discord, to a streamer who was equally confused): had to clarify that of the four files in the zip, only `modloader.gd` and `override.cfg` go in the game folder; the two installer scripts are alternatives that automate the install.

This rewrite of `MWS_PAGE.md`'s install section:

1. Names the four files in the download up front and explains that the installer scripts are alternatives (not extra files to copy).
2. Leads with the automated installer (`windows-installer.bat` / `linux-installer.sh`) as the recommended path.
3. Numbers the manual path with the exact Steam `Manage > Browse local files` flow and an explicit "do not copy the installer scripts" line.
4. Adds a short upgrade-from-v2 note for the `%APPDATA%\Road to Vostok` migration that bit Moradine.

No code changes. Source for the rewrite is the untracked `MWS_PAGE.md` at the modloader repo root; the live page on ModWorkshop will be updated by hand from this file.

## Test plan

- [ ] Render the diff and re-read end-to-end as if installing for the first time.
- [ ] Confirm the four file names match what the MWS download zip ships (`modloader.gd`, `override.cfg`, `windows-installer.bat`, `linux-installer.sh`).
- [ ] Sanity-check the upgrade note against the Windows installer's actual cleanup behavior before pasting onto MWS (see "Follow-up" below).

## Follow-up

The upgrade note states that the Windows installer cleans up old `%APPDATA%\Road to Vostok` files automatically. The current `windows-installer.bat` in this repo does not implement that cleanup -- it only downloads new files into the game folder. Either the installer needs a small cleanup pass added, or the doc text should be softened to "the manual cleanup below also applies to the automated path." Worth resolving before this gets pasted onto MWS so the docs match reality.