### PR TITLE
fix: download update under the server-supplied filename

### DIFF
--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -242,7 +242,90 @@ func fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 			latest_versions.merge(parsed, true)
 	return latest_versions
 
-func download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
+# Pull a usable filename out of the response's Content-Disposition header.
+# Supports the common attachment; filename=X and quoted filename="X" forms,
+# plus the RFC 5987 filename*=UTF-8''X variant some CDNs emit. Returns "" if
+# the header is missing or the value isn't a safe basename with one of the
+# extensions we already accept on disk -- we never let a server pick a path
+# we wouldn't have scanned in the first place.
+func _filename_from_content_disposition(headers: PackedStringArray) -> String:
+	for raw in headers:
+		var line: String = raw
+		var colon := line.find(":")
+		if colon < 0:
+			continue
+		if line.substr(0, colon).strip_edges().to_lower() != "content-disposition":
+			continue
+		var value := line.substr(colon + 1).strip_edges()
+		# Try filename* first -- RFC 5987 form is unicode-safe, and servers
+		# that emit both prefer the encoded one for non-ASCII names.
+		var star_val := _extract_disposition_param(value, "filename*")
+		if star_val != "":
+			var sep := star_val.find("''")
+			if sep >= 0:
+				star_val = star_val.substr(sep + 2).uri_decode()
+			if _is_safe_mod_filename(star_val):
+				return star_val.get_file()
+		var plain_val := _extract_disposition_param(value, "filename")
+		if plain_val != "" and _is_safe_mod_filename(plain_val):
+			return plain_val.get_file()
+		return ""
+	return ""
+
+func _extract_disposition_param(header_value: String, param: String) -> String:
+	var pos := header_value.to_lower().find(param.to_lower() + "=")
+	if pos < 0:
+		return ""
+	var rest := header_value.substr(pos + param.length() + 1).strip_edges()
+	if rest.begins_with("\""):
+		var end := rest.find("\"", 1)
+		if end < 0:
+			return ""
+		return rest.substr(1, end - 1)
+	var semi := rest.find(";")
+	if semi < 0:
+		return rest.strip_edges()
+	return rest.substr(0, semi).strip_edges()
+
+# Reject anything that isn't a plain basename with one of the mod extensions
+# we accept. Stops a malicious or misconfigured server from writing under a
+# parent dir or with an executable extension.
+func _is_safe_mod_filename(name: String) -> bool:
+	if name.is_empty():
+		return false
+	if name != name.get_file():
+		return false
+	return name.get_extension().to_lower() in ["vmz", "zip", "pck"]
+
+# Pick the filename the validated download should land under. Prefers
+# Content-Disposition; falls back to splicing the new mod.txt version onto
+# the old stem (CoolMod_v1.0.zip -> CoolMod_v1.1.zip) so the filename never
+# claims an older version than its contents. Returns the original filename
+# unchanged when neither path produces something better -- a rename is
+# best-effort and must never block an update.
+func _derive_updated_filename(old_file_name: String, headers: PackedStringArray, new_version: String) -> String:
+	var server_name := _filename_from_content_disposition(headers)
+	if server_name != "":
+		return server_name
+	if new_version.is_empty():
+		return old_file_name
+	var ext := old_file_name.get_extension()
+	var stem := old_file_name.get_basename()
+	var rx := RegEx.new()
+	rx.compile("[_-][vV]\\d+(?:\\.\\d+)*$")
+	var stripped := rx.sub(stem, "")
+	var new_stem := stripped + "_v" + new_version.lstrip("vV")
+	return new_stem if ext.is_empty() else new_stem + "." + ext
+
+# Returns { ok: bool, new_path: String, new_file_name: String }. On success
+# new_path / new_file_name reflect the on-disk filename the download landed
+# under -- which may differ from target_path when the server provided a
+# Content-Disposition or the mod.txt version-bumped (CoolMod_v1.0.zip ->
+# CoolMod_v1.1.zip). On failure the temp + backup are cleaned up and the
+# original file is left intact; new_path / new_file_name echo target_path.
+func download_and_replace_mod(target_path: String, modworkshop_id: int) -> Dictionary:
+	var failure := {"ok": false, "new_path": target_path, "new_file_name": target_path.get_file()}
+
 	var req := HTTPRequest.new()
 	req.timeout = API_DOWNLOAD_TIMEOUT
 	req.download_body_size_limit = 256 * 1024 * 1024
@@ -250,16 +333,17 @@ func download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 	var err := req.request(MODWORKSHOP_DOWNLOAD_URL_TEMPLATE % str(modworkshop_id))
 	if err != OK:
 		req.queue_free()
-		return false
+		return failure
 	# request_completed -> [result, http_code, headers, body]
 	var res: Array = await req.request_completed
 	req.queue_free()
 
 	if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
-		return false
+		return failure
+	var headers: PackedStringArray = res[2]
 	var response_body: PackedByteArray = res[3]
 	if response_body.is_empty():
