### PR TITLE
feat: Aggregators, new registry verbs, setup fan out + _many primitives

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,8 @@ FILES=(
     "$SRC/registry/resources.gd"
     "$SRC/registry/scene_nodes.gd"
     "$SRC/registry/aggregators.gd"
+    # Declarative setup() entry point (depends on registry _many verbs + hook_many)
+    "$SRC/setup.gd"
     "$SRC/framework_wrappers.gd"
     # Codegen pipeline
     "$SRC/gdsc_detokenizer.gd"

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,7 @@ FILES=(
     "$SRC/registry/fish.gd"
     "$SRC/registry/resources.gd"
     "$SRC/registry/scene_nodes.gd"
+    "$SRC/registry/weapons.gd"
     "$SRC/framework_wrappers.gd"
     # Codegen pipeline
     "$SRC/gdsc_detokenizer.gd"

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ FILES=(
     "$SRC/registry/fish.gd"
     "$SRC/registry/resources.gd"
     "$SRC/registry/scene_nodes.gd"
-    "$SRC/registry/weapons.gd"
+    "$SRC/registry/aggregators.gd"
     "$SRC/framework_wrappers.gd"
     # Codegen pipeline
     "$SRC/gdsc_detokenizer.gd"

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,7 @@ FILES=(
     "$SRC/registry/inputs.gd"
     "$SRC/registry/loader.gd"
     "$SRC/registry/ai.gd"
+    "$SRC/registry/ai_loadouts.gd"
     "$SRC/registry/fish.gd"
     "$SRC/registry/resources.gd"
     "$SRC/registry/scene_nodes.gd"

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -102,13 +102,23 @@ lib.unhook(id)
 
 if lib.has_replace("weaponrig-shoot"):
     print("another mod already replaced shoot")
+
+# Batched form for mods with many hooks at once.
+lib.hook_many({
+    "controller-_physics_process-pre":  _on_phys_pre,
+    "interface-getmagazine":            _replace_get_mag,
+    "interface-close-post":             _on_close_post,
+})
 ```
+
+For mods that register hooks alongside registry mutations as a single installation step, `hook_many` is also available as a `["hooks", {...}]` entry inside `lib.setup(plan)`. See [Setup](Setup) for the declarative form.
 
 ### Methods
 
 | Method | Purpose |
 |---|---|
 | `hook(name, callback, priority=100) -> int` | Register a callback, return its id. Replace hooks are single-owner (returns -1 if already taken) |
+| `hook_many({name: callback, ...}, priority=100) -> Dictionary` | Batched register; returns `{ok, results}` where `results[name]` is the hook id or -1 |
 | `unhook(id) -> void` | Remove a hook by id (linear scan across all hook names) |
 | `add_hook(path, method, cb, before=true) -> int` | godot-mod-loader compat wrapper around `hook()` + wrap-mask enrollment |
 | `has_hooks(name) -> bool` | Any callbacks registered at this name? |

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -141,43 +141,44 @@ Suffixes:
 |---|---|---|---|
 | `-pre` | Before vanilla body (or before replace) | Same as the vanilla method | Ignored |
 | (none) | In place of vanilla. **First registration wins, subsequent registrations are rejected** (returns -1). Within a replace callback, call `lib.skip_super()` to suppress vanilla | Same as vanilla | Return value becomes the method's return |
-| `-post` | After vanilla (or after replace if no `skip_super`) | Vanilla args, plus trailing `_result` for the 3-arg form | Observed for the new 3-arg form `func(...args, _result)` -- non-null replaces, null passes through. 2-arg legacy form is ignored and emits a one-shot deprecation warning per (hook, callback). See [Return mutation](#return-mutation) below. |
+| `-post` | After vanilla (or after replace if no `skip_super`). For **non-void** wrapped methods, post hooks may receive the running `_result` and mutate it; see below | Same as vanilla, **plus a trailing `_result` arg** for non-void methods if the callback declares it | For non-void methods: return non-null to replace `_result` for downstream post hooks; return null to pass through unchanged. Multiple post hooks chain in priority order |
 | `-callback` | Deferred via `Callable.bindv(args).call_deferred()` | Same as vanilla | Ignored |
 
-## Return mutation
+### Post-hook return mutation (non-void methods only)
 
-Post hooks on **non-void** wrapped methods can transform the return value. Declare your callback with a trailing `_result` parameter:
+When the wrapped vanilla method returns a value, post hooks can transform it. Two callback signatures are supported:
 
 ```gdscript
-func _on_lib_ready():
-    _lib = Engine.get_meta("RTVModLib")
-    # 3-arg form: vanilla args + trailing _result.
-    _lib.hook("weaponrig-getdamage-post", _double_damage)
+# Preferred form: declare the trailing _result param to receive + mutate
+func _on_value_post(current_result: int) -> int:
+    return current_result + 100  # bumps the result by 100
 
-func _double_damage(_attacker, _result):
-    # Return non-null to replace _result for downstream callbacks +
-    # the method's caller. Returning null is a pass-through ("I
-    # observed but do not want to change anything").
-    return _result * 2
+# Legacy form: just vanilla args, no _result, no return propagation.
+# Still works (read-only observer), but emits a one-shot deprecation warning
+# per (hook_name, callback) pair. Will be removed in a future major version.
+func _on_value_post() -> void:
+    print("Item.Value() ran")
 ```
 
-Callbacks chain in priority order. Each one receives the running `_result` left by the previous callback (or by the vanilla body, if it was first). Non-null returns replace the running value; `null` returns pass it through unchanged.
+The dispatcher detects callback arity via `Callable.get_argument_count()`. If the count matches `vanilla_args.size() + 1`, the trailing `_result` is passed and the return value chains forward. If the count matches just `vanilla_args.size()`, the legacy 2-arg path runs (fire-and-forget) and a deprecation warning fires once per callback registration.
 
-**Limitations**:
+Multiple post hooks chain in priority-ascending order. Each hook sees the running `_result` after all prior post hooks have transformed it:
 
-- Only non-void wrappers route through `_dispatch_post`. Void post hooks still see the legacy 2-arg shape with no return slot -- a callback declared as `func(args, _result)` against a void method just gets a deprecation warning and runs without mutation.
-- The `null` sentinel is structural: a callback that genuinely wants to set `_result = null` cannot express that here. Use a replace hook instead.
+```gdscript
+# Vanilla Item.Value() returns V (an int)
+lib.hook("item-value-post", func(r): return r + 100, 50)        # priority 50, runs first
+lib.hook("item-value-post", func(r): return min(r, 200), 100)   # priority 100, runs second
 
-**Legacy 2-arg form**: callbacks declared without the trailing `_result` (the pre-3.1.2 shape, `func(args)`) still run for backwards compatibility. The dispatcher detects the arity via `Callable.get_argument_count()`, fires the callback observation-only, and emits a one-shot warning per `(hook_name, callback)` pair so existing mods keep working without log spam:
-
+# For an item with vanilla value=50:
+#   1. vanilla returns 50
+#   2. priority-50 hook: r=50 -> returns 150 -> _result=150
+#   3. priority-100 hook: r=150 -> returns min(150, 200)=150 -> _result=150
+#   4. wrapper returns 150 to caller
 ```
-[RTVModLib] post hook 'weaponrig-getdamage-post' callback uses legacy 1-arg
-signature (expected 2 for non-void wrapper). Add a trailing _result param
-to your callback to receive + optionally mutate the return value; the
-legacy form will be removed in a future major version.
-```
 
-Implementation: [hooks_api.gd `_dispatch_post`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd).
+`null` returns are pass-through ("I observed but don't want to change anything"). Methods that legitimately return `null` for valid values can't be modeled via a mutator; document that limitation and pick a different sentinel if needed.
+
+**Void methods**: post hooks for void wrapped methods continue to be fire-and-forget. There's no `_result` to pass; the void wrapper template doesn't call `_dispatch_post`.
 
 ## Dispatch semantics
 
@@ -217,9 +218,12 @@ func <name>(args):
     else:
         _result = _rtv_vanilla_<name>(args)
 
-    # Non-void wrappers route post hooks through _dispatch_post so 3-arg
-    # callbacks can mutate _result. Void wrappers still emit plain _dispatch.
+    # Non-void wrapper: chained post-hook dispatch with arity detection.
+    # `_dispatch_post` walks each post hook in priority order, passes the
+    # running `_result` if the callback declared the trailing param, and
+    # propagates the callback's return value forward.
     _result = _lib._dispatch_post("<hook_base>-post", [args], _result)
+
     _lib._dispatch_deferred("<hook_base>-callback", [args])
     _lib._wrapper_active.erase("<hook_base>")
     return _result
@@ -231,7 +235,9 @@ Three performance / correctness features:
 - **Global short-circuit**: `_lib._any_mod_hooked` is a sticky bool flipped true by the first `hook()` call. Dispatch wrappers skip every dict/function call when no mod has registered anything. Same approach as godot-mod-loader's `_ModLoaderHooks.any_mod_hooked`.
 - **Re-entry guard**: when a mod script that extends wrapped vanilla calls `super()`, control lands back in the vanilla wrapper. Without the guard, the vanilla wrapper would dispatch hooks again. The guard flips `_wrapper_active[hook_base]` = true on entry; nested re-entry at the same `hook_base` skips dispatch and runs the body directly. One dispatch per logical call regardless of chain depth.
 
-Void methods, coroutines (`await`), and engine lifecycle methods (`_ready` et al.) use structurally similar templates with appropriate adjustments -- `await` prepended to vanilla calls for coroutines, no `_result` for void, etc.
+**Void methods** use a structurally similar template but call `_lib._dispatch("<hook_base>-post", [args])` (fire-and-forget, return ignored) instead of `_dispatch_post`, since there's no `_result` to mutate.
+
+**Coroutines** (`await`) and engine lifecycle methods (`_ready` et al.) use structurally similar templates with appropriate adjustments -- `await` prepended to vanilla calls for coroutines.
 
 ## Hook registration, step-by-step
 
@@ -260,6 +266,31 @@ func _dispatch(hook_name: String, args: Array) -> void:
 The `.duplicate()` is load-bearing: hooks that call `hook()` or `unhook()` mid-dispatch would otherwise mutate the live array during iteration. Snapshotting means new hooks registered during dispatch don't fire in the current dispatch -- they join the next one.
 
 `_dispatch_deferred` uses `callback.bindv(args).call_deferred()` instead, for `-callback` suffix hooks. `_dispatch_post` is the chained variant used by non-void post hooks: same snapshot-then-iterate shape, but each callback receives `args + [current_result]`, threads its non-null return into `current_result`, and the final value is returned to the wrapper. See [Return mutation](#return-mutation).
+
+`_dispatch_post` is the chained variant for non-void post hooks. Same snapshot-iterate pattern as `_dispatch`, but it inspects each callback's arity before calling and threads a running result through the chain:
+
+```gdscript
+func _dispatch_post(hook_name: String, args: Array, current_result: Variant) -> Variant:
+    if not _hooks.has(hook_name):
+        return current_result
+    var entries: Array = (_hooks[hook_name] as Array).duplicate()
+    var expected_with_result: int = args.size() + 1
+    for entry in entries:
+        _seq += 1
+        var cb: Callable = entry["callback"]
+        var argc: int = cb.get_argument_count()
+        var ret: Variant = null
+        if argc == expected_with_result:
+            ret = cb.callv(args + [current_result])  # 3-arg form: receive _result
+        else:
+            cb.callv(args)                            # legacy 2-arg form
+            # one-shot deprecation warning per (hook_name, callback) pair
+        if ret != null:
+            current_result = ret
+    return current_result
+```
+
+Per-callback warning suppression uses `_post_legacy_warned: Dictionary` keyed by `"<hook_name>::<callback_object_id>"`. First time a 2-arg callback is seen, the warning prints and the key flips. Subsequent dispatches against the same callback are silent. This is cheap enough that even a hot-path wrapped method with hundreds of dispatches per frame doesn't spam the log.
 
 ## How the code generation works
 
@@ -384,6 +415,66 @@ func _modify_prices():
         var current = int(interface.requestValue.text)
         interface.requestValue.text = str(current * 2)
 ```
+
+### Post-hook mutator chain
+
+A clean compose: two mods both transform a return value without conflicting. `Item.Value()` returns an `int`. Mod A wants to bump prices by a flat amount; Mod B wants to cap them. Both register `-post` hooks with priorities; the chain runs in order, each mod sees the running value.
+
+```gdscript
+# Mod A: Trader Inflation -- adds +50 to every item value
+extends Node
+var _lib = null
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready: _register()
+        else: lib.frameworks_ready.connect(_register)
+
+func _register():
+    _lib = Engine.get_meta("RTVModLib")
+    # Priority 50 -- runs early in the chain
+    _lib.hook("item-value-post", _bump_value, 50)
+
+func _bump_value(current_result: int) -> int:
+    return current_result + 50
+```
+
+```gdscript
+# Mod B: Price Cap -- caps every item value at 1000
+extends Node
+var _lib = null
+
+func _ready():
+    if Engine.has_meta("RTVModLib"):
+        var lib = Engine.get_meta("RTVModLib")
+        if lib._is_ready: _register()
+        else: lib.frameworks_ready.connect(_register)
+
+func _register():
+    _lib = Engine.get_meta("RTVModLib")
+    # Priority 100 -- runs after Mod A, so caps the inflated value
+    _lib.hook("item-value-post", _cap_value, 100)
+
+func _cap_value(current_result: int) -> int:
+    if current_result > 1000:
+        return 1000
+    return null  # null = pass-through, leaves _result unchanged
+```
+
+For a vanilla item with `value=970`:
+1. Vanilla `Item.Value()` returns 970
+2. Mod A's hook fires with `current_result=970`, returns 1020 → `_result=1020`
+3. Mod B's hook fires with `current_result=1020`, returns 1000 → `_result=1000`
+4. Wrapper returns 1000 to caller
+
+For a vanilla item with `value=500`:
+1. Vanilla returns 500
+2. Mod A: `current_result=500`, returns 550 → `_result=550`
+3. Mod B: `current_result=550`, returns null (no cap needed) → `_result` stays at 550
+4. Wrapper returns 550
+
+The chain composes without either mod knowing about the other. If a third mod ships and registers `item-value-post` with priority=75, it slots between Mod A and Mod B without code changes.
 
 ### Replace hook with fallback
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -126,6 +126,9 @@ For mods that register hooks alongside registry mutations as a single installati
 | `get_replace_owner(name) -> int` | Returns id of the current replace owner, or -1 |
 | `skip_super() -> void` | Inside a replace callback: prevent the vanilla body from running on return |
 | `seq() -> int` | Monotonic dispatch counter, useful for tests |
+| `has_mod(id, min_version="") -> bool` | True if a mod with the given id is loaded; optional `min_version` does a numeric semver compare (`>=`) |
+| `mod_info(id) -> Dictionary` | `{mod_id, mod_name, version, file_name, priority}` for a loaded mod, `{}` if absent. Returns a duplicate -- callers can mutate freely |
+| `loaded_mods() -> Array[String]` | All loaded mod ids. Order is not guaranteed |
 | `static version() -> String` | `MODLOADER_VERSION` |
 | `static major_version() -> int` | Parse major from `MODLOADER_VERSION` |
 | `static minor_version() -> int` | Same, minor |

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -69,20 +69,20 @@ Every mutating verb returns a bool indicating success; failures log a `push_warn
 
 ### Aggregator helpers
 
-Five high-level helpers that fan out to multiple primitive registries in one declarative call. They live alongside the standard verbs, take a single `Dictionary` payload, and return a granular result dict (per-step success bools) rather than a single bool.
+Five high-level helpers that fan out to multiple primitive registries in one declarative call. They live alongside the standard verbs, take a `Dictionary` of `{id: data, ...}` (one entry or many), and return a wrapped granular result `{ok, results: {id: per_id_dict}}`.
 
 | Method | Purpose |
 |---|---|
-| `register_item(id, dict) -> Dictionary` | Generic item bundle: ItemData + optional scene/icon/loot_tables/trader_pools |
-| `register_weapon(id, dict) -> Dictionary` | Weapon + rig + inline magazines + fits_attachments + loot_tables |
-| `register_magazine(id, dict) -> Dictionary` | Magazine + scene + fits_weapons (additive append to weapons' compatible) |
-| `register_attachment(id, dict) -> Dictionary` | Attachment + scene + fits_weapons (same shape as magazine; split for readability) |
-| `register_furniture(id, dict) -> Dictionary` | Furniture item + scene + trader_pools (default Generalist) + optional crafting recipe |
+| `register_item({id: dict, ...}) -> Dictionary` | Generic item bundle: ItemData + optional scene/icon/loot_tables/trader_pools |
+| `register_weapon({id: dict, ...}) -> Dictionary` | Weapon + rig + inline magazines + fits_attachments + loot_tables |
+| `register_magazine({id: dict, ...}) -> Dictionary` | Magazine + scene + fits_weapons (additive append to weapons' compatible) |
+| `register_attachment({id: dict, ...}) -> Dictionary` | Attachment + scene + fits_weapons (same shape as magazine; split for readability) |
+| `register_furniture({id: dict, ...}) -> Dictionary` | Furniture item + scene + trader_pools (default Generalist) + optional crafting recipe |
 
 Aggregators are pure fan-out -- they call existing primitives under the hood. There's no separate storage; mods can drop down to primitives any time. Use the aggregators when you're shipping a complete content unit (one weapon, one furniture piece) and want all the registrations + cross-compat patches in one call. Use primitives when you need fine-grained control or you're modifying existing content rather than adding.
 
-The result dict shape is per-helper but always includes:
-- `ok: bool` -- did everything succeed
+The wrapped result is always `{ok: bool, results: {id: per_id_dict}}`. Top-level `ok` is true when every entry's per-id `ok` is true. Per-id dict shape varies by helper but always includes:
+- `ok: bool` -- did this entry's full fan-out succeed
 - One bool per fanned-out registry call (e.g. `items`, `scene`, `rig`, `loot_count: int`)
 - For helpers with cross-compat fields: `<rel>: [String]` (resolved ids) and `<rel>_failed: [String]` (ids that didn't resolve)
 
@@ -770,51 +770,81 @@ The loader subscribes to `SceneTree.node_added`. When a scene whose path matches
 
 ## Aggregator helpers (registries to use them with)
 
-The five `register_<thing>(id, dict)` methods are pure fan-out wrappers that call multiple primitive registry verbs. Use them when you're shipping a complete content unit and want one declarative call.
+The five `register_<thing>(entries)` methods are pure fan-out wrappers that call multiple primitive registry verbs. Use them when you're shipping a complete content unit and want one declarative call. They're also reachable from [Setup](Setup) as `["register_weapon", {...}]` etc.
+
+**Always take a Dictionary**. Even a single registration goes in as a one-key dict. There is no `(id, data)` overload.
+
+```gdscript
+# Single registration
+lib.register_weapon({"my_ak": {item_path: ..., scene_path: ..., rig_path: ...}})
+
+# Multiple registrations -- same shape, more keys
+lib.register_weapon({
+    "my_ak":  {item_path: ..., scene_path: ..., rig_path: ...},
+    "my_m4":  {item_path: ..., scene_path: ..., rig_path: ...},
+})
+```
+
+**Return shape** is uniform: `{ok: bool, results: {id: granular_dict}}`. Each value in `results` is the per-id granular dict (the same shape the old singular form returned). `ok` at the top is true only when every entry succeeded.
+
+```gdscript
+var result := lib.register_weapon({"my_ak": {...}, "my_m4": {...}})
+if not result.ok:
+    for id in result.results:
+        var per: Dictionary = result.results[id]
+        if not per.ok:
+            push_warning("[mymod] %s failed: items=%s scene=%s rig=%s" \
+                    % [id, per.items, per.scene, per.rig])
+```
 
 ### register_item
 
 Generic item bundle. Use for content that doesn't fit weapon/mag/attachment/furniture (consumables, keys, tools, ammo).
 
 ```gdscript
-var lib = Engine.get_meta("RTVModLib")
-var result: Dictionary = lib.register_item("MyMedkit", {
-    "item_path":    "res://mymod/items/MyMedkit.tres",     # required
-    "scene_path":   "res://mymod/items/MyMedkit.tscn",     # optional
-    "icon_path":    "res://mymod/icons/MyMedkit.png",      # optional, sets ItemData.icon
-    "loot_tables":  ["LT_Master"],                         # optional
-    "trader_pools": ["Doctor"],                            # optional
+var result: Dictionary = lib.register_item({
+    "MyMedkit": {
+        "item_path":    "res://mymod/items/MyMedkit.tres",     # required
+        "scene_path":   "res://mymod/items/MyMedkit.tscn",     # optional
+        "icon_path":    "res://mymod/icons/MyMedkit.png",      # optional, sets ItemData.icon
+        "loot_tables":  ["LT_Master"],                         # optional
+        "trader_pools": ["Doctor"],                            # optional
+    },
 })
-# result = {ok, items, scene, loot_count, trader_pool_count,
-#           trader_pools: [String], trader_pools_failed: [String]}
+# result.results.MyMedkit = {ok, items, scene, loot_count, trader_pool_count,
+#                            trader_pools: [String], trader_pools_failed: [String]}
 ```
 
-**`scene` defaults to `true`** when no `scene_path` is provided (vacuously satisfied — there was nothing to do). `result.ok` requires `items` + `scene` + no failed trader_pools.
+Per-id `scene` defaults to `true` when no `scene_path` is provided (vacuously satisfied). The per-id `ok` requires `items` + `scene` + no failed trader_pools.
 
 ### register_weapon
 
 Weapon + first-person rig + optional inline magazines + optional fits_attachments + optional loot tables.
 
 ```gdscript
-var result: Dictionary = lib.register_weapon("MyRifle", {
-    "item_path":  "res://mymod/MyRifle.tres",                # required
-    "scene_path": "res://mymod/MyRifle.tscn",                # required (world model)
-    "rig_path":   "res://mymod/MyRifle_Rig.tscn",            # required (first-person rig)
-    "icon_path":  "res://mymod/Icon_MyRifle.png",            # optional
-    "magazines": [                                            # optional, mixed array
-        {                                                     # inline = new mag registration
-            "id": "MyRifle_StdMag",
-            "item_path":  "res://mymod/MyRifle_Mag.tres",
-            "scene_path": "res://mymod/MyRifle_Mag.tscn",
-            "loot_tables": ["LT_Master"],                     # mag's own loot
-        },
-        "AK_12_Magazine",                                     # id-string = ref to existing mag
-    ],
-    "fits_attachments": ["ACOG", "Kobra"],                    # optional, weapon accepts these
-    "loot_tables": ["LT_Master"],                             # optional, weapon's own loot
+var result: Dictionary = lib.register_weapon({
+    "MyRifle": {
+        "item_path":  "res://mymod/MyRifle.tres",                # required
+        "scene_path": "res://mymod/MyRifle.tscn",                # required (world model)
+        "rig_path":   "res://mymod/MyRifle_Rig.tscn",            # required (first-person rig)
+        "icon_path":  "res://mymod/Icon_MyRifle.png",            # optional
+        "magazines": [                                            # optional, mixed array
+            {                                                     # inline = new mag registration
+                "id": "MyRifle_StdMag",
+                "item_path":  "res://mymod/MyRifle_Mag.tres",
+                "scene_path": "res://mymod/MyRifle_Mag.tscn",
+                "loot_tables": ["LT_Master"],                     # mag's own loot
+            },
+            "AK_12_Magazine",                                     # id-string = ref to existing mag
+        ],
+        "fits_attachments": ["ACOG", "Kobra"],                    # optional
+        "loot_tables": ["LT_Master"],                             # optional, weapon's own loot
+    },
 })
-# result = {ok, items, scene, rig, magazines: [{id, ok, items, scene, loot_count}, ...],
-#           fits_attachments: [String], fits_attachments_failed: [String], loot_count: int}
+# result.results.MyRifle = {ok, items, scene, rig,
+#                           magazines: [{id, ok, items, scene, loot_count}, ...],
+#                           fits_attachments: [String], fits_attachments_failed: [String],
+#                           loot_count: int}
 ```
 
 The `magazines` field auto-populates the weapon's `compatible` array with each magazine's ItemData ref. `fits_attachments` resolves vanilla / mod-registered attachment ids and appends them to `compatible` too.
@@ -824,27 +854,32 @@ The `magazines` field auto-populates the weapon's `compatible` array with each m
 Standalone magazine. Registers item + scene + optional loot. `fits_weapons` patches each target weapon's `compatible` to include this magazine.
 
 ```gdscript
-var result: Dictionary = lib.register_magazine("MyExtendedMag", {
-    "item_path":  "res://mymod/MyExtendedMag.tres",       # required
-    "scene_path": "res://mymod/MyExtendedMag.tscn",       # required
-    "icon_path":  "res://mymod/Icon_MyMag.png",           # optional
-    "fits_weapons": ["AK_12", "AKM"],                     # optional
-    "loot_tables": ["LT_Master"],                         # optional
+var result: Dictionary = lib.register_magazine({
+    "MyExtendedMag": {
+        "item_path":  "res://mymod/MyExtendedMag.tres",       # required
+        "scene_path": "res://mymod/MyExtendedMag.tscn",       # required
+        "icon_path":  "res://mymod/Icon_MyMag.png",           # optional
+        "fits_weapons": ["AK_12", "AKM"],                     # optional
+        "loot_tables": ["LT_Master"],                         # optional
+    },
 })
-# result = {ok, items, scene, fits_weapons: [String],
-#           fits_weapons_failed: [String], loot_count: int}
+# result.results.MyExtendedMag = {ok, items, scene,
+#                                 fits_weapons: [String], fits_weapons_failed: [String],
+#                                 loot_count: int}
 ```
 
 ### register_attachment
 
-Same shape as `register_magazine`. Vanilla's `compatible` field accepts mags and attachments interchangeably; the API split is for mod-author readability.
+Same per-entry shape as `register_magazine`. Vanilla's `compatible` field accepts mags and attachments interchangeably; the API split is for mod-author readability.
 
 ```gdscript
-var result: Dictionary = lib.register_attachment("MyOptic", {
-    "item_path":  "res://mymod/MyOptic.tres",
-    "scene_path": "res://mymod/MyOptic.tscn",
-    "fits_weapons": ["AK_12", "AKM", "M4A1"],
-    "loot_tables": ["LT_Master"],
+var result: Dictionary = lib.register_attachment({
+    "MyOptic": {
+        "item_path":  "res://mymod/MyOptic.tres",
+        "scene_path": "res://mymod/MyOptic.tscn",
+        "fits_weapons": ["AK_12", "AKM", "M4A1"],
+        "loot_tables": ["LT_Master"],
+    },
 })
 ```
 
@@ -853,20 +888,22 @@ var result: Dictionary = lib.register_attachment("MyOptic", {
 Furniture is structurally an ItemData with `type = "Furniture"` plus a placed world scene. Distinct from `register_item` because furniture has a different obtainment path: it's never loot-pool spawnable, it's bought from traders or crafted, and on purchase vanilla routes it to the catalog grid (not the inventory grid).
 
 ```gdscript
-var result: Dictionary = lib.register_furniture("MyBed", {
-    "item_path":    "res://mymod/MyBed_F.tres",                # required, expects type="Furniture"
-    "scene_path":   "res://mymod/MyBed_F.tscn",                # required (placed world scene)
-    "icon_path":    "res://mymod/Icon_MyBed.png",              # optional
-    "trader_pools": ["Generalist"],                            # optional, defaults to ["Generalist"] with warn
-    "recipe": {                                                # optional crafting recipe
-        "name":  "My Bed",                                     # display name
-        "input": [<ItemData refs>],                            # required if recipe present
-        "time":  10.0,
-        "audio": <AudioEvent ref>,                             # optional
+var result: Dictionary = lib.register_furniture({
+    "MyBed": {
+        "item_path":    "res://mymod/MyBed_F.tres",                # required, expects type="Furniture"
+        "scene_path":   "res://mymod/MyBed_F.tscn",                # required (placed world scene)
+        "icon_path":    "res://mymod/Icon_MyBed.png",              # optional
+        "trader_pools": ["Generalist"],                            # optional, defaults to ["Generalist"] with warn
+        "recipe": {                                                # optional crafting recipe
+            "name":  "My Bed",                                     # display name
+            "input": [<ItemData refs>],                            # required if recipe present
+            "time":  10.0,
+            "audio": <AudioEvent ref>,                             # optional
+        },
     },
 })
-# result = {ok, items, scene, trader_pool_count,
-#           trader_pools: [String], trader_pools_failed: [String], recipe: bool}
+# result.results.MyBed = {ok, items, scene, trader_pool_count,
+#                         trader_pools: [String], trader_pools_failed: [String], recipe: bool}
 ```
 
 **`loot_tables` is rejected with a warning** -- furniture isn't loot-pool spawnable in vanilla. If the modder includes it, the field is logged as ignored.

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -45,8 +45,20 @@ lib.revert(lib.Registry.SCENES, "Potato")
 | `register(registry, id, data) -> bool` | Add a new entry. Fails on id collision with vanilla or prior mod registrations |
 | `override(registry, id, data) -> bool` | Replace an existing entry wholesale. Fails if the id doesn't resolve |
 | `patch(registry, id, fields) -> bool` | Mutate individual fields on an entry. Original values are stashed for revert |
+| `append(registry, id, field, values, allow_duplicates=false) -> bool` | Add to an Array field. De-dups by default. Stash shared with `patch` |
+| `prepend(registry, id, field, values, allow_duplicates=false) -> bool` | Same as `append` but inserts at the front |
+| `remove_from(registry, id, field, values) -> bool` | Drop matching values from an Array field. Removes all occurrences, idempotent |
 | `remove(registry, id) -> bool` | Undo a `register`. Fails on override-backed ids (use `revert`) |
 | `revert(registry, id, fields=[]) -> bool` | Undo an `override` or `patch`. Per-field revert when `fields` is non-empty |
+| `register_many(registry, {id: data, ...}) -> Dictionary` | Batched register; returns `{ok, results}` |
+| `override_many(registry, {id: data, ...}) -> Dictionary` | Batched override |
+| `patch_many(registry, {id: fields, ...}) -> Dictionary` | Batched patch |
+| `append_many(registry, field, {id: values, ...}, allow_duplicates=false) -> Dictionary` | Batched append on the same field across many ids |
+| `prepend_many(registry, field, {id: values, ...}, allow_duplicates=false) -> Dictionary` | Batched prepend |
+| `remove_from_many(registry, field, {id: values, ...}) -> Dictionary` | Batched remove_from |
+| `revert_many(registry, {id: fields_array, ...}) -> Dictionary` | Batched revert; per-id `fields_array` (empty = full revert of that id) |
+| `remove_many(registry, [id, ...]) -> Dictionary` | Batched remove |
+| `setup(plan) -> Dictionary` | Declarative entry point: list of `[verb, ...args]` entries dispatched in order. See the **`setup` plan** section below |
 | `get_entry(registry, id) -> Variant` | Read the current entry (after any registry mutations). Returns `null` if missing |
 | `has(registry, id, include_vanilla=true) -> bool` | Membership check. Cheaper than `get_entry(...) != null` |
 | `keys(registry, include_vanilla=true) -> Array[String]` | All ids in the registry |
@@ -83,20 +95,20 @@ Use `lib.Registry.<NAME>` rather than raw strings so typos surface at parse time
 | Constant | String | Underlying store | Verbs supported |
 |---|---|---|---|
 | `SCENES` | `"scenes"` | `Database.gd` scene consts | register, override, remove, revert |
-| `ITEMS` | `"items"` | `ItemData` `.tres` keyed by `file` | register, override, patch, remove, revert |
+| `ITEMS` | `"items"` | `ItemData` `.tres` keyed by `file` | register, override, patch, append/prepend/remove_from, remove, revert |
 | `LOOT` | `"loot"` | `LootTable.items` arrays | register, override, remove, revert |
-| `SOUNDS` | `"sounds"` | `AudioLibrary.tres` `@export` fields | register, override, patch, remove, revert |
-| `RECIPES` | `"recipes"` | `Recipes.tres` category arrays | register, override, patch, remove, revert |
-| `EVENTS` | `"events"` | `Events.tres` events array | register, override, patch, remove, revert |
+| `SOUNDS` | `"sounds"` | `AudioLibrary.tres` `@export` fields | register, override, patch, append/prepend/remove_from, remove, revert |
+| `RECIPES` | `"recipes"` | `Recipes.tres` category arrays | register, override, patch, append/prepend/remove_from, remove, revert |
+| `EVENTS` | `"events"` | `Events.tres` events array | register, override, patch, append/prepend/remove_from, remove, revert |
 | `TRADER_POOLS` | `"trader_pools"` | Per-item trader boolean flags | register, remove, revert |
-| `TRADER_TASKS` | `"trader_tasks"` | `TraderData.tasks` arrays | register, override, patch, remove, revert |
+| `TRADER_TASKS` | `"trader_tasks"` | `TraderData.tasks` arrays | register, override, patch, append/prepend/remove_from, remove, revert |
 | `INPUTS` | `"inputs"` | `InputMap` actions | register, override, patch, remove, revert |
 | `SCENE_PATHS` | `"scene_paths"` | Named scene lookup on `Loader.gd` | register, override, patch, remove, revert |
 | `SHELTERS` | `"shelters"` | `Loader.shelters` append-only list | register, remove |
 | `RANDOM_SCENES` | `"random_scenes"` | `Loader.randomScenes` append-only list | register, remove |
 | `AI_TYPES` | `"ai_types"` | Zone → agent scene overrides on `AISpawner` | register, override, remove, revert |
 | `FISH_SPECIES` | `"fish_species"` | `FishPool` extra species | register, remove |
-| `RESOURCES` | `"resources"` | Arbitrary `.tres` by absolute path | patch, revert |
+| `RESOURCES` | `"resources"` | Arbitrary `.tres` by absolute path | patch, append/prepend/remove_from, revert |
 | `SCENE_NODES` | `"scene_nodes"` | Property mutations on nodes inside any scene | patch, revert |
 | `WEAPONS` | `"weapons"` | Aggregator-only; routes to `register_weapon` | register (collapses to bool) |
 | `MAGAZINES` | `"magazines"` | Aggregator-only; routes to `register_magazine` | register (collapses to bool) |
@@ -151,6 +163,33 @@ lib.revert(lib.Registry.ITEMS, "Potato")              # restore everything else
 
 Registries that don't support patch (loot, scenes, trader_pools, fish_species) return `false` with guidance.
 
+### append / prepend / remove_from
+
+Array-only mutations on a single field. Use these instead of `patch` when you want to **add to** or **subtract from** an existing array (e.g. a weapon's `compatible` list) without overwriting other entries other mods may have contributed.
+
+```gdscript
+# Add new magazines as compatible options on the AKM, without clobbering vanilla's list:
+lib.append(lib.Registry.ITEMS, "res://Items/Magazines/AKM.tres", "compatible", [magA, magB])
+
+# Single value also works (no need to wrap in an array):
+lib.append(lib.Registry.ITEMS, "res://Items/Magazines/AKM.tres", "compatible", magC)
+
+# Insert at the front instead of the end:
+lib.prepend(lib.Registry.SOUNDS, "footsteps_dirt", "audio", newClip)
+
+# Remove an entry; silent skip if it isn't there.
+lib.remove_from(lib.Registry.ITEMS, "res://Items/Magazines/AKM.tres", "compatible", oldMag)
+```
+
+**Semantics:**
+- **Array fields only.** Calling on a non-Array field returns `false` with a "field is not an Array" warning. For scalar fields, use `patch` instead.
+- **De-dup on append/prepend by default.** If a value is already in the array, it isn't appended again. Pass `allow_duplicates=true` to permit repeats.
+- **`remove_from` removes all matching occurrences,** not just the first. Idempotent — re-running with the same value is a no-op after the first call.
+- **Stash is shared with `patch`.** A `patch` on `compatible` followed by `append` to `compatible` keeps the *original* (pre-patch, pre-append) value on first-write-wins. `revert(reg, id, ["compatible"])` restores the true original.
+- **Typed-array safety.** Values that don't match the array's declared type (e.g. trying to append a non-`ItemData` Resource into `Array[ItemData]`) are rejected before any mutation, with a "rejected by typed-array constraint" warning.
+
+**Supported registries:** `items`, `sounds`, `recipes`, `events`, `trader_tasks`, `resources`. Other registries either don't have Array fields (`inputs`, `scene_paths`) or have non-Resource entries (`scenes`, `loot`, `shelters`, etc.); calls return `false` with guidance.
+
 ### remove
 
 Reverses a prior `register`. Fails on override-backed or vanilla ids, those need `revert`.
@@ -161,6 +200,68 @@ Reverses an `override` or `patch`. Fails if there's nothing to undo (nothing ove
 
 - Bare `revert(registry, id)` with no `fields` argument unwinds everything for that id (patches first, then the override).
 - `revert(registry, id, ["field1", "field2"])` unwinds only those specific patched fields; other patches and the override stay.
+
+### Batched forms (`*_many`)
+
+Every mutation verb has a sibling that takes a Dictionary of ids (or, for `remove_many`, an Array). One call, many entries, single-registry. Useful for table-driven mods that already store their data as a dict.
+
+```gdscript
+# Patch many items in one call.
+lib.patch_many(lib.Registry.ITEMS, {
+    "res://Items/Weapons/AKM/AKM.tres":  {"damage": 45},
+    "res://Items/Weapons/AK74/AK74.tres": {"damage": 40},
+})
+
+# Append the same field across many ids.
+lib.append_many(lib.Registry.ITEMS, "compatible", {
+    "res://Items/Weapons/AKM/AKM.tres":  [magA, magB],
+    "res://Items/Weapons/AK74/AK74.tres": [magC],
+})
+
+# Per-id field lists for revert. Empty array = full revert of that id.
+lib.revert_many(lib.Registry.ITEMS, {
+    "res://Items/Weapons/AKM/AKM.tres":  ["damage", "compatible"],
+    "res://Items/Weapons/AK74/AK74.tres": [],
+})
+
+# Remove a list of mod-registered entries.
+lib.remove_many(lib.Registry.ITEMS, ["my_mod_potion", "my_mod_grenade"])
+```
+
+**Return shape.** Each `_many` returns `{ok: bool, results: {id: bool, ...}}`. `ok` is true only when every entry succeeded. Failures are isolated — one bad id doesn't stop the others, and the per-id success bools tell you which ones landed.
+
+```gdscript
+var result := lib.patch_many(lib.Registry.ITEMS, {...})
+if not result.ok:
+    for id in result.results:
+        if not result.results[id]:
+            push_warning("[mymod] failed to patch %s" % id)
+```
+
+**One field per call** for the array verbs. `append_many` / `prepend_many` / `remove_from_many` all take a single `field` arg that applies to every entry in the dict. If you need different fields per id, make multiple calls — or use `setup` (below) which runs an ordered sequence of verbs in one call.
+
+### setup -- declarative plan
+
+`setup(plan)` runs an ordered list of `[verb, ...args]` entries that map to the registry verbs above plus `hooks` (batched hook registration) and `when` (conditional sub-plans). One declarative literal replaces the typical pile of administrative `_ready` lines.
+
+```gdscript
+const PLAN = [
+    ["register", lib.Registry.ITEMS, {"my_mod_potion": myPotionData}],
+    ["patch",    lib.Registry.ITEMS, {"res://Items/Weapons/AKM/AKM.tres": {"damage": 45}}],
+    ["append",   lib.Registry.ITEMS, "compatible", {"res://Items/Weapons/AKM/AKM.tres": [magA, magB]}],
+    ["hooks",    {"interface-getmagazine": _replace_get_mag}],
+    ["when",     _is_hardcore, [
+        ["patch", lib.Registry.ITEMS, {"res://Items/Misc/Sticks/Sticks.tres": {"value": 200}}],
+    ]],
+]
+
+func _ready() -> void:
+    var lib = Engine.get_meta("RTVModLib")
+    await lib.frameworks_ready
+    lib.setup(PLAN)
+```
+
+See **[Setup](Setup)** for the full verb table, predicate forms, return shape, and a comprehensive example covering every supported entry.
 
 ### get_entry
 

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -48,8 +48,33 @@ lib.revert(lib.Registry.SCENES, "Potato")
 | `remove(registry, id) -> bool` | Undo a `register`. Fails on override-backed ids (use `revert`) |
 | `revert(registry, id, fields=[]) -> bool` | Undo an `override` or `patch`. Per-field revert when `fields` is non-empty |
 | `get_entry(registry, id) -> Variant` | Read the current entry (after any registry mutations). Returns `null` if missing |
+| `has(registry, id, include_vanilla=true) -> bool` | Membership check. Cheaper than `get_entry(...) != null` |
+| `keys(registry, include_vanilla=true) -> Array[String]` | All ids in the registry |
+| `list(registry, include_vanilla=true) -> Dictionary` | All `id -> entry` pairs |
+| `find(registry, predicate, include_vanilla=true) -> Array` | Filtered iteration; returns `[{id, entry}, ...]` |
 
-Every verb returns a bool indicating success; failures log a `push_warning` with the reason.
+Every mutating verb returns a bool indicating success; failures log a `push_warning` with the reason. The read methods (`get_entry`, `has`, `keys`, `list`, `find`) never warn; they return empty / null / false for misses.
+
+### Aggregator helpers
+
+Five high-level helpers that fan out to multiple primitive registries in one declarative call. They live alongside the standard verbs, take a single `Dictionary` payload, and return a granular result dict (per-step success bools) rather than a single bool.
+
+| Method | Purpose |
+|---|---|
+| `register_item(id, dict) -> Dictionary` | Generic item bundle: ItemData + optional scene/icon/loot_tables/trader_pools |
+| `register_weapon(id, dict) -> Dictionary` | Weapon + rig + inline magazines + fits_attachments + loot_tables |
+| `register_magazine(id, dict) -> Dictionary` | Magazine + scene + fits_weapons (additive append to weapons' compatible) |
+| `register_attachment(id, dict) -> Dictionary` | Attachment + scene + fits_weapons (same shape as magazine; split for readability) |
+| `register_furniture(id, dict) -> Dictionary` | Furniture item + scene + trader_pools (default Generalist) + optional crafting recipe |
+
+Aggregators are pure fan-out -- they call existing primitives under the hood. There's no separate storage; mods can drop down to primitives any time. Use the aggregators when you're shipping a complete content unit (one weapon, one furniture piece) and want all the registrations + cross-compat patches in one call. Use primitives when you need fine-grained control or you're modifying existing content rather than adding.
+
+The result dict shape is per-helper but always includes:
+- `ok: bool` -- did everything succeed
+- One bool per fanned-out registry call (e.g. `items`, `scene`, `rig`, `loot_count: int`)
+- For helpers with cross-compat fields: `<rel>: [String]` (resolved ids) and `<rel>_failed: [String]` (ids that didn't resolve)
+
+Each helper section below documents its specific schema. Source: [src/registry/aggregators.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry/aggregators.gd).
 
 ### Registry constants
 
@@ -72,9 +97,14 @@ Use `lib.Registry.<NAME>` rather than raw strings so typos surface at parse time
 | `AI_TYPES` | `"ai_types"` | Zone → agent scene overrides on `AISpawner` | register, override, remove, revert |
 | `FISH_SPECIES` | `"fish_species"` | `FishPool` extra species | register, remove |
 | `RESOURCES` | `"resources"` | Arbitrary `.tres` by absolute path | patch, revert |
-| `SCENE_NODES` | `"scene_nodes"` | Node properties on vanilla scenes (per-instance, via `node_added`) | patch, revert |
+| `SCENE_NODES` | `"scene_nodes"` | Property mutations on nodes inside any scene | patch, revert |
+| `WEAPONS` | `"weapons"` | Aggregator-only; routes to `register_weapon` | register (collapses to bool) |
+| `MAGAZINES` | `"magazines"` | Aggregator-only; routes to `register_magazine` | register (collapses to bool) |
+| `ATTACHMENTS` | `"attachments"` | Aggregator-only; routes to `register_attachment` | register (collapses to bool) |
 
 Unsupported verbs return `false` with a guidance warning (e.g. "patch on loot rejected, use override for content swaps").
+
+Aggregator-only registries (`WEAPONS`, `MAGAZINES`, `ATTACHMENTS`) reject `override`/`patch`/`remove`/`revert` at the standard-verb dispatcher with guidance to use the underlying primitives. They exist so mods that want bool-only routing (e.g. checking `register('weapons', ...)` in a generic loop) get consistent behavior, but the dedicated `register_weapon` / etc. methods are the preferred way to call them since you get the granular result dict.
 
 ## Timing
 
@@ -614,44 +644,180 @@ lib.revert(lib.Registry.RESOURCES, path)
 
 ## SCENE_NODES
 
-Mutates node properties inside vanilla scenes without shipping a full-scene override. Patches land **per-instance at `node_added` time**, before the scene root's `_ready` runs, so `@onready` values that depend on the patched properties observe the patched state. Verbs: `patch`, `revert` only. See [src/registry/scene_nodes.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/registry/scene_nodes.gd).
-
-IDs use a compound format: `"<res://scene_path>#<node_path>"`. The scene path is the `.tscn` res path; the node path is relative to that scene's root. The ID splits on the first `#` (scene paths don't legally contain `#`, and node names can't either).
+Patch property values on a specific node inside a scene without shipping a full scene override. Verbs: `patch`, `revert` only. Id format: `"<scene_path>#<node_path>"`.
 
 ```gdscript
 var lib = Engine.get_meta("RTVModLib")
 
-# patch: flip properties on a named node inside Interface.tscn
+# Mutate a button's `disabled` property inside Interface.tscn
 lib.patch(lib.Registry.SCENE_NODES,
     "res://UI/Interface.tscn#Tools/Crafting/Types/Margin/Buttons/Equipment",
     {"disabled": false, "modulate": Color(1, 1, 1, 1)})
 
-# revert per-field
-lib.revert(lib.Registry.SCENE_NODES,
-    "res://UI/Interface.tscn#Tools/Crafting/Types/Margin/Buttons/Equipment",
-    ["disabled"])
-
-# revert everything patched at this id
+# Revert
 lib.revert(lib.Registry.SCENE_NODES,
     "res://UI/Interface.tscn#Tools/Crafting/Types/Margin/Buttons/Equipment")
 ```
 
-**Validation.** At `patch` time the registry loads the PackedScene, instantiates a probe, resolves the node path, and checks each property exists on the target. Failures emit a `push_warning` and return `false`. The probe is freed immediately. Successful validations are memoized by `"<scene>#<node>|<sorted,fields>"` so repeat patches with the same id + field set don't re-instantiate the scene.
+The loader subscribes to `SceneTree.node_added`. When a scene whose path matches a registered patch instantiates, the loader walks the registered node paths inside that scene and applies the patch to each match. The PackedScene resource is never mutated; only live instances. Late patches (registered after the scene is already in the tree) scan existing live instances and apply retroactively.
 
-**Timing.** The listener is connected automatically at `frameworks_ready`; patches called earlier are fine (the listener connects lazily on the first `patch` call). Live instances already in the tree at `patch` time are walked and updated in-place.
+**No `register` / `override`**. To add new nodes use `override(SCENES, ...)` with a full replacement scene. To swap the whole scene's PackedScene wholesale, same. `SCENE_NODES` is patch-only.
 
-**Stash.** The revert stash populates at *apply* time, not at `patch` time -- the registry doesn't hold a live instance until one enters the tree. Per-field revert on a field that no live instance ever observed emits a warning since there's nothing to restore on any instance.
+**Conflicts.** Multiple mods patching different properties on the same node compose cleanly. Multiple mods patching the **same** property: last call wins; revert restores vanilla.
 
-**The PackedScene resource is never mutated.** Patches apply per-instance at `node_added`. Code that calls `packed_scene.get_bundled_scene()` directly still sees vanilla values.
+---
 
-**What SCENE_NODES can't do:**
-- Add or remove nodes (structural changes) -- use `override(lib.Registry.SCENES, ...)` to swap the whole scene.
-- Patch sub-resources embedded inside the scene. Inline `sub_resource` entries in the `.tscn` have no res:// path to target. Externally-referenced `.tres` sub-resources (via `ext_resource`) can be patched through `RESOURCES` by their path.
-- Patch values on scenes that never enter the tree (code that calls `packed_scene.get_bundled_scene()` directly still sees vanilla values).
+## Aggregator helpers (registries to use them with)
 
-**Conflicts.**
-- Two mods patching the **same field** on the same `(scene, node)`: both calls succeed in registration order; the second value is what the live instance observes. The stash holds the vanilla pre-patch value, so any `revert` returns to vanilla, not to mod A's value.
-- Two mods patching **different fields** on the same `(scene, node)`: both coexist with independent per-field stashes.
+The five `register_<thing>(id, dict)` methods are pure fan-out wrappers that call multiple primitive registry verbs. Use them when you're shipping a complete content unit and want one declarative call.
+
+### register_item
+
+Generic item bundle. Use for content that doesn't fit weapon/mag/attachment/furniture (consumables, keys, tools, ammo).
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+var result: Dictionary = lib.register_item("MyMedkit", {
+    "item_path":    "res://mymod/items/MyMedkit.tres",     # required
+    "scene_path":   "res://mymod/items/MyMedkit.tscn",     # optional
+    "icon_path":    "res://mymod/icons/MyMedkit.png",      # optional, sets ItemData.icon
+    "loot_tables":  ["LT_Master"],                         # optional
+    "trader_pools": ["Doctor"],                            # optional
+})
+# result = {ok, items, scene, loot_count, trader_pool_count,
+#           trader_pools: [String], trader_pools_failed: [String]}
+```
+
+**`scene` defaults to `true`** when no `scene_path` is provided (vacuously satisfied — there was nothing to do). `result.ok` requires `items` + `scene` + no failed trader_pools.
+
+### register_weapon
+
+Weapon + first-person rig + optional inline magazines + optional fits_attachments + optional loot tables.
+
+```gdscript
+var result: Dictionary = lib.register_weapon("MyRifle", {
+    "item_path":  "res://mymod/MyRifle.tres",                # required
+    "scene_path": "res://mymod/MyRifle.tscn",                # required (world model)
+    "rig_path":   "res://mymod/MyRifle_Rig.tscn",            # required (first-person rig)
+    "icon_path":  "res://mymod/Icon_MyRifle.png",            # optional
+    "magazines": [                                            # optional, mixed array
+        {                                                     # inline = new mag registration
+            "id": "MyRifle_StdMag",
+            "item_path":  "res://mymod/MyRifle_Mag.tres",
+            "scene_path": "res://mymod/MyRifle_Mag.tscn",
+            "loot_tables": ["LT_Master"],                     # mag's own loot
+        },
+        "AK_12_Magazine",                                     # id-string = ref to existing mag
+    ],
+    "fits_attachments": ["ACOG", "Kobra"],                    # optional, weapon accepts these
+    "loot_tables": ["LT_Master"],                             # optional, weapon's own loot
+})
+# result = {ok, items, scene, rig, magazines: [{id, ok, items, scene, loot_count}, ...],
+#           fits_attachments: [String], fits_attachments_failed: [String], loot_count: int}
+```
+
+The `magazines` field auto-populates the weapon's `compatible` array with each magazine's ItemData ref. `fits_attachments` resolves vanilla / mod-registered attachment ids and appends them to `compatible` too.
+
+### register_magazine
+
+Standalone magazine. Registers item + scene + optional loot. `fits_weapons` patches each target weapon's `compatible` to include this magazine.
+
+```gdscript
+var result: Dictionary = lib.register_magazine("MyExtendedMag", {
+    "item_path":  "res://mymod/MyExtendedMag.tres",       # required
+    "scene_path": "res://mymod/MyExtendedMag.tscn",       # required
+    "icon_path":  "res://mymod/Icon_MyMag.png",           # optional
+    "fits_weapons": ["AK_12", "AKM"],                     # optional
+    "loot_tables": ["LT_Master"],                         # optional
+})
+# result = {ok, items, scene, fits_weapons: [String],
+#           fits_weapons_failed: [String], loot_count: int}
+```
+
+### register_attachment
+
+Same shape as `register_magazine`. Vanilla's `compatible` field accepts mags and attachments interchangeably; the API split is for mod-author readability.
+
+```gdscript
+var result: Dictionary = lib.register_attachment("MyOptic", {
+    "item_path":  "res://mymod/MyOptic.tres",
+    "scene_path": "res://mymod/MyOptic.tscn",
+    "fits_weapons": ["AK_12", "AKM", "M4A1"],
+    "loot_tables": ["LT_Master"],
+})
+```
+
+### register_furniture
+
+Furniture is structurally an ItemData with `type = "Furniture"` plus a placed world scene. Distinct from `register_item` because furniture has a different obtainment path: it's never loot-pool spawnable, it's bought from traders or crafted, and on purchase vanilla routes it to the catalog grid (not the inventory grid).
+
+```gdscript
+var result: Dictionary = lib.register_furniture("MyBed", {
+    "item_path":    "res://mymod/MyBed_F.tres",                # required, expects type="Furniture"
+    "scene_path":   "res://mymod/MyBed_F.tscn",                # required (placed world scene)
+    "icon_path":    "res://mymod/Icon_MyBed.png",              # optional
+    "trader_pools": ["Generalist"],                            # optional, defaults to ["Generalist"] with warn
+    "recipe": {                                                # optional crafting recipe
+        "name":  "My Bed",                                     # display name
+        "input": [<ItemData refs>],                            # required if recipe present
+        "time":  10.0,
+        "audio": <AudioEvent ref>,                             # optional
+    },
+})
+# result = {ok, items, scene, trader_pool_count,
+#           trader_pools: [String], trader_pools_failed: [String], recipe: bool}
+```
+
+**`loot_tables` is rejected with a warning** -- furniture isn't loot-pool spawnable in vanilla. If the modder includes it, the field is logged as ignored.
+
+**Type validation**: warns (doesn't fail) if `ItemData.type` isn't `"Furniture"`. Vanilla code branches on this string when the player buys the item; a wrong type means the item goes to the inventory grid instead of the catalog.
+
+**Recipe construction**: builds a fresh `RecipeData` with output = the registered item, `category = "furniture"` locked. Mods that just want trader-only furniture skip the `recipe` field entirely.
+
+---
+
+## Reading the registry
+
+Three methods complement `get_entry` for bulk reads. All take an optional `include_vanilla: bool = true` -- pass `false` to see only what mods registered.
+
+```gdscript
+var lib = Engine.get_meta("RTVModLib")
+
+# Membership check
+if lib.has(lib.Registry.ITEMS, "AK_12"):
+    lib.patch(lib.Registry.ITEMS, "AK_12", {"damage": 50})
+
+# All ids in this registry (default: vanilla + mod)
+var all_item_ids: Array[String] = lib.keys(lib.Registry.ITEMS)
+var only_mod_items: Array[String] = lib.keys(lib.Registry.ITEMS, false)
+
+# Full id -> entry mapping
+var all_items: Dictionary = lib.list(lib.Registry.ITEMS)
+for id in all_items:
+    var item_data = all_items[id]
+
+# Filtered iteration. Predicate signature: func(entry) -> bool
+# Returns Array of {id, entry} dicts so callers don't need a separate id lookup
+var weapons: Array = lib.find(lib.Registry.ITEMS, func(it):
+    return it != null and "type" in it and it.get("type") == "Weapon"
+)
+for entry in weapons:
+    print(entry["id"], " -> ", entry["entry"].get("name"))
+```
+
+**Mod-vs-vanilla precedence** matches `get_entry`: mod entries override vanilla on id collision. So `list(ITEMS)` returns the mod's version when both exist.
+
+**Per-registry vanilla enumeration**:
+- `ITEMS` -- walks `LT_Master.items`, keyed by `.file`
+- `SCENES` -- Database script's const map filtered to `PackedScene`
+- `SCENE_PATHS` -- Loader script's const map filtered to `res://` strings
+- `SHELTERS` -- vanilla shelter list snapshot
+- `RECIPES` -- walks `Recipes.tres` seven category arrays, ids synthesized as `"<category>:<name>"`
+- All other registries (loot, trader_pools, sounds, events, inputs, etc.) -- vanilla side returns empty; these are mod-only registries by nature, the registry primitives only track what mods added
+
+`include_vanilla = false` returns only `_registry_registered[name]` for any registry.
+
+---
 
 ## Troubleshooting
 

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -107,6 +107,7 @@ Use `lib.Registry.<NAME>` rather than raw strings so typos surface at parse time
 | `SHELTERS` | `"shelters"` | `Loader.shelters` append-only list | register, remove |
 | `RANDOM_SCENES` | `"random_scenes"` | `Loader.randomScenes` append-only list | register, remove |
 | `AI_TYPES` | `"ai_types"` | Zone → agent scene overrides on `AISpawner` | register, override, remove, revert |
+| `AI_LOADOUTS` | `"ai_loadouts"` | Per-AI-category weapon injections (`AI.SelectWeapon` prelude) | register, override, remove, revert |
 | `FISH_SPECIES` | `"fish_species"` | `FishPool` extra species | register, remove |
 | `RESOURCES` | `"resources"` | Arbitrary `.tres` by absolute path | patch, append/prepend/remove_from, revert |
 | `SCENE_NODES` | `"scene_nodes"` | Property mutations on nodes inside any scene | patch, revert |

--- a/docs/wiki/Registry.md
+++ b/docs/wiki/Registry.md
@@ -785,7 +785,7 @@ lib.register_weapon({
 })
 ```
 
-**Return shape** is uniform: `{ok: bool, results: {id: granular_dict}}`. Each value in `results` is the per-id granular dict (the same shape the old singular form returned). `ok` at the top is true only when every entry succeeded.
+**Return shape** is uniform: `{ok: bool, results: {id: granular_dict}}`. Each value in `results` is the per-id granular dict. `ok` at the top is true only when every entry succeeded.
 
 ```gdscript
 var result := lib.register_weapon({"my_ak": {...}, "my_m4": {...}})

--- a/docs/wiki/Setup.md
+++ b/docs/wiki/Setup.md
@@ -132,6 +132,58 @@ func _ready() -> void:
             "my_mod_potion_recipe": {"recipe": my_recipe, "category": "consumables"},
         }],
 
+        # --- register_weapon: aggregator that fans out to items+scene+rig
+        # Aggregator verbs always take {id: data, ...}. The data dict per
+        # entry follows the aggregator's own schema (see Registry doc's
+        # "Aggregator helpers" section).
+        ["register_weapon", {
+            "MyRifle": {
+                "item_path":  "res://my_mod/MyRifle.tres",
+                "scene_path": "res://my_mod/MyRifle.tscn",
+                "rig_path":   "res://my_mod/MyRifle_Rig.tscn",
+                "magazines":  ["AK_12_Magazine"],   # ref existing mag
+            },
+        }],
+
+        # --- register_magazine: standalone mag registration ---------------
+        # `fits_weapons` patches each target's `compatible` array.
+        ["register_magazine", {
+            "MyExtendedMag": {
+                "item_path":    "res://my_mod/MyExtendedMag.tres",
+                "scene_path":   "res://my_mod/MyExtendedMag.tscn",
+                "fits_weapons": ["AK_12", "AKM"],
+                "loot_tables":  ["LT_Master"],
+            },
+        }],
+
+        # --- register_item: generic ItemData bundle -----------------------
+        # For consumables, keys, tools, ammo. Multiple ids in one call.
+        ["register_item", {
+            "MyMedkit": {
+                "item_path":    "res://my_mod/MyMedkit.tres",
+                "scene_path":   "res://my_mod/MyMedkit.tscn",
+                "trader_pools": ["Doctor"],
+            },
+            "MyKey": {
+                "item_path":  "res://my_mod/MyKey.tres",
+                "scene_path": "res://my_mod/MyKey.tscn",
+            },
+        }],
+
+        # --- register_furniture: ItemData(type=Furniture) + scene + recipe
+        ["register_furniture", {
+            "MyBed": {
+                "item_path":    "res://my_mod/MyBed_F.tres",
+                "scene_path":   "res://my_mod/MyBed_F.tscn",
+                "trader_pools": ["Generalist"],
+                "recipe": {
+                    "name":  "My Bed",
+                    "input": [],   # ItemData refs
+                    "time":  10.0,
+                },
+            },
+        }],
+
         # --- override: replace a vanilla entry wholesale ------------------
         ["override", _lib.Registry.SCENES, {
             "Potato": preload("res://my_mod/scenes/golden_potato.tscn"),
@@ -251,6 +303,10 @@ What the example demonstrates, top to bottom:
 | Section | Feature |
 |---|---|
 | `register` × 2 | Multiple registries, register-before-reference order |
+| `register_weapon` | Aggregator: weapon + scene + rig + magazine cross-ref |
+| `register_magazine` | Aggregator: magazine + scene + `fits_weapons` cross-compat |
+| `register_item` | Aggregator: generic item bundle, multi-entry in one call |
+| `register_furniture` | Aggregator: furniture item + scene + crafting recipe |
 | `override` | Whole-entry replace on scenes |
 | `patch` × 2 | Multi-id, multi-registry, items + resources together |
 | `append` | Multi-id with mixed single-value and Array values, default dedup |

--- a/docs/wiki/Setup.md
+++ b/docs/wiki/Setup.md
@@ -36,6 +36,11 @@ func _ready() -> void:
 | `["revert", reg, {id: fields_array, ...}]` | `revert_many` (empty array = full revert of that id) |
 | `["remove", reg, [id, id, ...]]` | `remove_many` |
 | `["hooks", {hook_name: callback, ...}]` | `hook_many` |
+| `["register_item", {id: data, ...}]` | `register_item` (aggregator) |
+| `["register_weapon", {id: data, ...}]` | `register_weapon` (aggregator) |
+| `["register_magazine", {id: data, ...}]` | `register_magazine` (aggregator) |
+| `["register_attachment", {id: data, ...}]` | `register_attachment` (aggregator) |
+| `["register_furniture", {id: data, ...}]` | `register_furniture` (aggregator) |
 | `["when", predicate, sub_plan]` | Recurse into `sub_plan` if `predicate` is truthy |
 
 ## Predicates for `when`

--- a/docs/wiki/Setup.md
+++ b/docs/wiki/Setup.md
@@ -1,0 +1,279 @@
+# Setup -- declarative plans
+
+`lib.setup(plan)` runs an ordered list of `[verb, ...args]` entries that map to the existing registry and hook APIs. It's designed for mods whose `_ready` is mostly administrative -- one line per hook, one per registration. With `setup`, the entire installation phase becomes one literal that can sit at module scope or be built locally in `_ready`.
+
+```gdscript
+const PLAN = [
+    ["register", lib.Registry.ITEMS,   {...}],
+    ["patch",    lib.Registry.ITEMS,   {...}],
+    ["append",   lib.Registry.ITEMS, "compatible", {...}],
+    ["hooks",    {...}],
+    ["when", _is_hardcore_mode, [
+        ["patch", lib.Registry.ITEMS, {...}],
+    ]],
+]
+
+func _ready() -> void:
+    var lib = Engine.get_meta("RTVModLib")
+    await lib.frameworks_ready
+    lib.setup(PLAN)
+```
+
+`setup` doesn't introduce new behavior -- it dispatches each entry to the existing public verbs. Anything you can do with `register` / `override` / `patch` / `append` / `prepend` / `remove_from` / `revert` / `remove` / `hook_many` you can do here, plus a meta verb `when` for conditional sub-plans.
+
+## Verb shapes
+
+| Entry | Maps to |
+|---|---|
+| `["register", reg, {id: data, ...}]` | `register_many` |
+| `["override", reg, {id: data, ...}]` | `override_many` |
+| `["patch", reg, {id: fields, ...}]` | `patch_many` |
+| `["append", reg, field, {id: values, ...}]` | `append_many` (de-dup default) |
+| `["append", reg, field, {id: values, ...}, true]` | `append_many(allow_duplicates=true)` |
+| `["prepend", reg, field, {id: values, ...}]` | `prepend_many` |
+| `["prepend", reg, field, {id: values, ...}, true]` | `prepend_many(allow_duplicates=true)` |
+| `["remove_from", reg, field, {id: values, ...}]` | `remove_from_many` |
+| `["revert", reg, {id: fields_array, ...}]` | `revert_many` (empty array = full revert of that id) |
+| `["remove", reg, [id, id, ...]]` | `remove_many` |
+| `["hooks", {hook_name: callback, ...}]` | `hook_many` |
+| `["when", predicate, sub_plan]` | Recurse into `sub_plan` if `predicate` is truthy |
+
+## Predicates for `when`
+
+Predicates accept three shapes:
+
+```gdscript
+["when", _hardcore_mode, [...]]                     # plain bool (member var)
+["when", _has_global_economy, [...]]                # named Callable
+["when", func(): return OS.has_feature("debug"), [...]]  # lambda
+```
+
+Evaluated when `setup` traverses the entry. A plan built in `_ready` can use runtime state freely. A `const PLAN = [...]` with non-Callable predicates evaluates them at script-parse time -- fine for compile-time constants but wrong for runtime state, so prefer Callable predicates in `const` plans.
+
+A skipped `when` (predicate false) returns `ok=true` -- it succeeded by not running anything.
+
+Nested `when` works as expected: the inner sub-plan only runs when both predicates evaluate truthy. There's no `unless` or `else` verb -- compose two `when` entries with negated predicates if you need branching.
+
+## Order matters
+
+Entries run in the order written. Insertion order is the source of truth. If you `register` an item and then `patch` it, write `register` first; the patch sees the just-registered entry. If you reverse the order the patch fails (no such id yet), and the register lands afterward unaffected.
+
+The same applies across registries. If a recipe references an item, register the item first. If you mix `revert` and `remove` after registers/patches, those run last and cleanly undo.
+
+## Failure isolation
+
+A bad entry (malformed shape, unknown verb, validation failure inside a verb) produces an `ok=false` result for that entry but **doesn't stop the next entry from running**. This matches the singular-verb and `_many` behavior. Mods that want fail-fast can inspect the result list themselves.
+
+## Return shape
+
+```gdscript
+{
+    "ok": bool,                # true only if every executed entry succeeded
+    "results": Array,          # one entry per top-level plan entry, in order
+}
+```
+
+Each item in `results` is a per-entry dict matching the verb:
+
+- Data verbs: `{verb, ok, results: {id: bool}}`
+- `hooks`: `{verb, ok, results: {hook_name: hook_id_or_-1}}`
+- `when`: `{verb, ok, evaluated, results?}` -- `results` present only when `evaluated=true`
+- Malformed: `{verb, ok: false, error: "..."}`
+
+Top-level `ok` is `true` only when every executed entry succeeded. A skipped `when` doesn't break this -- nothing failed because nothing ran.
+
+```gdscript
+var result: Dictionary = lib.setup(plan)
+if not result.ok:
+    for i in result.results.size():
+        var r: Dictionary = result.results[i]
+        if not bool(r.get("ok", false)):
+            push_warning("[mymod] entry %d (%s) failed: %s" \
+                    % [i, r.get("verb", "?"), r.get("error", "see log")])
+```
+
+## Comprehensive example
+
+A plan exercising every verb shape and predicate variant:
+
+```gdscript
+extends Node
+
+const _PotionScript := preload("res://Scripts/ItemData.gd")
+const _RecipeScript := preload("res://Scripts/RecipeData.gd")
+
+var _hardcore_mode: bool = false
+var _lib
+
+func _ready() -> void:
+    _lib = Engine.get_meta("RTVModLib")
+    await _lib.frameworks_ready
+
+    var my_potion: ItemData = _build_potion()
+    var my_grenade: ItemData = _build_grenade()
+    var my_recipe: RecipeData = _build_recipe(my_potion)
+    var ak12_mag: Resource = load("res://Items/Weapons/AK-12/AK-12_Magazine.tres")
+    var aks74u_mag: Resource = load("res://Items/Weapons/AKS-74U/AKS-74U_Magazine.tres")
+
+    var plan: Array = [
+        # --- register: add brand-new entries ------------------------------
+        # Order across entries matters: the recipe references my_potion, so
+        # register the potion first.
+        ["register", _lib.Registry.ITEMS, {
+            "my_mod_potion":  my_potion,
+            "my_mod_grenade": my_grenade,
+        }],
+        ["register", _lib.Registry.RECIPES, {
+            "my_mod_potion_recipe": {"recipe": my_recipe, "category": "consumables"},
+        }],
+
+        # --- override: replace a vanilla entry wholesale ------------------
+        ["override", _lib.Registry.SCENES, {
+            "Potato": preload("res://my_mod/scenes/golden_potato.tscn"),
+        }],
+
+        # --- patch: scalar field updates, multi-id, multi-registry --------
+        ["patch", _lib.Registry.ITEMS, {
+            "res://Items/Weapons/AKM/AKM.tres":  {"damage": 45.0, "weight": 3.2},
+            "res://Items/Weapons/AK74/AK74.tres": {"damage": 40.0},
+        }],
+        ["patch", _lib.Registry.RESOURCES, {
+            "res://Resources/GameData.tres": {"walk_speed": 5.5},
+        }],
+
+        # --- append: add to an Array field, dedup default -----------------
+        # Single value or Array on the right side; both forms work.
+        ["append", _lib.Registry.ITEMS, "compatible", {
+            "res://Items/Weapons/AKM/AKM.tres":   [ak12_mag, aks74u_mag],
+            "res://Items/Weapons/AK-12/AK-12.tres": aks74u_mag,
+        }],
+
+        # --- append with allow_duplicates=true ----------------------------
+        # Rare: when you genuinely want repeats (weighted lists, etc.).
+        ["append", _lib.Registry.ITEMS, "compatible", {
+            "res://Items/Weapons/AK-12/AK-12.tres": ak12_mag,
+        }, true],
+
+        # --- prepend: insert at the front ---------------------------------
+        ["prepend", _lib.Registry.SOUNDS, "audio", {
+            "footsteps_dirt": preload("res://my_mod/sounds/squelch.ogg"),
+        }],
+
+        # --- remove_from: drop matching entries ---------------------------
+        # Removes ALL occurrences. Idempotent if nothing matches.
+        ["remove_from", _lib.Registry.ITEMS, "compatible", {
+            "res://Items/Weapons/AKM/AKM.tres": ak12_mag,
+        }],
+
+        # --- hooks: batched hook registration -----------------------------
+        ["hooks", {
+            "interface-getmagazine":     _replace_get_mag,
+            "ai-_physics_process-pre":   _on_phys_pre,
+            "interface-close-post":      _on_close_post,
+            "loader-loadscene-callback": _on_scene_loaded,
+        }],
+
+        # --- when: plain bool predicate -----------------------------------
+        ["when", _hardcore_mode, [
+            ["patch", _lib.Registry.ITEMS, {
+                "res://Items/Weapons/AKM/AKM.tres": {"damage": 30.0},
+            }],
+        ]],
+
+        # --- when: named Callable predicate -------------------------------
+        ["when", _has_global_economy, [
+            ["patch", _lib.Registry.RESOURCES, {
+                "res://my_mod/Configs/scarcity.tres": {"enabled": true},
+            }],
+        ]],
+
+        # --- when: lambda predicate ---------------------------------------
+        ["when", func(): return OS.has_feature("debug"), [
+            ["hooks", {
+                "loader-loadscene-pre": _debug_logger,
+            }],
+        ]],
+
+        # --- nested when --------------------------------------------------
+        # Outer + inner predicates AND together.
+        ["when", _has_global_economy, [
+            ["when", _hardcore_mode, [
+                ["patch", _lib.Registry.ITEMS, {
+                    "res://Items/Misc/Sticks/Sticks.tres": {"value": 500},
+                }],
+            ]],
+        ]],
+
+        # --- revert: undo a previous patch (per-field or full) ------------
+        ["revert", _lib.Registry.ITEMS, {
+            "res://Items/Weapons/AK74/AK74.tres":  ["damage"],   # one field only
+            "res://Items/Weapons/AKM/AKM.tres":    [],            # full revert
+        }],
+
+        # --- remove: undo a previous register() ---------------------------
+        # Vanilla ids need revert; this only removes mod-registered entries.
+        ["remove", _lib.Registry.RECIPES, ["my_mod_potion_recipe"]],
+    ]
+
+    var result: Dictionary = _lib.setup(plan)
+
+    # Per-entry diagnostics if something failed.
+    if not result.ok:
+        for i in result.results.size():
+            var r: Dictionary = result.results[i]
+            if not bool(r.get("ok", false)):
+                push_warning("[mymod] plan entry %d (%s) failed: %s" \
+                        % [i, r.get("verb", "?"), r.get("error", "see log")])
+
+
+# Predicate helpers used in `when` entries.
+func _has_global_economy() -> bool:
+    return _lib.has_mod("global-economy")
+
+
+# Hook bodies referenced in the `hooks` entry.
+func _replace_get_mag(_weaponData, _weaponSlot, _swapMag) -> bool:
+    return false
+
+func _on_phys_pre(_delta: float) -> void: pass
+func _on_close_post() -> void: pass
+func _on_scene_loaded(_scene_name) -> void: pass
+func _debug_logger(_scene_name) -> void: print("[mymod] loading scene")
+```
+
+What the example demonstrates, top to bottom:
+
+| Section | Feature |
+|---|---|
+| `register` × 2 | Multiple registries, register-before-reference order |
+| `override` | Whole-entry replace on scenes |
+| `patch` × 2 | Multi-id, multi-registry, items + resources together |
+| `append` | Multi-id with mixed single-value and Array values, default dedup |
+| `append` (5-arg) | `allow_duplicates=true` form |
+| `prepend` | Insert-at-front on a different registry (sounds) |
+| `remove_from` | Drop matching values from an Array field |
+| `hooks` | Batched hook registration mixing pre/post/replace/callback variants |
+| `when` (bool) | Plain bool predicate from a member variable |
+| `when` (named) | Callable referencing a method by name |
+| `when` (lambda) | Inline closure |
+| `when` (nested) | Predicates compose; inner runs only if both are truthy |
+| `revert` | Per-id field arrays; mixed per-field and full-revert in one call |
+| `remove` | Undo a `register` from earlier in the plan |
+
+One subtlety: the **`remove` entry at the end removes the recipe registered at the top of the same plan**. That works because entries run in sequence; the recipe exists by the time the remove runs. Failure isolation means each entry stands alone, but order determines which ones land.
+
+## When not to use setup
+
+`setup` is for installation-phase work that runs once. Mods doing any of these still want imperative code in `_ready`:
+
+- Connecting to signals, scheduling timers, spawning UI nodes
+- File I/O or network requests
+- Long-running async work
+- Anything that needs to react to runtime events after the initial setup
+
+Use `setup` for the static, declarative slice and write whatever else you need around it.
+
+## See also
+
+- [Registry](Registry) -- the underlying verbs `setup` dispatches to
+- [Hooks](Hooks) -- hook registration, the `["hooks", {...}]` entry maps to `hook_many`

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -6,6 +6,7 @@
 - [Modules](Modules)
 - [Hooks](Hooks)
 - [Registry](Registry)
+- [Setup](Setup)
 - [Mod-Format](Mod-Format)
 - [Profile-Format](Profile-Format)
 - [Config-Files](Config-Files)

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -159,6 +159,13 @@ var _dispatch_counts: Dictionary = {}
 # when no mod has hooked anything at all. Sticky -- stays true once set.
 # Same approach as godot-mod-loader's `_ModLoaderHooks.any_mod_hooked`.
 var _any_mod_hooked: bool = false
+# Per-hook-base reference count. Keyed by hook_base ("<script>-<method>"
+# lowercase, no -pre/-post/-callback suffix). Incremented when hook() registers
+# any variant under that base, decremented (and erased at 0) by unhook(). The
+# generated wrapper short-circuits when _hooked_bases.has(base) is false, so a
+# wrapped method that nobody actually hooks costs one Dictionary.has() per call
+# instead of the full _wrapper_active/_caller/_dispatch pipeline.
+var _hooked_bases: Dictionary = {}
 var _next_id: int = 1
 var _skip_super: bool = false
 var _seq: int = 0

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -138,6 +138,12 @@ var _hidden_folder_profile_keys: Dictionary = {}
 var _hidden_folder_ids: Dictionary = {}
 var _pending_autoloads: Array[Dictionary] = []
 var _report_lines: Array[String] = []
+# Loaded mods, keyed by mod_id. Value is a Dictionary with at least
+# {version, file_name, priority, mod_name}; populated by mod_loading.
+# Public read API: lib.has_mod(id, ?min_version), lib.mod_info(id),
+# lib.loaded_mods(). Code that just checks presence still works via
+# Dict.has() since the key membership is unchanged from when the value
+# was a bare `true`.
 var _loaded_mod_ids: Dictionary = {}
 var _registered_autoload_names: Dictionary = {}
 var _override_registry: Dictionary = {}

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -21,6 +21,7 @@ const REGISTRY_TARGETS: Array[String] = [
 	"Database.gd",
 	"Loader.gd",
 	"AISpawner.gd",
+	"AI.gd",
 	"FishPool.gd",
 	"Compiler.gd",
 ]

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -41,6 +41,19 @@ func _emit_frameworks_ready() -> void:
 	# ext_resource staleness that take_over_path can't fix).
 	_verify_script_overrides()
 
+## Extract the hook_base ("<script>-<method>") from a full hook name by
+## stripping any -pre/-post/-callback suffix. A bare name (replace hook) is
+## already its own base. Used to maintain _hooked_bases.
+static func _hook_base_of(hook_name: String) -> String:
+	if hook_name.ends_with("-pre"):
+		return hook_name.substr(0, hook_name.length() - 4)
+	if hook_name.ends_with("-post"):
+		return hook_name.substr(0, hook_name.length() - 5)
+	if hook_name.ends_with("-callback"):
+		return hook_name.substr(0, hook_name.length() - 9)
+	return hook_name
+
+
 func hook(hook_name: String, callback: Callable, priority: int = 100) -> int:
 	var is_replace := not (hook_name.ends_with("-pre") \
 			or hook_name.ends_with("-post") \
@@ -62,6 +75,10 @@ func hook(hook_name: String, callback: Callable, priority: int = 100) -> int:
 	(_hooks[hook_name] as Array).sort_custom(func(a, b): return a["priority"] < b["priority"])
 	# Flip the global short-circuit so dispatch wrappers stop skipping.
 	_any_mod_hooked = true
+	# Refcount the hook_base so wrappers for never-hooked methods can
+	# fast-path past dispatch. Pre/post/callback all share the same base.
+	var base := _hook_base_of(hook_name)
+	_hooked_bases[base] = int(_hooked_bases.get(base, 0)) + 1
 	var id := _next_id
 	_next_id += 1
 	return id
@@ -105,6 +122,21 @@ func add_hook(script_path: String, method_name: String, callback: Callable, is_b
 	(_hooked_methods[res_path] as Dictionary)[method_name.to_lower()] = true
 	return hook(hook_name, callback, 100)
 
+## Batched form of hook(). `entries` is `{hook_name: callback, ...}`. Returns
+## `{ok: bool, results: {hook_name: hook_id_or_-1, ...}}`. Failures (e.g. a
+## replace name already owned by another mod) surface as -1 in the results
+## dict; ok is false if any registration returned -1.
+func hook_many(entries: Dictionary, priority: int = 100) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for hook_name in entries.keys():
+		var id: int = hook(String(hook_name), entries[hook_name], priority)
+		results[hook_name] = id
+		if id == -1:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
 ## Remove a hook by ID.
 func unhook(hook_id: int) -> void:
 	for hook_name in _hooks:
@@ -112,6 +144,12 @@ func unhook(hook_id: int) -> void:
 		for i in range(arr.size() - 1, -1, -1):
 			if arr[i]["id"] == hook_id:
 				arr.remove_at(i)
+				var base := _hook_base_of(hook_name)
+				var c: int = int(_hooked_bases.get(base, 0)) - 1
+				if c <= 0:
+					_hooked_bases.erase(base)
+				else:
+					_hooked_bases[base] = c
 				return
 
 ## Any hooks registered at this name?

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -175,6 +175,77 @@ func skip_super() -> void:
 func seq() -> int:
 	return _seq
 
+
+## ---- Mod-discovery API ----
+## Lets a mod ask "is this other mod loaded?" so it can integrate with peers
+## (e.g. defer to RTVCoop's trader-supply logic when present) or skip features
+## that depend on a missing dependency. All three calls operate on mod_id
+## strings (the `id="..."` field in mod.txt; folder/zip name as fallback).
+
+## True when a mod with the given id is loaded. Optional `min_version` does
+## a numeric semver compare (1.2.3 split on '.', component-wise int compare,
+## non-numeric components compare as 0). Mods declaring no version field
+## return version="" which compares as 0.0.0 -- they pass any min_version
+## of "0" but fail anything stricter.
+func has_mod(mod_id: String, min_version: String = "") -> bool:
+	if not _loaded_mod_ids.has(mod_id):
+		return false
+	if min_version == "":
+		return true
+	var info = _loaded_mod_ids[mod_id]
+	var have: String = ""
+	if info is Dictionary:
+		have = String(info.get("version", ""))
+	# Bare-true legacy values (shouldn't happen post-upgrade but defend
+	# against pre-upgrade callers): treat as unknown version, fail strict
+	# checks.
+	return _compare_versions(have, min_version) >= 0
+
+
+## Returns the full info dict for a loaded mod, or {} if not loaded.
+## Shape: {mod_id, mod_name, version, file_name, priority}. Stable enough
+## for mods to inspect for debug prints / MCM displays.
+func mod_info(mod_id: String) -> Dictionary:
+	var info = _loaded_mod_ids.get(mod_id, null)
+	if info is Dictionary:
+		return (info as Dictionary).duplicate()
+	return {}
+
+
+## All loaded mod ids. Order is not guaranteed; callers wanting consistent
+## display order should sort the result.
+func loaded_mods() -> Array[String]:
+	var out: Array[String] = []
+	for k in _loaded_mod_ids.keys():
+		out.append(String(k))
+	return out
+
+
+# Compare two dotted version strings component-wise. Returns -1 / 0 / 1.
+# Non-numeric components compare as 0 ("1.2.beta" -> [1,2,0]). Missing
+# trailing components default to 0 ("1.2" vs "1.2.0" compares equal).
+# This is intentionally minimal -- no semver pre-release / build metadata
+# parsing -- because RTV mods don't use those conventions in practice. If
+# they ever do, this is the spot to upgrade.
+func _compare_versions(a: String, b: String) -> int:
+	var pa: PackedStringArray = a.split(".")
+	var pb: PackedStringArray = b.split(".")
+	var n: int = max(pa.size(), pb.size())
+	for i in n:
+		var ai: int = 0 if i >= pa.size() else _to_version_int(pa[i])
+		var bi: int = 0 if i >= pb.size() else _to_version_int(pb[i])
+		if ai < bi:
+			return -1
+		if ai > bi:
+			return 1
+	return 0
+
+func _to_version_int(s: String) -> int:
+	if s.is_valid_int():
+		return int(s)
+	return 0
+
+
 # Internal dispatch -- called from the generated framework wrappers.
 
 func _dispatch(hook_name: String, args: Array) -> void:

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -154,7 +154,17 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 				_log_warning("  No mod.txt -- autoloads skipped")
 		return
 
-	_loaded_mod_ids[mod_id] = true
+	# Store full info so the public read API (has_mod/mod_info/loaded_mods)
+	# can answer version queries without re-walking the candidate list.
+	# Key membership is unchanged from when this was a bare `true`, so all
+	# existing _loaded_mod_ids.has(id) checks still work.
+	_loaded_mod_ids[mod_id] = {
+		"mod_id":    mod_id,
+		"mod_name":  mod_name,
+		"version":   String(c.get("version", "")),
+		"file_name": file_name,
+		"priority":  int(c.get("priority", 0)),
+	}
 
 	# [hooks] static declaration (v3.0.1 opt-in model). Escape hatch for
 	# mods that can't get auto-enrolled via the .hook("prefix-method-...",

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -85,33 +85,64 @@ var _registry_patched: Dictionary = {}
 ## Register a generic item bundle (ItemData + optional scene/icon/loot/
 ## trader_pools). Use this for content that doesn't fit the
 ## weapon/mag/attachment helpers (consumables, keys, tools, ammo).
-## See registry/aggregators.gd for the full schema.
-func register_item(id: String, data: Variant) -> Dictionary:
-	return _register_item_bundle(id, data)
+##
+## ALWAYS takes a Dictionary of {id: data}, even for a single registration:
+##   lib.register_item({"my_potion": {item: ..., scene: ..., loot_tables: [...]}})
+##
+## Returns {ok: bool, results: {id: granular_dict}} where each granular_dict
+## is the per-entry result with sub-bools for items/scene/loot_count/etc.
+## See registry/aggregators.gd for the full per-entry schema.
+func register_item(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("item", entries)
 
-## Register a furniture bundle (ItemData with type='Furniture' + placed
-## scene + trader_pools, optional crafting recipe). Furniture is
+## Register one or more furniture bundles (ItemData with type='Furniture' +
+## placed scene + trader_pools, optional crafting recipe). Furniture is
 ## intentionally not loot-pool spawnable; trader_pools defaults to
-## ['Generalist'] with a warn if missing. See registry/aggregators.gd.
-func register_furniture(id: String, data: Variant) -> Dictionary:
-	return _register_furniture_bundle(id, data)
+## ['Generalist'] with a warn if missing.
+func register_furniture(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("furniture", entries)
 
-## Register a weapon bundle (item + scene + rig, optional magazines /
-## fits_attachments / loot_tables). See registry/aggregators.gd for the
-## full schema. Returns a Dictionary; check result.ok for overall success.
-func register_weapon(id: String, data: Variant) -> Dictionary:
-	return _register_weapon(id, data)
+## Register one or more weapon bundles (item + scene + rig, optional
+## magazines / fits_attachments / loot_tables). Iterate result.results to
+## inspect per-id sub-result.
+func register_weapon(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("weapon", entries)
 
-## Register a magazine bundle (item + scene, optional fits_weapons /
-## loot_tables). Patches each fits_weapons target's compatible array.
-func register_magazine(id: String, data: Variant) -> Dictionary:
-	return _register_magazine(id, data)
+## Register one or more magazine bundles (item + scene, optional
+## fits_weapons / loot_tables). Patches each fits_weapons target's
+## compatible array.
+func register_magazine(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("magazine", entries)
 
-## Register an attachment bundle. Same shape as register_magazine; the
-## split is for mod-author readability (vanilla's `compatible` field
+## Register one or more attachment bundles. Same shape as register_magazine;
+## the split is for mod-author readability (vanilla's `compatible` field
 ## doesn't distinguish mag from attachment).
-func register_attachment(id: String, data: Variant) -> Dictionary:
-	return _register_attachment(id, data)
+func register_attachment(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("attachment", entries)
+
+
+# Internal: shared loop for all aggregator helpers. Dispatches each entry to
+# the per-aggregator worker (_register_item_bundle / _register_weapon / etc.)
+# and wraps the per-id granular results in {ok, results: {id: granular}}.
+# Failures isolate -- one bad entry doesn't stop the next.
+func _register_aggregator_batch(kind: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var sid := String(id)
+		var per: Dictionary
+		match kind:
+			"item":       per = _register_item_bundle(sid, entries[id])
+			"furniture":  per = _register_furniture_bundle(sid, entries[id])
+			"weapon":     per = _register_weapon(sid, entries[id])
+			"magazine":   per = _register_magazine(sid, entries[id])
+			"attachment": per = _register_attachment(sid, entries[id])
+			_:
+				per = {"ok": false, "error": "internal: unknown aggregator kind '%s'" % kind}
+		results[sid] = per
+		if not bool(per.get("ok", false)):
+			all_ok = false
+	return {"ok": all_ok, "results": results}
 
 # ---- Public verbs ----
 

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -474,3 +474,155 @@ func get_entry(registry: String, id: String) -> Variant:
 		_:
 			push_warning("[Registry] get_entry: unknown registry '%s'" % registry)
 			return null
+
+# ---- Bulk read API ----
+# Companion to get_entry for "what's in this registry?" queries. All four
+# methods accept include_vanilla (default true) so modders can choose
+# between "everything visible to gameplay" and "only what mods added."
+#
+# Per-registry vanilla-source dispatch lives in _enumerate_vanilla; mod
+# entries are read from _registry_registered. On id collision the mod
+# entry wins (matches get_entry precedence: override > register > vanilla).
+
+## True if the id resolves to anything in this registry. Skips the entry
+## construction get_entry would do; cheap membership check.
+func has(registry: String, id: String, include_vanilla: bool = true) -> bool:
+	var reg: Dictionary = _registry_registered.get(registry, {})
+	if reg.has(id):
+		return true
+	if not include_vanilla:
+		return false
+	var vanilla: Dictionary = _enumerate_vanilla(registry)
+	return vanilla.has(id)
+
+## Just the ids in this registry, as a typed String array. Cheaper than
+## list().keys() because we don't materialize the merged values dict when
+## the caller doesn't need it.
+func keys(registry: String, include_vanilla: bool = true) -> Array[String]:
+	var out: Array[String] = []
+	var seen: Dictionary = {}
+	if include_vanilla:
+		var vanilla: Dictionary = _enumerate_vanilla(registry)
+		for k in vanilla.keys():
+			out.append(String(k))
+			seen[k] = true
+	var reg: Dictionary = _registry_registered.get(registry, {})
+	for k in reg.keys():
+		if not seen.has(k):
+			out.append(String(k))
+	return out
+
+## Full id -> entry mapping for this registry. Mod entries override
+## vanilla on id collision (matches get_entry precedence).
+func list(registry: String, include_vanilla: bool = true) -> Dictionary:
+	var out: Dictionary = {}
+	if include_vanilla:
+		out = _enumerate_vanilla(registry).duplicate()
+	var reg: Dictionary = _registry_registered.get(registry, {})
+	for k in reg.keys():
+		out[k] = reg[k]
+	return out
+
+## Filtered iteration. Predicate signature: func(entry) -> bool. Returns
+## an Array of Dictionary {id, entry} pairs for every match. The id is
+## included in the result so callers don't need to lookup separately.
+func find(registry: String, predicate: Callable, include_vanilla: bool = true) -> Array:
+	var out: Array = []
+	var entries: Dictionary = list(registry, include_vanilla)
+	for id in entries.keys():
+		var entry = entries[id]
+		if entry == null:
+			continue
+		if bool(predicate.call(entry)):
+			out.append({"id": String(id), "entry": entry})
+	return out
+
+# Per-registry vanilla source enumerator. Returns id -> entry for every
+# vanilla content item the registry tracks. Pure-mod registries (loot,
+# trader_pools, scene_paths-mod-only, etc.) return {} -- their entries
+# are inherently mod-side only.
+func _enumerate_vanilla(registry: String) -> Dictionary:
+	match registry:
+		"items":
+			# Vanilla items live in LT_Master.items, indexed by their .file
+			# string. The items registry's _build_vanilla_item_cache does
+			# this same walk; reuse via _lookup_item for consistency.
+			var out: Dictionary = {}
+			var master = load("res://Loot/LT_Master.tres")
+			if master == null or not ("items" in master):
+				return out
+			for it in master.items:
+				if it == null:
+					continue
+				var f = it.get("file")
+				if f != null and String(f) != "":
+					out[String(f)] = it
+			return out
+		"scenes":
+			# Vanilla scenes are const declarations on Database.gd. Walk
+			# the script's constant map.
+			var out: Dictionary = {}
+			var db := _database_node()
+			if db == null or db.get_script() == null:
+				return out
+			var consts: Dictionary = db.get_script().get_script_constant_map()
+			for k in consts.keys():
+				var v = consts[k]
+				if v is PackedScene:
+					out[String(k)] = v
+			return out
+		"scene_paths":
+			# Vanilla scene-path consts on Loader.gd. Same const-map walk
+			# but values are Strings (res:// paths) rather than PackedScenes.
+			var out: Dictionary = {}
+			var ldr = get_tree().root.get_node_or_null("Loader")
+			if ldr == null or ldr.get_script() == null:
+				return out
+			var consts: Dictionary = ldr.get_script().get_script_constant_map()
+			for k in consts.keys():
+				var v = consts[k]
+				if v is String and String(v).begins_with("res://"):
+					out[String(k)] = v
+			return out
+		"shelters":
+			# Vanilla shelters are the entries in Loader.shelters that pre-
+			# date any mod additions. _rtv_vanilla_shelters captures this
+			# at @onready time. Each shelter "entry" is just its name; we
+			# return name -> name for shape consistency.
+			var out: Dictionary = {}
+			var ldr = get_tree().root.get_node_or_null("Loader")
+			if ldr == null or not ("_rtv_vanilla_shelters" in ldr):
+				return out
+			for name in ldr._rtv_vanilla_shelters:
+				out[String(name)] = String(name)
+			return out
+		"recipes":
+			# Vanilla recipes live in Recipes.tres across seven category
+			# arrays. RecipeData has no inherent id -- we synthesize one
+			# from "<category>:<recipe.name>" so two recipes with the same
+			# display name in different categories don't collide.
+			var out: Dictionary = {}
+			var recipes = load("res://Crafting/Recipes.tres")
+			if recipes == null:
+				return out
+			var cats: Array = ["consumables", "medical", "equipment", "weapons", "electronics", "misc", "furniture"]
+			for cat in cats:
+				var arr = recipes.get(cat)
+				if not (arr is Array):
+					continue
+				for r in arr:
+					if r == null:
+						continue
+					var rname = r.get("name") if r.has_method("get") else null
+					var key: String = "%s:%s" % [cat, String(rname) if rname != null else "<unnamed>"]
+					out[key] = r
+			return out
+		# Pure-mod registries: vanilla side is empty. The mod-entries dict
+		# in _registry_registered is the complete picture for these.
+		"loot", "trader_pools", "trader_tasks", "events", "sounds", \
+		"inputs", "random_scenes", "ai_types", "fish_species", "resources", \
+		"scene_nodes", "weapons", "magazines", "attachments":
+			return {}
+		_:
+			push_warning("[Registry] _enumerate_vanilla: unknown registry '%s'" % registry)
+			return {}

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -48,6 +48,7 @@ const Registry := {
 	WEAPONS = "weapons",
 	MAGAZINES = "magazines",
 	ATTACHMENTS = "attachments",
+	AI_LOADOUTS = "ai_loadouts",
 	# Future sections populate the rest:
 	# TRADER_POOLS = "trader_pools",
 	# TRADER_TASKS = "trader_tasks",
@@ -120,6 +121,23 @@ func register_magazine(entries: Dictionary) -> Dictionary:
 func register_attachment(entries: Dictionary) -> Dictionary:
 	return _register_aggregator_batch("attachment", entries)
 
+## Register one or more AI loadout entries (declares which AI categories
+## carry which weapon scenes, with per-entry probability + optional
+## replace-vanilla flag). Use this when:
+##   - You want to add an existing weapon (vanilla or modded) to AI's
+##     spawn pool without going through register_weapon.
+##   - You want different categories' rolls to use distinct ids so they
+##     can be reverted or removed independently.
+##
+## For weapons you're already registering, the simpler path is the
+## ai_loadout field on register_weapon -- it auto-uses the weapon's
+## scene and id, and a single failure mode is reported in result.ai_loadout.
+##
+## Per-entry data: {weapon_scene, ai_types[], chance?, replace?}.
+## See AI_LOADOUTS_PLAN.md or registry/ai_loadouts.gd for shape detail.
+func register_ai_loadout(entries: Dictionary) -> Dictionary:
+	return _register_aggregator_batch("ai_loadout", entries)
+
 
 # Internal: shared loop for all aggregator helpers. Dispatches each entry to
 # the per-aggregator worker (_register_item_bundle / _register_weapon / etc.)
@@ -137,6 +155,13 @@ func _register_aggregator_batch(kind: String, entries: Dictionary) -> Dictionary
 			"weapon":     per = _register_weapon(sid, entries[id])
 			"magazine":   per = _register_magazine(sid, entries[id])
 			"attachment": per = _register_attachment(sid, entries[id])
+			"ai_loadout":
+				# Thin wrapper: ai_loadouts is a primitive registry, not
+				# a multi-step bundle. Wrap the bool result in the same
+				# {ok, ...} shape as the other aggregators for batch-loop
+				# consistency.
+				var ok: bool = _register_ai_loadout(sid, entries[id])
+				per = {"ok": ok}
 			_:
 				per = {"ok": false, "error": "internal: unknown aggregator kind '%s'" % kind}
 		results[sid] = per
@@ -167,6 +192,7 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		"maps": return _register_map(id, data)
 		"random_scenes": return _register_random_scene(id, data)
 		"ai_types": return _register_ai_type(id, data)
+		"ai_loadouts": return _register_ai_loadout(id, data)
 		"fish_species": return _register_fish_species(id, data)
 		"resources":
 			push_warning("[Registry] register: 'resources' doesn't support register (the target .tres already exists in vanilla; use patch to mutate its fields)")
@@ -217,6 +243,7 @@ func override(registry: String, id: String, data: Variant) -> bool:
 			push_warning("[Registry] override: 'random_scenes' doesn't support override (append-only list; use register/remove)")
 			return false
 		"ai_types": return _override_ai_type(id, data)
+		"ai_loadouts": return _override_ai_loadout(id, data)
 		"fish_species":
 			push_warning("[Registry] override: 'fish_species' doesn't support override (append-only list; use register/remove)")
 			return false
@@ -290,6 +317,9 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 			return false
 		"ai_types":
 			push_warning("[Registry] patch: 'ai_types' doesn't support patch (entries are {scene, zone} refs; use override to swap the scene)")
+			return false
+		"ai_loadouts":
+			push_warning("[Registry] patch: 'ai_loadouts' doesn't support patch (entries are flat dicts; use override to replace)")
 			return false
 		"fish_species":
 			push_warning("[Registry] patch: 'fish_species' doesn't support patch (entries are {scene, pool_id} refs)")
@@ -415,6 +445,9 @@ func _array_op_dispatch(registry: String, id: Variant, field: String, op: String
 		"ai_types":
 			push_warning("[Registry] %s: 'ai_types' doesn't support array ops (entries are {scene, zone} refs)" % op)
 			return false
+		"ai_loadouts":
+			push_warning("[Registry] %s: 'ai_loadouts' doesn't support array ops (entries are flat dicts; use override to replace)" % op)
+			return false
 		"fish_species":
 			push_warning("[Registry] %s: 'fish_species' doesn't support array ops (entries are {scene, pool_id} refs)" % op)
 			return false
@@ -446,6 +479,7 @@ func remove(registry: String, id: String) -> bool:
 		"maps": return _remove_map(id)
 		"random_scenes": return _remove_random_scene(id)
 		"ai_types": return _remove_ai_type(id)
+		"ai_loadouts": return _remove_ai_loadout(id)
 		"fish_species": return _remove_fish_species(id)
 		"resources":
 			push_warning("[Registry] remove: 'resources' doesn't support remove (use revert to undo patches)")
@@ -527,6 +561,11 @@ func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 				push_warning("[Registry] revert('ai_types', ...): id must be a String")
 				return false
 			return _revert_ai_type(id)
+		"ai_loadouts":
+			if not (id is String):
+				push_warning("[Registry] revert('ai_loadouts', ...): id must be a String")
+				return false
+			return _revert_ai_loadout(id)
 		"fish_species":
 			if not (id is String):
 				push_warning("[Registry] revert('fish_species', ...): id must be a String")
@@ -713,6 +752,9 @@ func get_entry(registry: String, id: String) -> Variant:
 		"ai_types":
 			var reg: Dictionary = _registry_registered.get("ai_types", {})
 			return reg.get(id)
+		"ai_loadouts":
+			var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+			return reg.get(id)
 		"fish_species":
 			var reg: Dictionary = _registry_registered.get("fish_species", {})
 			return reg.get(id)
@@ -873,7 +915,7 @@ func _enumerate_vanilla(registry: String) -> Dictionary:
 		# in _registry_registered is the complete picture for these.
 		"loot", "trader_pools", "trader_tasks", "events", "sounds", \
 		"inputs", "random_scenes", "ai_types", "fish_species", "resources", \
-		"scene_nodes", "weapons", "magazines", "attachments":
+		"scene_nodes", "weapons", "magazines", "attachments", "ai_loadouts":
 			return {}
 		_:
 			push_warning("[Registry] _enumerate_vanilla: unknown registry '%s'" % registry)

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -280,6 +280,122 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 			push_warning("[Registry] patch: unknown registry '%s'" % registry)
 			return false
 
+## Append values to an Array field on a registry entry. Array-only.
+## De-duplicates by default (matches typical mod intent for compatibility lists);
+## pass allow_duplicates=true to permit repeats. `values` accepts a single value
+## or an Array. First-write-wins stash is shared with patch(), so revert()
+## restores the true pre-any-mutation array even after multiple ops.
+func append(registry: String, id: Variant, field: String, values: Variant, allow_duplicates: bool = false) -> bool:
+	return _array_op_dispatch(registry, id, field, "append", values, allow_duplicates)
+
+
+## Prepend values to an Array field. Same de-dup semantics as append; the
+## resulting prefix order matches the input order (prepend([a, b]) on [c]
+## yields [a, b, c]).
+func prepend(registry: String, id: Variant, field: String, values: Variant, allow_duplicates: bool = false) -> bool:
+	return _array_op_dispatch(registry, id, field, "prepend", values, allow_duplicates)
+
+
+## Remove values from an Array field. Removes ALL matching occurrences.
+## Silent skip if a value isn't present (idempotent).
+func remove_from(registry: String, id: Variant, field: String, values: Variant) -> bool:
+	return _array_op_dispatch(registry, id, field, "remove_from", values, false)
+
+
+# Shared dispatcher for append/prepend/remove_from. Mirrors patch()'s
+# registry-by-registry routing exactly: registries that support patch on
+# Resource fields get a per-registry helper here; registries with non-Resource
+# entries (scenes, loot, shelters, etc.) get a warn-and-return-false branch.
+func _array_op_dispatch(registry: String, id: Variant, field: String, op: String, values: Variant, allow_duplicates: bool) -> bool:
+	if id is String and id == "":
+		push_warning("[Registry] %s(%s, ...) called with empty id" % [op, registry])
+		return false
+	if field == "":
+		push_warning("[Registry] %s(%s, ...) called with empty field" % [op, registry])
+		return false
+	var arr: Array = _coerce_to_array(values)
+	if arr.is_empty():
+		push_warning("[Registry] %s('%s', ...): empty values is a no-op" % [op, registry])
+		return false
+	match registry:
+		"items":
+			if not (id is String):
+				push_warning("[Registry] %s('items', ...): id must be a String" % op)
+				return false
+			match op:
+				"append":      return _append_item(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_item(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_item(id, field, arr)
+		"sounds":
+			if not (id is String):
+				push_warning("[Registry] %s('sounds', ...): id must be a String" % op)
+				return false
+			match op:
+				"append":      return _append_sound(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_sound(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_sound(id, field, arr)
+		"recipes":
+			match op:
+				"append":      return _append_recipe(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_recipe(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_recipe(id, field, arr)
+		"events":
+			match op:
+				"append":      return _append_event(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_event(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_event(id, field, arr)
+		"trader_tasks":
+			match op:
+				"append":      return _append_trader_task(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_trader_task(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_trader_task(id, field, arr)
+		"inputs":
+			push_warning("[Registry] %s: 'inputs' has no Array-typed fields (display_label/default_event/deadzone are scalars; use patch instead)" % op)
+			return false
+		"scene_paths":
+			push_warning("[Registry] %s: 'scene_paths' has no Array-typed fields (entries are path/Resource scalars; use patch instead)" % op)
+			return false
+		"resources":
+			if not (id is String):
+				push_warning("[Registry] %s('resources', ...): id must be a res:// path String" % op)
+				return false
+			match op:
+				"append":      return _append_resource(id, field, arr, allow_duplicates)
+				"prepend":     return _prepend_resource(id, field, arr, allow_duplicates)
+				"remove_from": return _remove_from_resource(id, field, arr)
+		"scene_nodes":
+			push_warning("[Registry] %s: 'scene_nodes' patches store literal property values applied on scene-load; Array-merge isn't supported (read the property in a hook and patch the merged value instead)" % op)
+			return false
+		"scenes":
+			push_warning("[Registry] %s: 'scenes' doesn't support array ops (scenes are monolithic PackedScenes)" % op)
+			return false
+		"loot":
+			push_warning("[Registry] %s: 'loot' doesn't support array ops (loot entries are ItemData references; use the items registry instead)" % op)
+			return false
+		"trader_pools":
+			push_warning("[Registry] %s: 'trader_pools' doesn't support array ops (entries are boolean flags)" % op)
+			return false
+		"shelters":
+			push_warning("[Registry] %s: 'shelters' doesn't support array ops (entries are bare strings)" % op)
+			return false
+		"random_scenes":
+			push_warning("[Registry] %s: 'random_scenes' doesn't support array ops (entries are bare paths)" % op)
+			return false
+		"ai_types":
+			push_warning("[Registry] %s: 'ai_types' doesn't support array ops (entries are {scene, zone} refs)" % op)
+			return false
+		"fish_species":
+			push_warning("[Registry] %s: 'fish_species' doesn't support array ops (entries are {scene, pool_id} refs)" % op)
+			return false
+		"weapons", "magazines", "attachments":
+			push_warning("[Registry] %s: '%s' is a pure aggregator -- use the underlying primitive (e.g. %s('items', ...))" % [op, registry, op])
+			return false
+		_:
+			push_warning("[Registry] %s: unknown registry '%s'" % [op, registry])
+			return false
+	return false
+
+
 ## Undo a register(). Fails if the id wasn't registered by a mod (can't
 ## remove vanilla entries via this API; use override with a disabled
 ## equivalent, or rely on the game's own toggle mechanisms).
@@ -401,6 +517,111 @@ func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 		_:
 			push_warning("[Registry] revert: unknown registry '%s'" % registry)
 			return false
+
+## Batched form of register(). `entries` is `{id: data, ...}`. Fans out to
+## register() per entry; failures are isolated (one bad id doesn't stop the
+## others). Returns `{ok: bool, results: {id: bool, ...}}`. `ok` is true only
+## when every entry succeeded.
+func register_many(registry: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = register(registry, id, entries[id])
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of override(). Same shape as register_many.
+func override_many(registry: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = override(registry, id, entries[id])
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of patch(). `entries` is `{id: fields_dict, ...}`.
+func patch_many(registry: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = patch(registry, id, entries[id])
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of append(). `entries` is `{id: values, ...}` where values is
+## a single value or Array. Same field across all entries (most common case);
+## use individual append() calls if you need different fields per id.
+func append_many(registry: String, field: String, entries: Dictionary, allow_duplicates: bool = false) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = append(registry, id, field, entries[id], allow_duplicates)
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of prepend(). Same shape as append_many.
+func prepend_many(registry: String, field: String, entries: Dictionary, allow_duplicates: bool = false) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = prepend(registry, id, field, entries[id], allow_duplicates)
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of remove_from(). Same shape as append_many.
+func remove_from_many(registry: String, field: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var ok: bool = remove_from(registry, id, field, entries[id])
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of revert(). `entries` is `{id: fields_array, ...}` where
+## fields_array can be empty (full revert of that id) or a list of field names.
+func revert_many(registry: String, entries: Dictionary) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in entries.keys():
+		var fields_arg: Array = entries[id] if entries[id] is Array else []
+		var ok: bool = revert(registry, id, fields_arg)
+		results[id] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+## Batched form of remove(). `ids` is an Array of String ids. Per-id results
+## keyed by id.
+func remove_many(registry: String, ids: Array) -> Dictionary:
+	var results: Dictionary = {}
+	var all_ok := true
+	for id in ids:
+		var sid := String(id)
+		var ok: bool = remove(registry, sid)
+		results[sid] = ok
+		if not ok:
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
 
 ## Read API: resolve an id to its current value (vanilla, mod-registered, or
 ## mod-overridden, in the same priority the game itself sees). Useful for

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -45,6 +45,9 @@ const Registry := {
 	FISH_SPECIES = "fish_species",
 	RESOURCES = "resources",
 	SCENE_NODES = "scene_nodes",
+	WEAPONS = "weapons",
+	MAGAZINES = "magazines",
+	ATTACHMENTS = "attachments",
 	# Future sections populate the rest:
 	# TRADER_POOLS = "trader_pools",
 	# TRADER_TASKS = "trader_tasks",
@@ -68,6 +71,31 @@ const Registry := {
 var _registry_registered: Dictionary = {}
 var _registry_overridden: Dictionary = {}
 var _registry_patched: Dictionary = {}
+
+# ---- Aggregator helpers (weapons / magazines / attachments) ----
+# These wrap several primitive registries (ITEMS + SCENES + LOOT, plus
+# patches to vanilla weapons' `compatible`) into a single call. Return a
+# Dictionary with per-step success bools so mods can inspect partial
+# failures. The standard `register('weapons'/'magazines'/'attachments')`
+# routes through these but collapses the dict to a single bool. Call the
+# public methods below directly when you want the granular result.
+
+## Register a weapon bundle (item + scene + rig, optional magazines /
+## fits_attachments / loot_tables). See registry/weapons.gd for the full
+## schema. Returns a Dictionary; check result.ok for the overall success.
+func register_weapon(id: String, data: Variant) -> Dictionary:
+	return _register_weapon(id, data)
+
+## Register a magazine bundle (item + scene, optional fits_weapons /
+## loot_tables). Patches each fits_weapons target's compatible array.
+func register_magazine(id: String, data: Variant) -> Dictionary:
+	return _register_magazine(id, data)
+
+## Register an attachment bundle. Same shape as register_magazine; the
+## split is for mod-author readability (vanilla's `compatible` field
+## doesn't distinguish mag from attachment).
+func register_attachment(id: String, data: Variant) -> Dictionary:
+	return _register_attachment(id, data)
 
 # ---- Public verbs ----
 
@@ -99,6 +127,16 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		"scene_nodes":
 			push_warning("[Registry] register: 'scene_nodes' doesn't support register (nodes are positional inside a scene; use override('scenes', ...) to replace the whole scene or patch('scene_nodes', ...) to mutate node properties)")
 			return false
+		"weapons":
+			# Aggregator helper returns a granular Dictionary. register()
+			# collapses to the bool "did everything succeed" view; mods that
+			# want per-step success should call lib.register_weapon(id, data)
+			# directly to get the full dict.
+			return bool(_register_weapon(id, data).get("ok", false))
+		"magazines":
+			return bool(_register_magazine(id, data).get("ok", false))
+		"attachments":
+			return bool(_register_attachment(id, data).get("ok", false))
 		_:
 			push_warning("[Registry] register: unknown registry '%s'" % registry)
 			return false
@@ -140,6 +178,9 @@ func override(registry: String, id: String, data: Variant) -> bool:
 			return false
 		"scene_nodes":
 			push_warning("[Registry] override: 'scene_nodes' doesn't support override (whole-scene swap goes through override('scenes', ...); scene_nodes is patch-only)")
+			return false
+		"weapons", "magazines", "attachments":
+			push_warning("[Registry] override: '%s' is a pure aggregator -- override the underlying primitives instead (override('items', ...) for the ItemData, override('scenes', ...) for the world/rig scene)" % registry)
 			return false
 		_:
 			push_warning("[Registry] override: unknown registry '%s'" % registry)
@@ -216,6 +257,9 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 				push_warning("[Registry] patch('scene_nodes', ...): id must be a String in the form '<scene_path>#<node_path>'")
 				return false
 			return _patch_scene_node(id, fields)
+		"weapons", "magazines", "attachments":
+			push_warning("[Registry] patch: '%s' is a pure aggregator -- patch the underlying primitive instead (patch('items', ...) for ItemData fields like compatible/damage/etc)" % registry)
+			return false
 		_:
 			push_warning("[Registry] patch: unknown registry '%s'" % registry)
 			return false
@@ -245,6 +289,9 @@ func remove(registry: String, id: String) -> bool:
 			return false
 		"scene_nodes":
 			push_warning("[Registry] remove: 'scene_nodes' doesn't support remove (use revert to undo a property patch)")
+			return false
+		"weapons", "magazines", "attachments":
+			push_warning("[Registry] remove: '%s' is a pure aggregator -- remove the underlying primitives instead (remove('items', ...), remove('scenes', ...), remove('loot', ...))" % registry)
 			return false
 		_:
 			push_warning("[Registry] remove: unknown registry '%s'" % registry)
@@ -332,6 +379,9 @@ func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 				push_warning("[Registry] revert('scene_nodes', ...): id must be a String in the form '<scene_path>#<node_path>'")
 				return false
 			return _revert_scene_node(id, fields)
+		"weapons", "magazines", "attachments":
+			push_warning("[Registry] revert: '%s' is a pure aggregator -- revert the underlying primitives instead" % registry)
+			return false
 		_:
 			push_warning("[Registry] revert: unknown registry '%s'" % registry)
 			return false

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -73,16 +73,25 @@ var _registry_overridden: Dictionary = {}
 var _registry_patched: Dictionary = {}
 
 # ---- Aggregator helpers (weapons / magazines / attachments) ----
-# These wrap several primitive registries (ITEMS + SCENES + LOOT, plus
-# patches to vanilla weapons' `compatible`) into a single call. Return a
-# Dictionary with per-step success bools so mods can inspect partial
-# failures. The standard `register('weapons'/'magazines'/'attachments')`
-# routes through these but collapses the dict to a single bool. Call the
-# public methods below directly when you want the granular result.
+# These wrap several primitive registries (ITEMS + SCENES + LOOT +
+# TRADER_POOLS, plus patches to vanilla weapons' `compatible`) into a
+# single call. Return a Dictionary with per-step success bools so mods
+# can inspect partial failures. The weapon/magazine/attachment standard
+# verbs collapse the dict to a single bool; call the public methods
+# below directly when you want the granular result. register_item is
+# method-only (no Registry const) since the bare-Resource form of
+# register('items', ...) already exists.
+
+## Register a generic item bundle (ItemData + optional scene/icon/loot/
+## trader_pools). Use this for content that doesn't fit the
+## weapon/mag/attachment helpers (consumables, keys, tools, ammo).
+## See registry/aggregators.gd for the full schema.
+func register_item(id: String, data: Variant) -> Dictionary:
+	return _register_item_bundle(id, data)
 
 ## Register a weapon bundle (item + scene + rig, optional magazines /
-## fits_attachments / loot_tables). See registry/weapons.gd for the full
-## schema. Returns a Dictionary; check result.ok for the overall success.
+## fits_attachments / loot_tables). See registry/aggregators.gd for the
+## full schema. Returns a Dictionary; check result.ok for overall success.
 func register_weapon(id: String, data: Variant) -> Dictionary:
 	return _register_weapon(id, data)
 

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -89,6 +89,13 @@ var _registry_patched: Dictionary = {}
 func register_item(id: String, data: Variant) -> Dictionary:
 	return _register_item_bundle(id, data)
 
+## Register a furniture bundle (ItemData with type='Furniture' + placed
+## scene + trader_pools, optional crafting recipe). Furniture is
+## intentionally not loot-pool spawnable; trader_pools defaults to
+## ['Generalist'] with a warn if missing. See registry/aggregators.gd.
+func register_furniture(id: String, data: Variant) -> Dictionary:
+	return _register_furniture_bundle(id, data)
+
 ## Register a weapon bundle (item + scene + rig, optional magazines /
 ## fits_attachments / loot_tables). See registry/aggregators.gd for the
 ## full schema. Returns a Dictionary; check result.ok for overall success.

--- a/src/registry/aggregators.gd
+++ b/src/registry/aggregators.gd
@@ -329,6 +329,146 @@ func _register_item_bundle(id: String, data: Variant) -> Dictionary:
 	_log_debug("[Registry] register_item('%s') result: %s" % [id, result])
 	return result
 
+# -------- furniture --------
+
+# Furniture is structurally an ItemData with type="Furniture" plus a placed
+# world scene. Its lifecycle differs from generic items in three ways:
+#   - never spawns from loot pools (intentionally not in LT_*)
+#   - obtained via trader supply (or task rewards, out of scope here)
+#   - on purchase, vanilla routes it to the catalog grid (Interface.gd
+#     branches on itemData.type == "Furniture")
+#
+# So `register_furniture` is `register_item` with: scene_path required,
+# loot_tables forbidden, trader_pools required (default Generalist if
+# absent), optional inline recipe targeting Recipes.furniture.
+#
+# Schema:
+#   item_path     -- required, .tres ItemData (should have type="Furniture")
+#   scene_path    -- required, placed world .tscn
+#   icon_path     -- optional
+#   trader_pools  -- optional, default ["Generalist"] (warn). One register
+#                    call per pool name flips the matching flag on the
+#                    ItemData.
+#   recipe        -- optional dict {input: Array[ItemData], time: float,
+#                    audio?: AudioEvent}. Output is implicit (the item).
+#                    category is locked to "furniture" -- ignored if set.
+#
+# Returns: {ok, items, scene, trader_pool_count, trader_pools: [String],
+#           trader_pools_failed: [String], recipe: bool}
+func _register_furniture_bundle(id: String, data: Variant) -> Dictionary:
+	var result: Dictionary = {
+		"ok": false,
+		"items": false,
+		"scene": false,
+		"trader_pool_count": 0,
+		"trader_pools": [],
+		"trader_pools_failed": [],
+		"recipe": false,
+	}
+	if not (data is Dictionary):
+		push_warning("[Registry] register_furniture('%s', ...) expects Dictionary" % id)
+		return result
+	var d: Dictionary = data
+	for required in ["item_path", "scene_path"]:
+		if not d.has(required):
+			push_warning("[Registry] register_furniture('%s'): missing required key '%s'" % [id, required])
+			return result
+	if d.has("loot_tables"):
+		push_warning("[Registry] register_furniture('%s'): loot_tables is not supported (furniture isn't loot-pool spawnable in vanilla; use trader_pools instead). Ignored." % id)
+	# Step 1: load + register the ItemData. Validate type="Furniture";
+	# warn but don't fail if missing -- vanilla still routes by the type
+	# field at runtime, but a wrong type means the item won't go to the
+	# catalog when bought.
+	var item_data: Resource = load(d["item_path"])
+	if item_data == null:
+		push_warning("[Registry] register_furniture('%s'): failed to load item from '%s'" % [id, d["item_path"]])
+		return result
+	if "type" in item_data and String(item_data.get("type")) != "Furniture":
+		push_warning("[Registry] register_furniture('%s'): ItemData.type is '%s', expected 'Furniture'. Item won't be routed to the catalog grid on purchase. Fix the .tres or the player will get inventory items instead." % [id, item_data.get("type")])
+	if d.has("icon_path"):
+		_apply_icon(item_data, d["icon_path"], id)
+	result["items"] = _register_item(id, item_data)
+	if not result["items"]:
+		return result
+	# Step 2: world scene. Required for furniture (placed object).
+	var scene: Resource = load(d["scene_path"])
+	if scene == null:
+		push_warning("[Registry] register_furniture('%s'): failed to load scene from '%s'" % [id, d["scene_path"]])
+	else:
+		result["scene"] = _register_scene(id, scene)
+	# Step 3: trader pools. Default to ["Generalist"] with a warn so
+	# unobtainable furniture surfaces loudly at register time.
+	var pools: Array = []
+	if d.has("trader_pools") and d["trader_pools"] is Array and not (d["trader_pools"] as Array).is_empty():
+		pools = d["trader_pools"]
+	else:
+		pools = ["Generalist"]
+		push_warning("[Registry] register_furniture('%s'): no trader_pools specified -- defaulting to ['Generalist']. Furniture is only obtainable via traders, so omitting this would make the item unreachable." % id)
+	for pool_name in pools:
+		if not (pool_name is String):
+			continue
+		var pool_id: String = "%s_in_pool_%s" % [id, pool_name]
+		if _register_trader_pool(pool_id, {"item": item_data, "trader": String(pool_name)}):
+			result["trader_pools"].append(String(pool_name))
+			result["trader_pool_count"] = int(result["trader_pool_count"]) + 1
+		else:
+			result["trader_pools_failed"].append(String(pool_name))
+	# Step 4: optional crafting recipe. Build a fresh RecipeData with
+	# output = [our item], register under recipes/furniture category. Mods
+	# that just want trader-only furniture skip this.
+	if d.has("recipe") and d["recipe"] is Dictionary:
+		var rd: Dictionary = d["recipe"]
+		if not (rd.has("input") and rd["input"] is Array) or (rd["input"] as Array).is_empty():
+			push_warning("[Registry] register_furniture('%s'): recipe.input must be a non-empty array of ItemData" % id)
+		else:
+			var recipe := _build_furniture_recipe(id, item_data, rd)
+			if recipe != null:
+				var recipe_id: String = "%s_recipe" % id
+				result["recipe"] = _register_recipe(recipe_id, {"recipe": recipe, "category": "furniture"})
+	result["ok"] = result["items"] and result["scene"] and result["trader_pools_failed"].is_empty()
+	_log_debug("[Registry] register_furniture('%s') result: %s" % [id, result])
+	return result
+
+# Construct a fresh RecipeData from the modder's recipe dict. Output is
+# implicit (the item we're registering). Returns null if construction
+# fails (unlikely; RecipeData.new is reliable, but the typed-array
+# coercion can fail if input contains non-ItemData).
+func _build_furniture_recipe(id: String, output_item: Resource, rd: Dictionary) -> Resource:
+	var script: GDScript = load("res://Scripts/RecipeData.gd") as GDScript
+	if script == null:
+		push_warning("[Registry] register_furniture('%s'): failed to load RecipeData.gd; recipe skipped" % id)
+		return null
+	var recipe: Resource = script.new()
+	recipe.set("name", String(rd.get("name", id)))
+	recipe.set("time", float(rd.get("time", 1.0)))
+	if rd.has("audio"):
+		recipe.set("audio", rd["audio"])
+	# Build typed Array[ItemData] for input. RecipeData.input is typed,
+	# and assigning an untyped Array silently fails the typed-array check
+	# in _register_recipe.
+	var typed_input: Array[ItemData] = []
+	for it in rd["input"]:
+		if it is ItemData:
+			typed_input.append(it)
+		else:
+			push_warning("[Registry] register_furniture('%s'): recipe.input contains non-ItemData entry; skipped" % id)
+	if typed_input.is_empty():
+		return null
+	recipe.set("input", typed_input)
+	# Output is the item we're registering, single-element typed array.
+	var typed_output: Array[ItemData] = []
+	if output_item is ItemData:
+		typed_output.append(output_item)
+	else:
+		push_warning("[Registry] register_furniture('%s'): output ItemData isn't typed as ItemData; recipe skipped" % id)
+		return null
+	recipe.set("output", typed_output)
+	# Optional proximity flags.
+	for flag in ["heat", "workbench", "testbench", "shelter"]:
+		if rd.has(flag):
+			recipe.set(flag, bool(rd[flag]))
+	return recipe
+
 # -------- shared helpers --------
 
 # Load an icon image, convert to ImageTexture, assign to item_data.icon if

--- a/src/registry/aggregators.gd
+++ b/src/registry/aggregators.gd
@@ -1,30 +1,35 @@
-## ----- registry/weapons.gd -----
+## ----- registry/aggregators.gd -----
 ##
-## Three pure-aggregator helpers that fan out to existing primitive
-## registries (ITEMS, SCENES, LOOT) and patch the vanilla `compatible`
-## ItemData arrays where appropriate. No new state -- mods can drop down
-## to primitives any time. The helpers exist to compress the 6-10 calls
-## a typical weapon/attachment/magazine mod ends up making into one.
+## Pure-aggregator helpers that fan out to primitive registries (ITEMS,
+## SCENES, LOOT, TRADER_POOLS) and patch related vanilla state. No new
+## state -- mods can drop down to primitives any time. The helpers exist
+## to compress the typical 5-10 calls a content mod ends up making into
+## a single declarative dict.
 ##
-## Three helpers, three Registry consts:
-##   - register_weapon(id, dict)     -> Registry.WEAPONS
-##   - register_magazine(id, dict)   -> Registry.MAGAZINES
-##   - register_attachment(id, dict) -> Registry.ATTACHMENTS
+## Helpers:
+##   - register_item(id, dict)       -- generic item with optional scene/icon/loot/trader_pools
+##   - register_weapon(id, dict)     -- weapon + rig + inline magazines + fits_attachments
+##   - register_magazine(id, dict)   -- standalone mag with fits_weapons
+##   - register_attachment(id, dict) -- standalone attachment with fits_weapons
 ##
-## Magazine and attachment are nearly identical at the implementation
-## level (both register an item + scene + optional loot, then patch
-## `compatible` on target weapons). The vanilla `compatible` field
-## doesn't distinguish mag from attachment -- the split in the API is
-## for mod-author readability, not engine semantics.
+## Three of these (weapon/magazine/attachment) also have Registry consts
+## (WEAPONS / MAGAZINES / ATTACHMENTS) for symmetry with primitive
+## registries. register_item is method-only -- the bare-Resource form of
+## register('items', ...) already exists, so the bundle helper has a
+## different name to avoid arg-shape polymorphism.
 ##
-## Cross-relationship resolution: `magazines`, `fits_attachments`, and
+## Magazine and attachment share an implementation (_register_compat_item)
+## because the vanilla `compatible` field on weapon ItemData accepts both
+## interchangeably. The API split is for mod-author readability.
+##
+## Cross-relationship resolution: `magazines`, `fits_attachments`,
 ## `fits_weapons` accept id strings. Lookup goes through _lookup_item,
 ## which sees both mod-registered and vanilla items. Inline magazine
 ## bundles (Dictionary instead of String) get registered first, then
 ## their ItemData ref is appended to the parent weapon's compatible.
 ##
-## All three helpers return a Dictionary with granular per-step success
-## bools so mod authors can debug partial failures without parsing logs.
+## All helpers return a Dictionary with granular per-step success bools
+## so mod authors can debug partial failures without parsing logs.
 
 # -------- weapons --------
 
@@ -242,6 +247,86 @@ func _register_compat_item(id: String, data: Variant, label: String) -> Dictiona
 				result["loot_count"] = int(result["loot_count"]) + 1
 	result["ok"] = result["items"] and result["scene"] and result["fits_weapons_failed"].is_empty()
 	_log_debug("[Registry] register_%s('%s') result: %s" % [label.trim_suffix("s"), id, result])
+	return result
+
+# -------- generic items --------
+
+# Single-item bundle for content that doesn't fit the weapon/mag/attachment
+# split (consumables, keys, tools, ammo, etc). Schema:
+#   item_path     -- required, res:// to the .tres ItemData
+#   scene_path    -- optional, res:// to the world .tscn (skip for items
+#                    that only ever exist as inventory entries / refs)
+#   icon_path     -- optional, image path; loaded + assigned to item.icon
+#   loot_tables   -- optional, list of table names to add the item to
+#                    (one register('loot', ...) per name)
+#   trader_pools  -- optional, list of trader names ("Generalist",
+#                    "Doctor", "Gunsmith", "Grandma") to flip the
+#                    matching ItemData boolean flag for trader supply
+#
+# Returns:
+#   {ok, items, scene, loot_count, trader_pool_count,
+#    trader_pools: [String], trader_pools_failed: [String]}
+# `scene` is true when no scene_path was provided (vacuously satisfied).
+# `result.ok` requires items+scene success and no trader_pool failures.
+func _register_item_bundle(id: String, data: Variant) -> Dictionary:
+	var result: Dictionary = {
+		"ok": false,
+		"items": false,
+		"scene": true,  # default true so missing scene_path doesn't fail ok
+		"loot_count": 0,
+		"trader_pool_count": 0,
+		"trader_pools": [],
+		"trader_pools_failed": [],
+	}
+	if not (data is Dictionary):
+		push_warning("[Registry] register_item('%s', ...) expects Dictionary" % id)
+		return result
+	var d: Dictionary = data
+	if not d.has("item_path"):
+		push_warning("[Registry] register_item('%s'): missing required key 'item_path'" % id)
+		return result
+	# Step 1: load + register the ItemData.
+	var item_data: Resource = load(d["item_path"])
+	if item_data == null:
+		push_warning("[Registry] register_item('%s'): failed to load item from '%s'" % [id, d["item_path"]])
+		return result
+	if d.has("icon_path"):
+		_apply_icon(item_data, d["icon_path"], id)
+	result["items"] = _register_item(id, item_data)
+	if not result["items"]:
+		return result
+	# Step 2: world scene (optional). Only override the default-true `scene`
+	# when a path was provided -- no path means "intentionally skipped."
+	if d.has("scene_path"):
+		var scene: Resource = load(d["scene_path"])
+		if scene != null:
+			result["scene"] = _register_scene(id, scene)
+		else:
+			result["scene"] = false
+			push_warning("[Registry] register_item('%s'): failed to load scene from '%s'" % [id, d["scene_path"]])
+	# Step 3: loot tables (optional).
+	if d.has("loot_tables") and d["loot_tables"] is Array:
+		for table_name in d["loot_tables"]:
+			if not (table_name is String):
+				continue
+			var loot_id: String = "%s_in_%s" % [id, table_name]
+			if _register_loot(loot_id, {"item": item_data, "table": String(table_name)}):
+				result["loot_count"] = int(result["loot_count"]) + 1
+	# Step 4: trader pools (optional). Each name fans to one
+	# register('trader_pools', ...) call. Failures (unknown trader name,
+	# missing flag field on ItemData) get tracked per-pool.
+	if d.has("trader_pools") and d["trader_pools"] is Array:
+		for pool_name in d["trader_pools"]:
+			if not (pool_name is String):
+				continue
+			var pool_id: String = "%s_in_pool_%s" % [id, pool_name]
+			if _register_trader_pool(pool_id, {"item": item_data, "trader": String(pool_name)}):
+				result["trader_pools"].append(String(pool_name))
+				result["trader_pool_count"] = int(result["trader_pool_count"]) + 1
+			else:
+				result["trader_pools_failed"].append(String(pool_name))
+	result["ok"] = result["items"] and result["scene"] and result["trader_pools_failed"].is_empty()
+	_log_debug("[Registry] register_item('%s') result: %s" % [id, result])
 	return result
 
 # -------- shared helpers --------

--- a/src/registry/aggregators.gd
+++ b/src/registry/aggregators.gd
@@ -54,6 +54,11 @@ func _register_weapon(id: String, data: Variant) -> Dictionary:
 		"fits_attachments": [],
 		"fits_attachments_failed": [],
 		"loot_count": 0,
+		# `ai_loadout` is left as null when the data dict didn't request
+		# AI loadout registration; set to true/false depending on the
+		# registration outcome when it did. Caller can distinguish "not
+		# requested" from "requested but failed" without parsing logs.
+		"ai_loadout": null,
 	}
 	if not (data is Dictionary):
 		push_warning("[Registry] register('weapons', '%s', ...) expects Dictionary" % id)
@@ -128,8 +133,27 @@ func _register_weapon(id: String, data: Variant) -> Dictionary:
 			var loot_id: String = "%s_in_%s" % [id, table_name]
 			if _register_loot(loot_id, {"item": weapon_item, "table": String(table_name)}):
 				result["loot_count"] = int(result["loot_count"]) + 1
+	# Step 8: AI loadout. Optional. Auto-uses the weapon's scene_path and id;
+	# the caller's ai_loadout dict adds ai_types / chance / replace.
+	# Failure is reported in result.ai_loadout but does not fail the whole
+	# weapon register -- the weapon still spawns as loot, it just won't be
+	# carried by AI.
+	if d.has("ai_loadout"):
+		var al: Variant = d["ai_loadout"]
+		if not (al is Dictionary):
+			push_warning("[Registry] register('weapons', '%s'): ai_loadout must be a Dictionary, got %s" % [id, typeof(al)])
+			result["ai_loadout"] = false
+		else:
+			# Compose the ai_loadouts entry: pin weapon_scene to this weapon's
+			# already-loaded scene resource so we don't re-load or risk a
+			# scene-id resolution miss.
+			var loadout_data: Dictionary = (al as Dictionary).duplicate()
+			loadout_data["weapon_scene"] = world_scene
+			result["ai_loadout"] = _register_ai_loadout(id, loadout_data)
 	# Final ok: items+scene+rig succeeded, no fits failures (magazines
-	# tracked separately -- caller can drill in).
+	# tracked separately -- caller can drill in). ai_loadout doesn't gate
+	# ok since "weapon registered, loadout failed" is a partial-success
+	# the mod author can choose to act on.
 	result["ok"] = result["items"] and result["scene"] and result["rig"] \
 			and result["fits_attachments_failed"].is_empty()
 	_log_debug("[Registry] register_weapon('%s') result: %s" % [id, result])

--- a/src/registry/ai_loadouts.gd
+++ b/src/registry/ai_loadouts.gd
@@ -1,0 +1,197 @@
+## ----- registry/ai_loadouts.gd -----
+##
+## Per-AI-category weapon injection. Mods register entries declaring
+## "this weapon scene should appear in AI of these categories N% of the
+## time." Vanilla AI scenes (Bandit, Guard, Military, Punisher) bake
+## their weapon list as preloaded children of a `weapons: Node3D` and
+## `AI.SelectWeapon()` picks one at random. We rewrite SelectWeapon
+## with a one-line prelude that consults this registry's flat list and
+## injects weapon scene instances into `weapons` before vanilla picks.
+##
+## Architecture mirrors registry/ai.gd:
+##   - Per-id dict lives in _registry_registered["ai_loadouts"]
+##   - _rebuild_ai_loadouts_engine_meta() flattens active entries into
+##     Engine.set_meta("_rtv_ai_loadouts", [...]) which the rewriter
+##     prelude reads at runtime
+##   - Override stashes the prior entry in _registry_overridden so revert
+##     can restore it
+##
+## Data shape (input):
+##   {
+##     weapon_scene: PackedScene | String,  # scene ref or id resolvable via Database
+##     ai_types:     Array[String],         # subset of [Bandit, Guard, Military, Punisher]
+##     chance:       float,                 # optional, default 1.0; clamped [0.0, 1.0]
+##     replace:      bool,                  # optional, default false
+##   }
+##
+## Data shape (stored, post-canonicalization):
+##   {
+##     weapon_scene: PackedScene,           # always a ref
+##     ai_types:     Array[String],         # always canonical CamelCase
+##     chance:       float,                 # always clamped
+##     replace:      bool,
+##   }
+
+const _AI_LOADOUTS_ENGINE_META_KEY := "_rtv_ai_loadouts"
+const _VALID_AI_CATEGORIES := ["Bandit", "Guard", "Military", "Punisher"]
+
+func _rebuild_ai_loadouts_engine_meta() -> void:
+	# Flat list, not a dict -- the runtime prelude iterates and rolls
+	# per-entry independently, so per-entry order doesn't carry meaning.
+	# Multiple mods stacking is the expected case; entries are additive.
+	var flat: Array = []
+	var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+	for id in reg.keys():
+		flat.append(reg[id])
+	Engine.set_meta(_AI_LOADOUTS_ENGINE_META_KEY, flat)
+
+# Returns the canonical category String if `raw` matches one of the four
+# valid categories case-insensitively, else "". Used for input
+# normalization so mod authors can write "bandit", "BANDIT", or "Bandit".
+func _canonicalize_ai_category(raw: Variant) -> String:
+	if not (raw is String):
+		return ""
+	var s: String = (raw as String).strip_edges()
+	if s == "":
+		return ""
+	for canon in _VALID_AI_CATEGORIES:
+		if s.to_lower() == canon.to_lower():
+			return canon
+	return ""
+
+# Resolve a String id to a PackedScene via the Database autoload (the same
+# lookup vanilla code uses). Returns null on miss; caller decides how to
+# handle the error.
+func _resolve_scene_ref(ref: Variant) -> PackedScene:
+	if ref is PackedScene:
+		return ref
+	if ref is String:
+		var db = get_tree().root.get_node_or_null("Database")
+		if db == null:
+			return null
+		var resolved = db.get(ref as String)
+		if resolved is PackedScene:
+			return resolved
+	return null
+
+# Validate + canonicalize input. Returns the stored-shape Dictionary on
+# success, null on validation failure (with a push_warning already
+# emitted). Verb arg is just for warn message context.
+func _validate_ai_loadout_data(id: String, verb: String, data: Variant):
+	if not (data is Dictionary):
+		push_warning("[Registry] %s('ai_loadouts', '%s', ...) expects Dictionary, got %s" % [verb, id, typeof(data)])
+		return null
+	var d: Dictionary = data
+	for required in ["weapon_scene", "ai_types"]:
+		if not d.has(required):
+			push_warning("[Registry] %s('ai_loadouts', '%s'): missing required key '%s'" % [verb, id, required])
+			return null
+	var scene := _resolve_scene_ref(d["weapon_scene"])
+	if scene == null:
+		push_warning("[Registry] %s('ai_loadouts', '%s'): weapon_scene didn't resolve to a PackedScene (got %s)" % [verb, id, d["weapon_scene"]])
+		return null
+	# ai_types: canonicalize each string; reject the whole call on any
+	# unrecognized entry so authors see typos at register time, not at
+	# runtime when nothing spawns.
+	var raw_types: Variant = d["ai_types"]
+	if not (raw_types is Array):
+		push_warning("[Registry] %s('ai_loadouts', '%s'): ai_types must be an Array of Strings" % [verb, id])
+		return null
+	if (raw_types as Array).is_empty():
+		push_warning("[Registry] %s('ai_loadouts', '%s'): ai_types is empty (must contain at least one of: %s)" % [verb, id, _VALID_AI_CATEGORIES])
+		return null
+	var canonical_types: Array[String] = []
+	for raw in (raw_types as Array):
+		var canon := _canonicalize_ai_category(raw)
+		if canon == "":
+			# Help the author by showing both the raw input and what
+			# capitalize-style canonicalization would have produced, so
+			# they can tell whether it was a typo vs an unknown category.
+			var hint: String = ""
+			if raw is String:
+				hint = " (canonicalized to '%s')" % (raw as String).capitalize()
+			push_warning("[Registry] %s('ai_loadouts', '%s'): unknown ai_type '%s'%s; valid: %s" % [verb, id, raw, hint, _VALID_AI_CATEGORIES])
+			return null
+		if not (canon in canonical_types):
+			canonical_types.append(canon)
+	# chance: optional, clamp to [0.0, 1.0]. Out-of-range warns but
+	# doesn't reject -- a 0.0 entry is a no-op (legitimate "wired but
+	# disabled" pattern) and a >1.0 entry just always fires.
+	var chance: float = 1.0
+	if d.has("chance"):
+		chance = clampf(float(d["chance"]), 0.0, 1.0)
+		if float(d["chance"]) < 0.0 or float(d["chance"]) > 1.0:
+			push_warning("[Registry] %s('ai_loadouts', '%s'): chance %s clamped to %s" % [verb, id, d["chance"], chance])
+	# replace: optional, default false. Document as a sharp edge in the
+	# plan but don't reject -- some mods want to override a vanilla AI's
+	# loadout entirely.
+	var replace: bool = bool(d.get("replace", false))
+	return {
+		"weapon_scene": scene,
+		"ai_types": canonical_types,
+		"chance": chance,
+		"replace": replace,
+	}
+
+func _register_ai_loadout(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+	if reg.has(id):
+		push_warning("[Registry] register('ai_loadouts', '%s'): already registered (pick a unique id or use override)" % id)
+		return false
+	var entry = _validate_ai_loadout_data(id, "register", data)
+	if entry == null:
+		return false
+	reg[id] = entry
+	_registry_registered["ai_loadouts"] = reg
+	_rebuild_ai_loadouts_engine_meta()
+	_log_debug("[Registry] registered ai_loadout '%s' (ai_types=%s, chance=%.2f, replace=%s)" % [id, entry.ai_types, entry.chance, entry.replace])
+	return true
+
+func _override_ai_loadout(id: String, data: Variant) -> bool:
+	var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+	if not reg.has(id):
+		push_warning("[Registry] override('ai_loadouts', '%s'): no existing entry to override" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("ai_loadouts", {})
+	if ov.has(id):
+		push_warning("[Registry] override('ai_loadouts', '%s'): already overridden (revert first)" % id)
+		return false
+	var entry = _validate_ai_loadout_data(id, "override", data)
+	if entry == null:
+		return false
+	ov[id] = reg[id]
+	_registry_overridden["ai_loadouts"] = ov
+	reg[id] = entry
+	_registry_registered["ai_loadouts"] = reg
+	_rebuild_ai_loadouts_engine_meta()
+	_log_debug("[Registry] overrode ai_loadout '%s'" % id)
+	return true
+
+func _remove_ai_loadout(id: String) -> bool:
+	var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+	if not reg.has(id):
+		push_warning("[Registry] remove('ai_loadouts', '%s'): not registered by a mod" % id)
+		return false
+	var ov: Dictionary = _registry_overridden.get("ai_loadouts", {})
+	if ov.has(id):
+		push_warning("[Registry] remove('ai_loadouts', '%s'): entry is overridden, use revert instead" % id)
+		return false
+	reg.erase(id)
+	_registry_registered["ai_loadouts"] = reg
+	_rebuild_ai_loadouts_engine_meta()
+	_log_debug("[Registry] removed ai_loadout '%s'" % id)
+	return true
+
+func _revert_ai_loadout(id: String) -> bool:
+	var ov: Dictionary = _registry_overridden.get("ai_loadouts", {})
+	if not ov.has(id):
+		push_warning("[Registry] revert('ai_loadouts', '%s'): no override to revert" % id)
+		return false
+	var reg: Dictionary = _registry_registered.get("ai_loadouts", {})
+	reg[id] = ov[id]
+	_registry_registered["ai_loadouts"] = reg
+	ov.erase(id)
+	_registry_overridden["ai_loadouts"] = ov
+	_rebuild_ai_loadouts_engine_meta()
+	_log_debug("[Registry] reverted ai_loadout '%s'" % id)
+	return true

--- a/src/registry/events.gd
+++ b/src/registry/events.gd
@@ -148,6 +148,31 @@ func _resolve_event_patch_target(id: Variant) -> Array:
 	push_warning("[Registry] patch('events', ...): id must be a String handle or an EventData Resource")
 	return [null, null]
 
+func _append_event(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_event_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("events", key, target, field, "append", values, allow_duplicates)
+
+func _prepend_event(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_event_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("events", key, target, field, "prepend", values, allow_duplicates)
+
+func _remove_from_event(id: Variant, field: String, values: Array) -> bool:
+	var resolved := _resolve_event_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("events", key, target, field, "remove_from", values, false)
+
+
 func _patch_event(id: Variant, fields: Dictionary) -> bool:
 	if fields.is_empty():
 		push_warning("[Registry] patch('events', ...): empty fields dict is a no-op")

--- a/src/registry/items.gd
+++ b/src/registry/items.gd
@@ -93,6 +93,28 @@ func _patch_item(id: String, fields: Dictionary) -> bool:
 	_log_debug("[Registry] patched item '%s' fields %s" % [id, fields.keys()])
 	return true
 
+func _append_item(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var target := _lookup_item(id)
+	if target == null:
+		push_warning("[Registry] append('items', '%s'): no item with that id" % id)
+		return false
+	return _array_op_on_resource("items", id, target, field, "append", values, allow_duplicates)
+
+func _prepend_item(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var target := _lookup_item(id)
+	if target == null:
+		push_warning("[Registry] prepend('items', '%s'): no item with that id" % id)
+		return false
+	return _array_op_on_resource("items", id, target, field, "prepend", values, allow_duplicates)
+
+func _remove_from_item(id: String, field: String, values: Array) -> bool:
+	var target := _lookup_item(id)
+	if target == null:
+		push_warning("[Registry] remove_from('items', '%s'): no item with that id" % id)
+		return false
+	return _array_op_on_resource("items", id, target, field, "remove_from", values, false)
+
+
 func _remove_item(id: String) -> bool:
 	var reg: Dictionary = _registry_registered.get("items", {})
 	if not reg.has(id):

--- a/src/registry/recipes.gd
+++ b/src/registry/recipes.gd
@@ -188,6 +188,31 @@ func _resolve_patch_target(id: Variant) -> Array:
 	push_warning("[Registry] patch('recipes', ...): id must be a String handle or a RecipeData Resource")
 	return [null, null]
 
+func _append_recipe(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("recipes", key, target, field, "append", values, allow_duplicates)
+
+func _prepend_recipe(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("recipes", key, target, field, "prepend", values, allow_duplicates)
+
+func _remove_from_recipe(id: Variant, field: String, values: Array) -> bool:
+	var resolved := _resolve_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("recipes", key, target, field, "remove_from", values, false)
+
+
 func _patch_recipe(id: Variant, fields: Dictionary) -> bool:
 	if fields.is_empty():
 		push_warning("[Registry] patch('recipes', ...): empty fields dict is a no-op")

--- a/src/registry/resources.gd
+++ b/src/registry/resources.gd
@@ -32,6 +32,25 @@ func _load_resource_at(path: String, verb: String) -> Resource:
 		return null
 	return res
 
+func _append_resource(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var res := _load_resource_at(id, "append")
+	if res == null:
+		return false
+	return _array_op_on_resource("resources", id, res, field, "append", values, allow_duplicates)
+
+func _prepend_resource(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var res := _load_resource_at(id, "prepend")
+	if res == null:
+		return false
+	return _array_op_on_resource("resources", id, res, field, "prepend", values, allow_duplicates)
+
+func _remove_from_resource(id: String, field: String, values: Array) -> bool:
+	var res := _load_resource_at(id, "remove_from")
+	if res == null:
+		return false
+	return _array_op_on_resource("resources", id, res, field, "remove_from", values, false)
+
+
 func _patch_resource(id: String, fields: Dictionary) -> bool:
 	if fields.is_empty():
 		push_warning("[Registry] patch('resources', '%s'): empty fields is a no-op" % id)

--- a/src/registry/scene_nodes.gd
+++ b/src/registry/scene_nodes.gd
@@ -12,6 +12,11 @@
 ## are split on the FIRST '#' (scene paths don't legally contain #, node
 ## names in Godot can't either).
 ##
+## To target the scene's ROOT node directly (e.g. for properties on a script
+## attached to the root), use "<scene_path>#" or "<scene_path>#.". Without
+## a special root path get_node_or_null can only walk DOWN from the root,
+## so root-attached properties would otherwise be unreachable.
+##
 ## How it works: we subscribe to get_tree().node_added at frameworks_ready
 ## time. Godot sets `node.scene_file_path` on the ROOT of an instantiated
 ## scene (and only there); we use that as a cheap filter. When a match
@@ -81,7 +86,7 @@ func _apply_patches_for_scene_root(scene_path: String, scene_root: Node) -> void
 	var per_node: Dictionary = _scene_node_patches[scene_path]
 	var stash_per_scene: Dictionary = _scene_node_stash.get(scene_path, {})
 	for node_path in per_node.keys():
-		var target: Node = scene_root.get_node_or_null(NodePath(node_path))
+		var target: Node = _resolve_scene_target(scene_root, node_path)
 		if target == null:
 			_log_warning("[Registry] scene_nodes: node '%s' not found in instantiated '%s'; patch skipped for this instance" \
 					% [node_path, scene_path])
@@ -102,15 +107,32 @@ func _apply_patches_for_scene_root(scene_path: String, scene_root: Node) -> void
 
 # Split 'scene#node' id on the first '#'. Returns [scene_path, node_path] or
 # [null, null] on malformed input.
+#
+# Accepts three forms for the node_path side:
+#   "...tscn#Foo/Bar"  -> node_path = "Foo/Bar"   (descendant)
+#   "...tscn#."        -> node_path = "."         (root, explicit)
+#   "...tscn#"         -> node_path = ""          (root, empty form)
+# The empty and "." forms both target the scene's root node. Without this,
+# patching a property that lives on the scene's root requires constructing
+# an artificial child path (which may not exist), since get_node_or_null
+# walks DOWN from the root and can't return the root itself by name.
 func _split_scene_node_id(id: String) -> Array:
 	var hash_idx: int = id.find("#")
-	if hash_idx <= 0 or hash_idx == id.length() - 1:
+	if hash_idx <= 0:
 		return [null, null]
 	var scene_path: String = id.substr(0, hash_idx)
 	var node_path: String = id.substr(hash_idx + 1)
 	if not scene_path.begins_with("res://"):
 		return [null, null]
 	return [scene_path, node_path]
+
+# Resolve a node_path against a scene root. Empty or "." means the root
+# itself; anything else falls through to get_node_or_null. Returns null
+# only when a non-root path doesn't resolve.
+func _resolve_scene_target(scene_root: Node, node_path: String) -> Node:
+	if node_path == "" or node_path == ".":
+		return scene_root
+	return scene_root.get_node_or_null(NodePath(node_path))
 
 # Check property existence at patch-time against a freshly-instantiated
 # probe. We don't require the scene to be in the tree at patch() time
@@ -135,7 +157,7 @@ func _validate_scene_node_patch(scene_path: String, node_path: String, fields: D
 	if probe == null:
 		push_warning("[Registry] patch('scene_nodes'): scene '%s' failed to instantiate for validation" % scene_path)
 		return false
-	var target: Node = probe.get_node_or_null(NodePath(node_path))
+	var target: Node = _resolve_scene_target(probe, node_path)
 	if target == null:
 		push_warning("[Registry] patch('scene_nodes', '%s#%s'): node path doesn't resolve in the scene; check node hierarchy" \
 				% [scene_path, node_path])
@@ -259,7 +281,7 @@ func _revert_scene_node(id: String, fields: Array) -> bool:
 			continue
 		if stash_per_node.has(fname):
 			for root in live_roots:
-				var target: Node = root.get_node_or_null(NodePath(node_path))
+				var target: Node = _resolve_scene_target(root, node_path)
 				if target != null and _node_has_property(target, fname):
 					target.set(fname, stash_per_node[fname])
 			stash_per_node.erase(fname)

--- a/src/registry/shared.gd
+++ b/src/registry/shared.gd
@@ -50,3 +50,78 @@ func _typed_array_accepts(arr: Array, item: Variant) -> bool:
 			return true
 		s = s.get_base_script()
 	return false
+
+
+# Shared core for append/prepend/remove_from. Per-registry helpers resolve the
+# target Resource (via their existing _lookup_* / _load_* code) and delegate
+# here. `stash_key` is the key under _registry_patched[reg] -- usually the id,
+# but registries that accept Variant ids (recipes/events/trader_tasks) may
+# resolve the id to a different stable key (see _resolve_patch_target). Stash
+# is the same dict patch() uses, so patch + append on the same field keeps the
+# true original on first-write-wins and revert restores it cleanly.
+#
+# `op` is "append", "prepend", or "remove_from".
+# `allow_duplicates` only affects append/prepend; ignored on remove_from.
+# Returns false on any validation failure (and does not mutate target).
+func _array_op_on_resource(reg: String, stash_key: Variant, target: Resource, field: String, op: String, values: Array, allow_duplicates: bool = false) -> bool:
+	if not _resource_has_property(target, field):
+		push_warning("[Registry] %s('%s', %s): field '%s' doesn't exist on %s" \
+				% [op, reg, str(stash_key), field, target.get_class()])
+		return false
+	var current = target.get(field)
+	if not (current is Array):
+		push_warning("[Registry] %s('%s', %s): field '%s' is not an Array (got %s)" \
+				% [op, reg, str(stash_key), field, type_string(typeof(current))])
+		return false
+	var working: Array = (current as Array).duplicate()
+	# Validate every input value passes the typed-array constraint up front,
+	# so partial application can't leave the field with mixed-validity entries.
+	if op != "remove_from":
+		for v in values:
+			if not _typed_array_accepts(working, v):
+				push_warning("[Registry] %s('%s', %s): value %s rejected by typed-array constraint on field '%s'" \
+						% [op, reg, str(stash_key), str(v), field])
+				return false
+	# First-write-wins stash. Stash holds the original Array (duplicated so the
+	# stash itself can't be mutated by future ops on `working`). Shared with
+	# patch's stash dict so a patch-then-append sequence preserves the true
+	# pre-any-mutation value for revert.
+	var patched: Dictionary = _registry_patched.get(reg, {})
+	var stash: Dictionary = patched.get(stash_key, {})
+	if not stash.has(field):
+		stash[field] = (current as Array).duplicate()
+	# Apply the op to `working`.
+	match op:
+		"append":
+			for v in values:
+				if allow_duplicates or not working.has(v):
+					working.append(v)
+		"prepend":
+			# Insert in reverse so the resulting prefix order matches the
+			# input order: prepend([a, b]) on [c] -> [a, b, c], not [b, a, c].
+			for i in range(values.size() - 1, -1, -1):
+				var v = values[i]
+				if allow_duplicates or not working.has(v):
+					working.insert(0, v)
+		"remove_from":
+			for v in values:
+				# Remove ALL matching occurrences, not just the first. Mods
+				# saying "remove this" almost always mean every instance.
+				while working.has(v):
+					working.erase(v)
+		_:
+			push_warning("[Registry] _array_op_on_resource: unknown op '%s'" % op)
+			return false
+	target.set(field, working)
+	patched[stash_key] = stash
+	_registry_patched[reg] = patched
+	_log_debug("[Registry] %s('%s', %s) field '%s' values=%s" % [op, reg, str(stash_key), field, str(values)])
+	return true
+
+
+# Coerce a single value or Array into an Array. Lets the public verbs accept
+# either lib.append(reg, id, field, magA) or lib.append(reg, id, field, [magA, magB]).
+func _coerce_to_array(values: Variant) -> Array:
+	if values is Array:
+		return values
+	return [values]

--- a/src/registry/sounds.gd
+++ b/src/registry/sounds.gd
@@ -169,6 +169,28 @@ func _override_sound(id: String, data: Variant) -> bool:
 	_log_debug("[Registry] overrode sound '%s'" % id)
 	return true
 
+func _append_sound(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var target := _lookup_sound(id)
+	if target == null:
+		push_warning("[Registry] append('sounds', '%s'): no sound with that id" % id)
+		return false
+	return _array_op_on_resource("sounds", id, target, field, "append", values, allow_duplicates)
+
+func _prepend_sound(id: String, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var target := _lookup_sound(id)
+	if target == null:
+		push_warning("[Registry] prepend('sounds', '%s'): no sound with that id" % id)
+		return false
+	return _array_op_on_resource("sounds", id, target, field, "prepend", values, allow_duplicates)
+
+func _remove_from_sound(id: String, field: String, values: Array) -> bool:
+	var target := _lookup_sound(id)
+	if target == null:
+		push_warning("[Registry] remove_from('sounds', '%s'): no sound with that id" % id)
+		return false
+	return _array_op_on_resource("sounds", id, target, field, "remove_from", values, false)
+
+
 func _patch_sound(id: String, fields: Dictionary) -> bool:
 	if fields.is_empty():
 		push_warning("[Registry] patch('sounds', '%s', ...): empty fields dict is a no-op" % id)

--- a/src/registry/traders.gd
+++ b/src/registry/traders.gd
@@ -245,6 +245,31 @@ func _resolve_trader_task_patch_target(id: Variant) -> Array:
 	push_warning("[Registry] patch('trader_tasks', ...): id must be a String handle or a TaskData Resource")
 	return [null, null]
 
+func _append_trader_task(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_trader_task_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("trader_tasks", key, target, field, "append", values, allow_duplicates)
+
+func _prepend_trader_task(id: Variant, field: String, values: Array, allow_duplicates: bool) -> bool:
+	var resolved := _resolve_trader_task_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("trader_tasks", key, target, field, "prepend", values, allow_duplicates)
+
+func _remove_from_trader_task(id: Variant, field: String, values: Array) -> bool:
+	var resolved := _resolve_trader_task_patch_target(id)
+	var target: Resource = resolved[0]
+	var key = resolved[1]
+	if target == null:
+		return false
+	return _array_op_on_resource("trader_tasks", key, target, field, "remove_from", values, false)
+
+
 func _patch_trader_task(id: Variant, fields: Dictionary) -> bool:
 	if fields.is_empty():
 		push_warning("[Registry] patch('trader_tasks', ...): empty fields dict is a no-op")

--- a/src/registry/weapons.gd
+++ b/src/registry/weapons.gd
@@ -1,0 +1,262 @@
+## ----- registry/weapons.gd -----
+##
+## Three pure-aggregator helpers that fan out to existing primitive
+## registries (ITEMS, SCENES, LOOT) and patch the vanilla `compatible`
+## ItemData arrays where appropriate. No new state -- mods can drop down
+## to primitives any time. The helpers exist to compress the 6-10 calls
+## a typical weapon/attachment/magazine mod ends up making into one.
+##
+## Three helpers, three Registry consts:
+##   - register_weapon(id, dict)     -> Registry.WEAPONS
+##   - register_magazine(id, dict)   -> Registry.MAGAZINES
+##   - register_attachment(id, dict) -> Registry.ATTACHMENTS
+##
+## Magazine and attachment are nearly identical at the implementation
+## level (both register an item + scene + optional loot, then patch
+## `compatible` on target weapons). The vanilla `compatible` field
+## doesn't distinguish mag from attachment -- the split in the API is
+## for mod-author readability, not engine semantics.
+##
+## Cross-relationship resolution: `magazines`, `fits_attachments`, and
+## `fits_weapons` accept id strings. Lookup goes through _lookup_item,
+## which sees both mod-registered and vanilla items. Inline magazine
+## bundles (Dictionary instead of String) get registered first, then
+## their ItemData ref is appended to the parent weapon's compatible.
+##
+## All three helpers return a Dictionary with granular per-step success
+## bools so mod authors can debug partial failures without parsing logs.
+
+# -------- weapons --------
+
+# Required keys: item_path, scene_path, rig_path. Returns:
+# {
+#   ok: bool,                  # all sub-registrations succeeded
+#   items: bool,               # weapon ItemData registered
+#   scene: bool,               # weapon world scene registered
+#   rig: bool,                 # weapon rig scene registered
+#   magazines: [{id, ok, items?, scene?, loot_count?}],
+#   fits_attachments: [String], # ids successfully appended to compatible
+#   fits_attachments_failed: [String], # ids that didn't resolve
+#   loot_count: int,           # tables successfully populated
+# }
+func _register_weapon(id: String, data: Variant) -> Dictionary:
+	var result: Dictionary = {
+		"ok": false,
+		"items": false,
+		"scene": false,
+		"rig": false,
+		"magazines": [],
+		"fits_attachments": [],
+		"fits_attachments_failed": [],
+		"loot_count": 0,
+	}
+	if not (data is Dictionary):
+		push_warning("[Registry] register('weapons', '%s', ...) expects Dictionary" % id)
+		return result
+	var d: Dictionary = data
+	for required in ["item_path", "scene_path", "rig_path"]:
+		if not d.has(required):
+			push_warning("[Registry] register('weapons', '%s'): missing required key '%s'" % [id, required])
+			return result
+	# Step 1: load + register the weapon ItemData.
+	var weapon_item: Resource = load(d["item_path"])
+	if weapon_item == null:
+		push_warning("[Registry] register('weapons', '%s'): failed to load item from '%s'" % [id, d["item_path"]])
+		return result
+	# Optional icon load + assign before registering.
+	if d.has("icon_path"):
+		_apply_icon(weapon_item, d["icon_path"], id)
+	result["items"] = _register_item(id, weapon_item)
+	if not result["items"]:
+		# Item registration is the foundation; if it failed, abort -- the
+		# rest of the fan-out has nothing to attach `compatible` to.
+		return result
+	# Step 2: world scene.
+	var world_scene: Resource = load(d["scene_path"])
+	if world_scene != null:
+		result["scene"] = _register_scene(id, world_scene)
+	# Step 3: rig scene. Rig id convention: "<weapon_id>_Rig".
+	var rig_scene: Resource = load(d["rig_path"])
+	if rig_scene != null:
+		result["rig"] = _register_scene(id + "_Rig", rig_scene)
+	# Step 4: magazines. Mixed array of inline bundles + id strings.
+	# Track ItemData refs to append to compatible later.
+	var compatible_additions: Array = []
+	if d.has("magazines") and d["magazines"] is Array:
+		for entry in d["magazines"]:
+			var mag_result: Dictionary = _register_weapon_magazine_entry(entry)
+			result["magazines"].append(mag_result)
+			if mag_result.get("item_data") != null:
+				compatible_additions.append(mag_result["item_data"])
+	# Step 5: fits_attachments -- id-only refs. Resolve through _lookup_item
+	# (covers vanilla + mod items). Failures don't abort; append what we can.
+	if d.has("fits_attachments") and d["fits_attachments"] is Array:
+		for att_id in d["fits_attachments"]:
+			if not (att_id is String):
+				continue
+			var att_item: Resource = _lookup_item(att_id)
+			if att_item == null:
+				result["fits_attachments_failed"].append(att_id)
+				push_warning("[Registry] register('weapons', '%s'): fits_attachments id '%s' didn't resolve to any item (typo? not registered yet?)" % [id, att_id])
+				continue
+			result["fits_attachments"].append(att_id)
+			if not (att_item in compatible_additions):
+				compatible_additions.append(att_item)
+	# Step 6: patch the weapon's compatible array in one shot. Read current,
+	# extend with additions, write back via _patch_item so revert tracking
+	# still works.
+	if not compatible_additions.is_empty():
+		var existing: Array = []
+		if "compatible" in weapon_item:
+			var cur = weapon_item.get("compatible")
+			if cur is Array:
+				existing = (cur as Array).duplicate()
+		for add in compatible_additions:
+			if not (add in existing):
+				existing.append(add)
+		_patch_item(id, {"compatible": existing})
+	# Step 7: loot tables. Each entry becomes one register(LOOT, ...) call.
+	if d.has("loot_tables") and d["loot_tables"] is Array:
+		for table_name in d["loot_tables"]:
+			if not (table_name is String):
+				continue
+			var loot_id: String = "%s_in_%s" % [id, table_name]
+			if _register_loot(loot_id, {"item": weapon_item, "table": String(table_name)}):
+				result["loot_count"] = int(result["loot_count"]) + 1
+	# Final ok: items+scene+rig succeeded, no fits failures (magazines
+	# tracked separately -- caller can drill in).
+	result["ok"] = result["items"] and result["scene"] and result["rig"] \
+			and result["fits_attachments_failed"].is_empty()
+	_log_debug("[Registry] register_weapon('%s') result: %s" % [id, result])
+	return result
+
+# Per-magazine processing inside register_weapon. Accepts either a
+# Dictionary (inline bundle) or a String (id ref). Returns:
+#   {id, ok, item_data, items?, scene?, loot_count?}
+# `item_data` is the ItemData ref to append to the weapon's compatible.
+# It's null on resolution failure.
+func _register_weapon_magazine_entry(entry: Variant) -> Dictionary:
+	if entry is String:
+		# id ref to existing mod or vanilla item. Resolve, return ref-only.
+		var mag: Resource = _lookup_item(entry)
+		if mag == null:
+			push_warning("[Registry] register_weapon: magazine id '%s' didn't resolve (typo? not registered yet?)" % entry)
+			return {"id": entry, "ok": false, "item_data": null}
+		return {"id": entry, "ok": true, "item_data": mag}
+	if entry is Dictionary:
+		# Inline bundle. Register as a fresh magazine.
+		var d: Dictionary = entry
+		if not d.has("id") or not (d["id"] is String):
+			push_warning("[Registry] register_weapon: inline magazine missing 'id' string key")
+			return {"id": "", "ok": false, "item_data": null}
+		var sub: Dictionary = _register_magazine(d["id"], d)
+		var sub_item: Resource = _lookup_item(d["id"])
+		return {
+			"id": d["id"],
+			"ok": sub["ok"],
+			"item_data": sub_item,
+			"items": sub.get("items", false),
+			"scene": sub.get("scene", false),
+			"loot_count": sub.get("loot_count", 0),
+		}
+	push_warning("[Registry] register_weapon: magazine entry must be a Dictionary or String id, got %s" % typeof(entry))
+	return {"id": "", "ok": false, "item_data": null}
+
+# -------- magazines --------
+
+# Standalone magazine. Required: item_path, scene_path. Optional:
+# icon_path, fits_weapons (id list), loot_tables. Returns:
+# {ok, items, scene, fits_weapons: [String], fits_weapons_failed: [String],
+#  loot_count}
+func _register_magazine(id: String, data: Variant) -> Dictionary:
+	return _register_compat_item(id, data, "magazines")
+
+# -------- attachments --------
+
+# Same shape as magazine. The split exists for mod-author readability;
+# vanilla's `compatible` field doesn't distinguish.
+func _register_attachment(id: String, data: Variant) -> Dictionary:
+	return _register_compat_item(id, data, "attachments")
+
+# Shared implementation for magazines + attachments. Both register an item
+# + scene + optional loot, then patch `compatible` on each weapon listed
+# in fits_weapons.
+func _register_compat_item(id: String, data: Variant, label: String) -> Dictionary:
+	var result: Dictionary = {
+		"ok": false,
+		"items": false,
+		"scene": false,
+		"fits_weapons": [],
+		"fits_weapons_failed": [],
+		"loot_count": 0,
+	}
+	if not (data is Dictionary):
+		push_warning("[Registry] register('%s', '%s', ...) expects Dictionary" % [label, id])
+		return result
+	var d: Dictionary = data
+	for required in ["item_path", "scene_path"]:
+		if not d.has(required):
+			push_warning("[Registry] register('%s', '%s'): missing required key '%s'" % [label, id, required])
+			return result
+	var item_data: Resource = load(d["item_path"])
+	if item_data == null:
+		push_warning("[Registry] register('%s', '%s'): failed to load item from '%s'" % [label, id, d["item_path"]])
+		return result
+	if d.has("icon_path"):
+		_apply_icon(item_data, d["icon_path"], id)
+	result["items"] = _register_item(id, item_data)
+	if not result["items"]:
+		return result
+	var scene: Resource = load(d["scene_path"])
+	if scene != null:
+		result["scene"] = _register_scene(id, scene)
+	# fits_weapons: patch each target weapon's `compatible` to include this item.
+	if d.has("fits_weapons") and d["fits_weapons"] is Array:
+		for weapon_id in d["fits_weapons"]:
+			if not (weapon_id is String):
+				continue
+			var weapon_item: Resource = _lookup_item(weapon_id)
+			if weapon_item == null:
+				result["fits_weapons_failed"].append(weapon_id)
+				push_warning("[Registry] register('%s', '%s'): fits_weapons id '%s' didn't resolve" % [label, id, weapon_id])
+				continue
+			# Read current compatible, append, write back.
+			var existing: Array = []
+			if "compatible" in weapon_item:
+				var cur = weapon_item.get("compatible")
+				if cur is Array:
+					existing = (cur as Array).duplicate()
+			if not (item_data in existing):
+				existing.append(item_data)
+			if _patch_item(weapon_id, {"compatible": existing}):
+				result["fits_weapons"].append(weapon_id)
+			else:
+				result["fits_weapons_failed"].append(weapon_id)
+	# Loot tables.
+	if d.has("loot_tables") and d["loot_tables"] is Array:
+		for table_name in d["loot_tables"]:
+			if not (table_name is String):
+				continue
+			var loot_id: String = "%s_in_%s" % [id, table_name]
+			if _register_loot(loot_id, {"item": item_data, "table": String(table_name)}):
+				result["loot_count"] = int(result["loot_count"]) + 1
+	result["ok"] = result["items"] and result["scene"] and result["fits_weapons_failed"].is_empty()
+	_log_debug("[Registry] register_%s('%s') result: %s" % [label.trim_suffix("s"), id, result])
+	return result
+
+# -------- shared helpers --------
+
+# Load an icon image, convert to ImageTexture, assign to item_data.icon if
+# the field exists. Best-effort: failures warn but don't abort the parent
+# registration -- icons are cosmetic.
+func _apply_icon(item_data: Resource, icon_path: String, owner_id: String) -> void:
+	if not _resource_has_property(item_data, "icon"):
+		return
+	var img := Image.new()
+	if img.load(icon_path) != OK:
+		push_warning("[Registry] register: '%s' icon load failed for '%s'" % [owner_id, icon_path])
+		return
+	if img.get_size().x == 0 or img.get_size().y == 0:
+		push_warning("[Registry] register: '%s' icon loaded but is empty (path resolved but size 0)" % owner_id)
+		return
+	item_data.icon = ImageTexture.create_from_image(img)

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -1285,6 +1285,13 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		# ~10 dict ops + meta/prop/fn calls. Matches godot-mod-loader.
 		out += "%sif not _lib._any_mod_hooked:\n" % I1
 		out += "%sreturn %s%s\n" % [I2, aw, vanilla_call]
+		# Per-hook-base short-circuit: even when SOME mod has hooked SOMETHING
+		# (which makes _any_mod_hooked sticky-true forever), most wrapped
+		# methods still have no hooks of their own. One Dictionary.has() lets
+		# them fast-path past the full _wrapper_active/_caller/_dispatch
+		# pipeline.
+		out += "%sif not _lib._hooked_bases.has(\"%s\"):\n" % [I1, hook_base]
+		out += "%sreturn %s%s\n" % [I2, aw, vanilla_call]
 		# Dev-mode-only per-method dispatch counter. Gated by a property
 		# read so non-dev users pay ~1 branch per call; dev users see a
 		# top-15 summary at 30s that pinpoints runaway method calls (e.g.
@@ -1340,6 +1347,10 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%svar _lib = Engine.get_meta(\"RTVModLib\")\n" % I1
 		# Global short-circuit: see non-void branch above.
 		out += "%sif not _lib._any_mod_hooked:\n" % I1
+		out += "%s%s%s\n" % [I2, aw, vanilla_call]
+		out += "%sreturn\n" % I2
+		# Per-hook-base short-circuit: see non-void branch above.
+		out += "%sif not _lib._hooked_bases.has(\"%s\"):\n" % [I1, hook_base]
 		out += "%s%s%s\n" % [I2, aw, vanilla_call]
 		out += "%sreturn\n" % I2
 		# Dev-mode-only per-method dispatch counter (see non-void branch).

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -347,6 +347,10 @@ func _rtv_registry_injection(filename: String, indent: String) -> String:
 			var inj := _rtv_inject_aispawner_registry(indent)
 			_log_info("[RTVCodegen] Injected registry into %s (%d chars)" % [filename, inj.length()])
 			return inj
+		"AI.gd":
+			var inj := _rtv_inject_ai_registry(indent)
+			_log_info("[RTVCodegen] Injected registry into %s (%d chars)" % [filename, inj.length()])
+			return inj
 		_:
 			return ""
 
@@ -461,6 +465,8 @@ func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, r
 			return _rtv_inject_prelude(lines, rename_prefix + "LoadScene", _rtv_loader_loadscene_prelude())
 		"FishPool.gd":
 			return _rtv_inject_prelude(lines, rename_prefix + "_ready", _rtv_fishpool_ready_prelude())
+		"AI.gd":
+			return _rtv_inject_prelude(lines, rename_prefix + "SelectWeapon", _rtv_ai_selectweapon_prelude())
 		"Compiler.gd":
 			# Spawn's prelude assigns to vanilla's `spawnTarget` local, which
 			# is declared on the first body line. Insert after the run of
@@ -792,6 +798,87 @@ func _rtv_compiler_spawn_prelude() -> PackedStringArray:
 	p.append("\t\t\t\tspawnTarget = String(_rtv_e.get(\"entrance_spawn\", \"\"))")
 	p.append("\t# Fall through to vanilla if-elif (which handles vanilla maps).")
 	return p
+
+# AI.SelectWeapon prelude: calls the loadout-application helper before
+# vanilla picks a weapon. Helper iterates the ai_loadouts engine-meta
+# entries, rolls per entry, instantiates matching weapon scenes and
+# adds them to self.weapons. Vanilla SelectWeapon then runs as written
+# and picks one at random from the augmented pool.
+func _rtv_ai_selectweapon_prelude() -> PackedStringArray:
+	var p := PackedStringArray()
+	p.append("\t# --- Metro mod loader: ai_loadouts registry prelude ---")
+	p.append("\t_rtv_apply_ai_loadouts()")
+	return p
+
+func _rtv_inject_ai_registry(indent: String) -> String:
+	# AI.gd registry appendix. Helper functions read the ai_loadouts
+	# Engine-meta list and inject weapon scene instances into self.weapons
+	# before vanilla SelectWeapon picks. Category derivation uses self.boss
+	# + self.AISpawner.zone (vanilla AISpawner is the per-AI back-reference
+	# set during CreatePools).
+	var I1 := indent
+	var out := "\n\n# --- Metro mod loader: AI loadouts registry ---\n"
+	out += "func _rtv_apply_ai_loadouts() -> void:\n"
+	out += I1 + "var entries: Array = Engine.get_meta(\"_rtv_ai_loadouts\", [])\n"
+	out += I1 + "if entries.is_empty():\n"
+	out += I1 + I1 + "return\n"
+	# weapons may be null on AI scenes that don't declare it (mod-defined
+	# AI scenes might omit the @export). Bail rather than crash.
+	out += I1 + "if weapons == null:\n"
+	out += I1 + I1 + "return\n"
+	out += I1 + "var category: String = _rtv_ai_category()\n"
+	out += I1 + "if category == \"\":\n"
+	out += I1 + I1 + "return\n"
+	out += I1 + "for e in entries:\n"
+	# Defensive checks -- entries originate from the registry validator
+	# but Engine.meta is process-global so other code could in theory
+	# write nonsense in. Skip silently rather than crash.
+	out += I1 + I1 + "if not (e is Dictionary):\n"
+	out += I1 + I1 + I1 + "continue\n"
+	out += I1 + I1 + "var ai_types: Array = e.get(\"ai_types\", [])\n"
+	out += I1 + I1 + "if not (category in ai_types):\n"
+	out += I1 + I1 + I1 + "continue\n"
+	out += I1 + I1 + "if randf() > float(e.get(\"chance\", 1.0)):\n"
+	out += I1 + I1 + I1 + "continue\n"
+	out += I1 + I1 + "if bool(e.get(\"replace\", false)):\n"
+	out += I1 + I1 + I1 + "for child in weapons.get_children():\n"
+	out += I1 + I1 + I1 + I1 + "child.queue_free()\n"
+	out += I1 + I1 + "var scene: PackedScene = e.get(\"weapon_scene\")\n"
+	out += I1 + I1 + "if scene == null:\n"
+	out += I1 + I1 + I1 + "continue\n"
+	out += I1 + I1 + "var inst: Node = scene.instantiate()\n"
+	out += I1 + I1 + "weapons.add_child(inst)\n"
+	# Vanilla SelectWeapon expects every child of weapons to be hidden
+	# initially; show() runs only on the picked one. Match that contract
+	# so vanilla logic stays correct.
+	out += I1 + I1 + "if inst.has_method(\"hide\"):\n"
+	out += I1 + I1 + I1 + "inst.hide()\n"
+	out += "\n"
+	out += "func _rtv_ai_category() -> String:\n"
+	# self.boss is set by AISpawner.CreatePools() (true for the punisher
+	# in BPool, false for the regular agents in APool). AISpawner is the
+	# back-reference also set there. Without AISpawner we can't tell which
+	# zone-driven category this AI belongs to, so we bail.
+	out += I1 + "if boss:\n"
+	out += I1 + I1 + "return \"Punisher\"\n"
+	out += I1 + "if AISpawner == null:\n"
+	out += I1 + I1 + "return \"\"\n"
+	# Zone is an int (enum). AISpawner.Zone.keys() yields the string form
+	# at the same index, matching the convention used by ai_types.
+	out += I1 + "var z: int = AISpawner.zone\n"
+	out += I1 + "var zone_keys: Array = AISpawner.Zone.keys()\n"
+	out += I1 + "if z < 0 or z >= zone_keys.size():\n"
+	out += I1 + I1 + "return \"\"\n"
+	out += I1 + "match zone_keys[z]:\n"
+	out += I1 + I1 + "\"Area05\":\n"
+	out += I1 + I1 + I1 + "return \"Bandit\"\n"
+	out += I1 + I1 + "\"BorderZone\":\n"
+	out += I1 + I1 + I1 + "return \"Guard\"\n"
+	out += I1 + I1 + "\"Vostok\":\n"
+	out += I1 + I1 + I1 + "return \"Military\"\n"
+	out += I1 + I1 + "_:\n"
+	out += I1 + I1 + I1 + "return \"\"\n"
+	return out
 
 func _rtv_inject_aispawner_registry(indent: String) -> String:
 	# AISpawner.gd registry appendix. Adds the resolver helper used by the

--- a/src/setup.gd
+++ b/src/setup.gd
@@ -1,0 +1,178 @@
+## ----- setup.gd -----
+##
+## lib.setup(plan) -- declarative mod-installation entry point.
+##
+## A "plan" is an Array of [verb, ...args] entries. Order is insertion order,
+## so register-then-patch flows work naturally. Each entry maps to one of the
+## existing public verbs (register, override, patch, append, prepend,
+## remove_from, revert, remove, hooks) plus a meta verb `when` for
+## conditional sub-plans.
+##
+## Why this exists: mods that lean heavily on the hook + registry systems
+## tend to accumulate dozens of administrative lines in _ready (one per
+## hook, one per registration). setup() collapses that into one
+## declarative literal that can be a const at module scope or a runtime-
+## built local in _ready.
+##
+## Schema reference (Array of arrays):
+##   ["register",    reg, {id: data, ...}]
+##   ["override",    reg, {id: data, ...}]
+##   ["patch",       reg, {id: fields_dict, ...}]
+##   ["append",      reg, field, {id: values, ...}]                       # de-dup default
+##   ["append",      reg, field, {id: values, ...}, true]                 # allow_duplicates
+##   ["prepend",     reg, field, {id: values, ...}]                       # de-dup default
+##   ["prepend",     reg, field, {id: values, ...}, true]                 # allow_duplicates
+##   ["remove_from", reg, field, {id: values, ...}]
+##   ["revert",      reg, {id: fields_array, ...}]   # [] = full revert of that id
+##   ["remove",      reg, [id, id, ...]]
+##   ["hooks",       {hook_name: callback, ...}]
+##   ["when",        predicate, sub_plan]            # predicate: bool | Callable -> bool
+##
+## Predicate evaluation: at setup() traversal time. If a plan is built in
+## _ready (typical), runtime state is queryable in the predicate. A const
+## plan with non-Callable predicates evaluates them at script-parse time --
+## fine for compile-time bools but wrong for runtime state, so prefer
+## Callable/lambda predicates in const plans.
+##
+## Return shape (Dictionary):
+##   {
+##     "ok": bool,                # true only if every executed entry succeeded
+##     "results": Array,          # one entry per top-level plan entry
+##   }
+##
+## Per-result entries match their verb:
+##   {"verb": "register", "ok": bool, "results": {id: bool}}
+##   {"verb": "patch",    "ok": bool, "results": {id: bool}}
+##   {"verb": "hooks",    "ok": bool, "results": {hook_name: int}}
+##   {"verb": "when",     "evaluated": bool, "ok": bool, "results": [...]?}
+##                                  # results present only when evaluated=true
+##   {"verb": "<unknown>", "ok": false, "error": "..."}   # malformed entry
+##
+## Failures isolate. A bad entry produces a result with ok=false and the
+## next entry runs anyway -- consistent with the singular verbs and the
+## _many forms.
+
+func setup(plan: Array) -> Dictionary:
+	var results: Array = []
+	var all_ok := true
+	for entry in plan:
+		var r: Dictionary = _setup_run_entry(entry)
+		results.append(r)
+		if not bool(r.get("ok", false)):
+			all_ok = false
+	return {"ok": all_ok, "results": results}
+
+
+# Dispatch a single plan entry. Returns the per-entry result Dictionary.
+func _setup_run_entry(entry: Variant) -> Dictionary:
+	if not (entry is Array):
+		return {"verb": "<malformed>", "ok": false, "error": "entry is not an Array"}
+	var arr: Array = entry
+	if arr.is_empty():
+		return {"verb": "<empty>", "ok": false, "error": "entry is empty"}
+	var verb: String = String(arr[0])
+	match verb:
+		"register":
+			return _setup_dispatch_many("register", arr, _bind_register_many())
+		"override":
+			return _setup_dispatch_many("override", arr, _bind_override_many())
+		"patch":
+			return _setup_dispatch_many("patch", arr, _bind_patch_many())
+		"append":
+			return _setup_dispatch_array_op("append", arr)
+		"prepend":
+			return _setup_dispatch_array_op("prepend", arr)
+		"remove_from":
+			return _setup_dispatch_array_op("remove_from", arr)
+		"revert":
+			return _setup_dispatch_many("revert", arr, _bind_revert_many())
+		"remove":
+			# remove takes an Array of ids, not a {id: ...} dict.
+			if arr.size() != 3:
+				return {"verb": verb, "ok": false, "error": "expected [\"remove\", reg, [ids]]"}
+			if not (arr[2] is Array):
+				return {"verb": verb, "ok": false, "error": "expected ids Array as 3rd arg"}
+			var rm: Dictionary = remove_many(String(arr[1]), arr[2])
+			return {"verb": verb, "ok": rm.ok, "results": rm.results}
+		"hooks":
+			if arr.size() != 2:
+				return {"verb": verb, "ok": false, "error": "expected [\"hooks\", {name: cb, ...}]"}
+			if not (arr[1] is Dictionary):
+				return {"verb": verb, "ok": false, "error": "expected hooks dict as 2nd arg"}
+			var hr: Dictionary = hook_many(arr[1])
+			return {"verb": verb, "ok": hr.ok, "results": hr.results}
+		"when":
+			return _setup_dispatch_when(arr)
+		_:
+			return {"verb": verb, "ok": false, "error": "unknown verb"}
+
+
+# Common shape: [verb, reg, {id: payload}]. The Callable invokes the
+# corresponding _many form.
+func _setup_dispatch_many(verb: String, arr: Array, many_fn: Callable) -> Dictionary:
+	if arr.size() != 3:
+		return {"verb": verb, "ok": false, "error": "expected [\"%s\", reg, {id: payload}]" % verb}
+	if not (arr[2] is Dictionary):
+		return {"verb": verb, "ok": false, "error": "expected payload dict as 3rd arg"}
+	var res: Dictionary = many_fn.call(String(arr[1]), arr[2])
+	return {"verb": verb, "ok": res.ok, "results": res.results}
+
+
+# Array-op shape: [verb, reg, field, {id: values}, allow_duplicates?].
+# allow_duplicates only applies to append/prepend; remove_from ignores it.
+func _setup_dispatch_array_op(verb: String, arr: Array) -> Dictionary:
+	if arr.size() < 4 or arr.size() > 5:
+		return {"verb": verb, "ok": false, "error": "expected [\"%s\", reg, field, {id: values}, allow_duplicates?]" % verb}
+	if not (arr[3] is Dictionary):
+		return {"verb": verb, "ok": false, "error": "expected payload dict as 4th arg"}
+	var reg: String = String(arr[1])
+	var field: String = String(arr[2])
+	var entries: Dictionary = arr[3]
+	var allow_dups: bool = arr.size() == 5 and bool(arr[4])
+	var res: Dictionary
+	match verb:
+		"append":      res = append_many(reg, field, entries, allow_dups)
+		"prepend":     res = prepend_many(reg, field, entries, allow_dups)
+		"remove_from": res = remove_from_many(reg, field, entries)
+		_:
+			return {"verb": verb, "ok": false, "error": "internal: bad array-op verb"}
+	return {"verb": verb, "ok": res.ok, "results": res.results}
+
+
+# When-shape: [when, predicate, sub_plan]. Recurse on sub_plan if predicate
+# evaluates truthy. Skipped when-blocks return ok=true (vacuously: nothing
+# failed because nothing ran).
+func _setup_dispatch_when(arr: Array) -> Dictionary:
+	if arr.size() != 3:
+		return {"verb": "when", "ok": false, "error": "expected [\"when\", predicate, sub_plan]"}
+	if not (arr[2] is Array):
+		return {"verb": "when", "ok": false, "error": "sub_plan must be an Array"}
+	var truthy: bool = _setup_evaluate_predicate(arr[1])
+	if not truthy:
+		return {"verb": "when", "evaluated": false, "ok": true}
+	# Predicate true -- recurse. Inner plan returns its own {ok, results};
+	# bubble up the same shape so callers can introspect nested outcomes.
+	var inner: Dictionary = setup(arr[2])
+	return {"verb": "when", "evaluated": true, "ok": inner.ok, "results": inner.results}
+
+
+# Predicate accepts plain bool, Callable, or anything bool()-coercible. Any
+# other type is treated as false (with a warning) -- safer than running the
+# sub-plan on a typo.
+func _setup_evaluate_predicate(p: Variant) -> bool:
+	if p is Callable:
+		return bool((p as Callable).call())
+	if p is bool or p is int or p is float:
+		return bool(p)
+	if p == null:
+		return false
+	push_warning("[Registry] setup: when-predicate has unexpected type %s; treating as false" % typeof(p))
+	return false
+
+
+# These helpers wrap the _many methods as Callables so the dispatcher can
+# pass them through _setup_dispatch_many. Saves a small amount of repetition.
+func _bind_register_many() -> Callable: return Callable(self, "register_many")
+func _bind_override_many() -> Callable: return Callable(self, "override_many")
+func _bind_patch_many() -> Callable:    return Callable(self, "patch_many")
+func _bind_revert_many() -> Callable:   return Callable(self, "revert_many")

--- a/src/setup.gd
+++ b/src/setup.gd
@@ -101,6 +101,16 @@ func _setup_run_entry(entry: Variant) -> Dictionary:
 				return {"verb": verb, "ok": false, "error": "expected hooks dict as 2nd arg"}
 			var hr: Dictionary = hook_many(arr[1])
 			return {"verb": verb, "ok": hr.ok, "results": hr.results}
+		"register_item":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_item())
+		"register_weapon":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_weapon())
+		"register_magazine":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_magazine())
+		"register_attachment":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_attachment())
+		"register_furniture":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_furniture())
 		"when":
 			return _setup_dispatch_when(arr)
 		_:
@@ -176,3 +186,22 @@ func _bind_register_many() -> Callable: return Callable(self, "register_many")
 func _bind_override_many() -> Callable: return Callable(self, "override_many")
 func _bind_patch_many() -> Callable:    return Callable(self, "patch_many")
 func _bind_revert_many() -> Callable:   return Callable(self, "revert_many")
+
+
+# Aggregator-shape: [verb, {id: data, ...}]. No `reg` arg -- each aggregator
+# is registry-implicit. Maps to the public aggregator helpers, which already
+# accept and return a Dictionary.
+func _setup_dispatch_aggregator(verb: String, arr: Array, agg_fn: Callable) -> Dictionary:
+	if arr.size() != 2:
+		return {"verb": verb, "ok": false, "error": "expected [\"%s\", {id: data, ...}]" % verb}
+	if not (arr[1] is Dictionary):
+		return {"verb": verb, "ok": false, "error": "expected payload dict as 2nd arg"}
+	var res: Dictionary = agg_fn.call(arr[1])
+	return {"verb": verb, "ok": res.get("ok", false), "results": res.get("results", {})}
+
+
+func _bind_register_item() -> Callable:       return Callable(self, "register_item")
+func _bind_register_weapon() -> Callable:     return Callable(self, "register_weapon")
+func _bind_register_magazine() -> Callable:   return Callable(self, "register_magazine")
+func _bind_register_attachment() -> Callable: return Callable(self, "register_attachment")
+func _bind_register_furniture() -> Callable:  return Callable(self, "register_furniture")

--- a/src/setup.gd
+++ b/src/setup.gd
@@ -111,6 +111,8 @@ func _setup_run_entry(entry: Variant) -> Dictionary:
 			return _setup_dispatch_aggregator(verb, arr, _bind_register_attachment())
 		"register_furniture":
 			return _setup_dispatch_aggregator(verb, arr, _bind_register_furniture())
+		"register_ai_loadout":
+			return _setup_dispatch_aggregator(verb, arr, _bind_register_ai_loadout())
 		"when":
 			return _setup_dispatch_when(arr)
 		_:
@@ -205,3 +207,4 @@ func _bind_register_weapon() -> Callable:     return Callable(self, "register_we
 func _bind_register_magazine() -> Callable:   return Callable(self, "register_magazine")
 func _bind_register_attachment() -> Callable: return Callable(self, "register_attachment")
 func _bind_register_furniture() -> Callable:  return Callable(self, "register_furniture")
+func _bind_register_ai_loadout() -> Callable: return Callable(self, "register_ai_loadout")


### PR DESCRIPTION
  Aggregator helpers, high-level content registration

  Five fan-out helpers that bundle ItemData + scenes + cross-compat patches into one declarative call.
  Each takes a Dictionary {id: data, ...} (one entry or many) and returns {ok, results: {id:
  granular_dict}} for per-id introspection.

  - register_item({id: data, ...}), generic ItemData + optional scene/icon/loot/trader_pools
  - register_weapon({id: data, ...}), weapon + scene + rig + inline magazines + fits_attachments + loot
  - register_magazine({id: data, ...}), magazine + scene + fits_weapons cross-compat
  - register_attachment({id: data, ...}), same shape as magazine, split for readability
  - register_furniture({id: data, ...}), furniture item + placed scene + trader_pools + optional
  crafting recipe
  - register_ai_loadout({id: data, ...}), new AI_LOADOUTS registry for spawning AI with custom gear

  All accept dict-only input (no (id, data) overload). Single registration is just a one-key dict.
  Per-entry granular result preserved through batch wrapping.

  Array verbs, additive field mutation

  Three primitives for Array-typed Resource fields. First-write-wins stash shared with patch(), so
  revert(reg, id, [field]) restores the true original even after multiple ops. Typed-array safety
  enforced before any mutation.

  - append(reg, id, field, values, allow_duplicates=false), add to Array, dedup default
  - prepend(reg, id, field, values, allow_duplicates=false), same but at front; resulting prefix matches
   input order
  - remove_from(reg, id, field, values), drop all matching occurrences, idempotent

  Supported on items, sounds, recipes, events, trader_tasks, resources. values accepts single value or
  Array.

  _many batch forms, single-registry batched verbs

  Batched siblings for every mutation verb. Single registry per call, dict of {id: payload} (or [id,
  ...] for remove). Each is a thin loop over the singular form; failures isolate per-entry.

  register_many / override_many / patch_many / append_many / prepend_many / remove_from_many /
  revert_many / remove_many / hook_many

  Returns {ok: bool, results: {id: bool_or_id, ...}}.

  lib.setup(plan), declarative entry point

  Mod's entire _ready setup as one literal. Plan is a list of [verb, ...args] entries dispatched in
  order. Failure isolation per-entry (one bad entry doesn't stop the next).

  Verbs: register, override, patch, append, prepend, remove_from, revert, remove, hooks, register_item,
  register_weapon, register_magazine, register_attachment, register_furniture, when (conditional
  sub-plans).

  when: predicates accept plain bool, named Callable, or lambda, evaluated at traversal time. Nested when
   works as expected (predicates AND together).

  Insertion order matters: register then patch on same id works because entries run sequentially.

  Mod-discovery API

  Three methods on the lib for cross-mod compat detection:

  - has_mod(mod_id, min_version=""), bool, optional semver-style min comparison
  - mod_info(mod_id), {mod_id, mod_name, version, file_name, priority} or {}
  - loaded_mods(), Array of all loaded mod ids

  Lets mods do if lib.has_mod("rtv-coop"): defer_to_coop() without poking at _loaded_mod_ids.

  Loader-side optimizations

  - Per-hook-base wrapper short-circuit, _hooked_bases refcount on the lib lets generated wrappers skip
  the full dispatch pipeline when no mod has hooked the specific base. One Dictionary.has() vs ~14
  dict/property ops per wrapped call. Makes 60Hz hot paths (AI._physics_process, etc.) essentially free
  for unhooked methods.
  - scene_nodes root targeting, patch the scene root itself by passing only <scene_path># or #.

  Docs

  - New docs/wiki/Setup.md (340 lines), full schema table, predicate forms, return shape, comprehensive
  worked example covering every verb and aggregator
  - docs/wiki/Registry.md (+363 lines), new sections for array verbs, batched forms, aggregators,
  mod-discovery; tables updated
  - docs/wiki/Hooks.md (+162 lines), hook_many and cross-references to Setup
  - docs/wiki/_Sidebar.md, Setup added


  Backwards compatibility

  - All new APIs are additive, no existing methods changed signatures
  - Wrapper short-circuit fully transparent to mods; helps any mod that wraps a method with no per-base
  hooks (most of them)