-		return false
+		return failure
 
 	var temp_path   := target_path + ".download"
 	var backup_path := target_path + ".bak"
@@ -268,33 +352,49 @@ func download_and_replace_mod(target_path: String, modworkshop_id: int) -> bool:
 
 	var out := FileAccess.open(temp_path, FileAccess.WRITE)
 	if out == null:
-		return false
+		return failure
 	out.store_buffer(response_body)
 	out.close()
 
-	if read_mod_config(temp_path) == null:
+	var new_cfg: ConfigFile = read_mod_config(temp_path)
+	if new_cfg == null:
 		DirAccess.remove_absolute(temp_path)
-		return false
+		return failure
 
 	var dir_access := DirAccess.open(target_path.get_base_dir())
 	if dir_access == null:
 		DirAccess.remove_absolute(temp_path)
-		return false
+		return failure
 
+	# Decide where the validated download should land.
+	var old_file_name := target_path.get_file()
+	var new_version := str(new_cfg.get_value("mod", "version", ""))
+	var new_file_name := _derive_updated_filename(old_file_name, headers, new_version)
+	var new_path := target_path.get_base_dir().path_join(new_file_name)
+
+	# Refuse to overwrite an unrelated archive that already lives at the
+	# derived path. Better to fail loudly than silently clobber a different
+	# mod that happens to share the new versioned name.
+	if new_file_name != old_file_name and FileAccess.file_exists(new_path):
+		DirAccess.remove_absolute(temp_path)
+		return failure
+
+	# Stash the old archive under .bak so a failed rename can roll back.
 	if FileAccess.file_exists(target_path):
 		if dir_access.rename(target_path.get_file(), backup_path.get_file()) != OK:
 			DirAccess.remove_absolute(temp_path)
-			return false
+			return failure
 
-	if dir_access.rename(temp_path.get_file(), target_path.get_file()) != OK:
+	if dir_access.rename(temp_path.get_file(), new_file_name) != OK:
 		if FileAccess.file_exists(backup_path):
 			dir_access.rename(backup_path.get_file(), target_path.get_file())
 		DirAccess.remove_absolute(temp_path)
-		return false
+		return failure
 
+	# New file is in place; the .bak (which is the old archive) can go.
 	if FileAccess.file_exists(backup_path):
 		DirAccess.remove_absolute(backup_path)
-	return true
+	return {"ok": true, "new_path": new_path, "new_file_name": new_file_name}
 
 func _chunk_int_array(arr: Array[int], chunk_size: int) -> Array:
 	var result: Array = []

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1782,10 +1782,15 @@ func build_updates_tab() -> Control:
 		list.add_child(HSeparator.new())
 
 		if mw_id > 0 and version != "":
+			# Hold a reference to the underlying _ui_mod_entries dict so the
+			# download callback can update full_path / file_name in place
+			# when a successful update lands the archive under a new name.
+			# GDScript dicts are reference-typed, so writing through here
+			# mutates the canonical entry the next discovery pass sees.
 			status_info[entry["file_name"]] = {
 				"label": status_lbl, "ver_lbl": ver_lbl, "version": version, "mw_id": mw_id,
 				"dl_btn": dl_btn, "full_path": entry["full_path"],
-				"mod_name": entry["mod_name"],
+				"mod_name": entry["mod_name"], "entry": entry,
 			}
 
 	if list.get_child_count() == 0:
@@ -1897,13 +1902,13 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 				dl_btn.text = "Downloading..."
 				lbl.text = "downloading..."
 				check_btn.disabled = true
-				var ok := await download_and_replace_mod(full_path, mw_id)
+				var result: Dictionary = await download_and_replace_mod(full_path, mw_id)
 				if not is_instance_valid(check_btn):
 					return
 				if not is_instance_valid(dl_btn):
 					return
 				check_btn.disabled = false
-				if ok:
+				if result.get("ok", false):
 					lbl.text = "updated -- restart to apply"
 					lbl.modulate = Color(0.80, 0.80, 0.80)
 					dl_btn.modulate.a = 0.0
@@ -1913,7 +1918,19 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 					# Update cached version so next Check won't re-flag this mod.
 					info["version"] = new_ver
 					(info["ver_lbl"] as Label).text = "v" + new_ver
-					add_log.call(mod_name + " -- updated to v" + new_ver + ". Restart game to apply.")
+					# Reflect the on-disk rename in the in-memory entry so the
+					# next discovery pass (and any subsequent UI rebuild before
+					# relaunch) point at the right archive instead of the old
+					# filename that no longer exists.
+					var new_path: String = result.get("new_path", full_path)
+					var new_fn: String = result.get("new_file_name", full_path.get_file())
+					info["full_path"] = new_path
+					var entry_ref: Dictionary = info.get("entry", {})
+					if not entry_ref.is_empty():
+						entry_ref["full_path"] = new_path
+						entry_ref["file_name"] = new_fn
+					var rename_note: String = (" (renamed to " + new_fn + ")") if new_fn != full_path.get_file() else ""
+					add_log.call(mod_name + " -- updated to v" + new_ver + rename_note + ". Restart game to apply.")
 				else:
 					lbl.text = "download failed"
 					lbl.modulate = Color(1.0, 0.4, 0.4)


### PR DESCRIPTION
## Summary

When the launcher downloads a mod update via the Updates tab, the new content was written back to the old filename. If the local file was named with an embedded version (`CoolMod_v1.0.zip`), the user ended up with a file still named `CoolMod_v1.0.zip` containing v1.1 content -- the filename lied about the contents. Surfaced from maintainer-noted MWS feedback.

`download_and_replace_mod` in [src/mod_discovery.gd](src/mod_discovery.gd) now:

- **Honors `Content-Disposition`.** Parses the response's `Content-Disposition` header (`attachment; filename="CoolMod_v1.1.zip"`, the unquoted form, and `filename*=UTF-8''X` RFC 5987 form) and uses the server-supplied filename. A basename + extension allowlist (`vmz`/`zip`/`pck`) keeps a hostile or misconfigured server from writing under a parent directory or with an executable extension.
- **Falls back to splicing the new version onto the old stem.** When `Content-Disposition` is absent or unsafe, derives a name from the new `mod.txt`'s `[mod] version`: `CoolMod_v1.0.zip` -> `CoolMod_v1.1.zip`. Strips any trailing `_v<digits>(.<digits>)*` / `-v<digits>(.<digits>)*` first so versions never compound (`CoolMod_v1.0_v1.1.zip` would be a worse lie than the original bug).
- **Preserves the original filename when neither path helps.** If the server returns no `Content-Disposition` *and* the new `mod.txt` has no version, the file keeps its old name with the new content -- updates never refuse on missing metadata.
- **Returns `Dictionary { ok, new_path, new_file_name }` instead of `bool`.** The UI caller in [src/ui.gd](src/ui.gd) updates `info["full_path"]` *and* mutates the underlying `_ui_mod_entries` dict (GDScript dicts are reference-typed; a stored ref into status_info is enough) so `entry["full_path"]` and `entry["file_name"]` reflect disk before the next discovery pass.
- **Refuses to clobber an unrelated archive.** If the derived path collides with an existing file that isn't the one being updated, the rename is rolled back rather than silently overwriting a different mod.

The activity log entry now also surfaces the rename so the user knows their `Foo_v1.0.zip` became `Foo_v1.1.zip`.

### Interaction with `_dedupe_by_mod_id`

[fix/profile-defaults-and-dupes](https://github.com/ametrocavich/vostok-mod-loader/pull/62) adds `_dedupe_by_mod_id` running on every `collect_mod_metadata()`. If a user already has multiple same-id archives on disk (e.g. they manually copied old + new), an update under the new versioned filename can leave a stale lower-version sibling behind. That straggler is automatically absorbed by the dedup pass on the next launch -- no explicit cleanup needed here.

## Test plan

- [ ] **Versioned filename + version-bump.** Mod with `Foo_v1.0.zip` whose `mod.txt` declares `version="1.0"`. Trigger update; the server's response (or version-derivation fallback) lands a `Foo_v1.1.zip`; the old `Foo_v1.0.zip` is gone; the UI's row points at the new path; relaunch shows no duplicate row.
- [ ] **Unversioned filename, server returns same name.** Mod with `Foo.zip`. Server's `Content-Disposition` says `filename="Foo.zip"`. File stays as `Foo.zip` with new content; activity log shows no rename note.
- [ ] **Unversioned filename, server returns versioned name.** Mod with `Foo.zip`. Server's `Content-Disposition` says `filename="Foo_v1.1.zip"`. File renamed to `Foo_v1.1.zip`; old `Foo.zip` gone.
- [ ] **No version + no `Content-Disposition`.** `mod.txt` declares no `version` and the server doesn't supply a filename. File keeps its old name; content updated; no error raised.
- [ ] **Hostile `Content-Disposition` rejected.** `filename="../../evil.exe"` or `filename="evil.exe"` is rejected by `_is_safe_mod_filename`; falls through to version-suffix derivation (or keeps the old name).
- [ ] **Dedup absorbs stragglers.** Have `CoolMod_v1.0.zip` + `CoolMod_v1.1.zip` (same `mod_id`) on disk. Update the v1.1 to v1.2 via the launcher; on next launch, the v1.0 straggler is collapsed by `_dedupe_by_mod_id` (verifies the interaction once [#62](https://github.com/ametrocavich/vostok-mod-loader/pull/62) lands too).

Verified locally that the launcher boots cleanly with the change deployed (full mod scan + UI render with no script-level parse errors); interactive update click-through is for the maintainer to drive against a real `[updates]`-bearing mod.