### PR TITLE
release: B_Loader compat + launcher self-update (extends #66 for v3.2.0)

### DIFF
--- a/src/constants.gd
+++ b/src/constants.gd
@@ -41,6 +41,11 @@ const HOOK_PACK_MOUNT_BASE := "res://modloader_hooks"
 const VANILLA_CACHE_DIR := "user://modloader_hooks/vanilla"
 const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
 const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
+const MODWORKSHOP_PAGE_URL_TEMPLATE := "https://modworkshop.net/mod/%s"
+# ModWorkshop ID for this modloader itself. Used by the launcher's self-update
+# check to flag when the installed MODLOADER_VERSION is older than what's
+# published on ModWorkshop. Set to <= 0 to disable the check entirely.
+const MODLOADER_MODWORKSHOP_ID := 55623
 const MODWORKSHOP_BATCH_SIZE := 100
 const API_CHECK_TIMEOUT := 15.0
 const API_DOWNLOAD_TIMEOUT := 30.0
@@ -104,6 +109,14 @@ var _ui_hint_label: Label = null
 # Launch button kept on self so refresh_launch_button_label can reach it
 # from the mod-enable toggle handler.
 var _ui_launch_btn: Button = null
+# Self-update check state. _modloader_latest_version is populated by
+# _check_modloader_update_async once the API responds; empty until then or
+# when the check fails. _ui_update_alert_btn is the inline LinkButton in the
+# launch row -- always shows the installed version dim by default, swaps to
+# an orange "update available" prompt when the API reports a newer release.
+# Both cleared on UI close.
+var _modloader_latest_version: String = ""
+var _ui_update_alert_btn: LinkButton = null
 var _has_loaded := false
 var _last_mod_txt_status := "none"
 # Detailed parse-failure diagnostic written by _parse_mod_txt when ConfigFile

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -22,6 +22,7 @@ const REGISTRY_TARGETS: Array[String] = [
 	"Loader.gd",
 	"AISpawner.gd",
 	"FishPool.gd",
+	"Compiler.gd",
 ]
 
 func _is_registry_target(filename: String) -> bool:

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -213,6 +213,22 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		_any_mod_declared_registry = true
 		_log_info("  Registry declared [%s]" % mod_name)
 
+	# B_Loader compat: mods written against BitByteBytes/B_Loader call
+	# Loader.add_shelter / Loader.add_map without ever declaring [registry]
+	# in their mod.txt. The shim methods on Loader.gd only get injected when
+	# the rewriter runs over Loader.gd, which itself depends on at least one
+	# mod opting into [registry]. Treat the call-site presence as an
+	# implicit registry declaration so the shim activates without a mod.txt
+	# edit. Mods can migrate to the explicit form (and to lib.register())
+	# at their own pace.
+	var analysis: Dictionary = _mod_script_analysis.get(mod_name, {})
+	if analysis.get("calls_bloader_api", false):
+		if not _any_mod_declared_registry:
+			_any_mod_declared_registry = true
+			_log_info("  B_Loader-style call detected (Loader.add_shelter/add_map) [%s] -- treating as registry-declaring; compat shim activates" % mod_name)
+		else:
+			_log_info("  B_Loader-style call detected [%s] -- compat shim active" % mod_name)
+
 	# [script_extend] / [script_overrides] -- full script replacements that
 	# chain via Godot's extends resolution. Both section names accepted
 	# (script_extend is the preferred v3.0.1 name; script_overrides is the
@@ -397,6 +413,13 @@ func scan_and_register_archive_claims(archive_path: String, mod_name: String,
 		# hooks AND zero [hooks]/[registry] mod.txt sections leaves the
 		# wrap surface empty and skips hook pack generation entirely.
 		"hook_calls":              [],  # Array of {prefix, method}
+		# True if the mod's source contains a B_Loader-style call
+		# (Loader.add_shelter / Loader.add_map). The B_Loader compat shim
+		# lives in our injected Loader.gd appendix, but the rewriter only
+		# fires when at least one mod declares [registry]. Detecting these
+		# call patterns lets us auto-treat such mods as registry-declaring
+		# so they Just Work without requiring a mod.txt edit.
+		"calls_bloader_api":       false,
 	}
 
 	for f in files:
@@ -485,6 +508,14 @@ func _scan_gd_source(text: String, analysis: Dictionary) -> void:
 	# by HUD._physics_process from gameData.tooltip -- this override has no effect there.
 	if not analysis["calls_update_tooltip"]:
 		analysis["calls_update_tooltip"] = "UpdateTooltip" in text
+
+	# B_Loader-pattern detection. Substring match is fine -- Loader.add_shelter
+	# isn't a vanilla method, and false positives in non-call contexts (a
+	# string literal, a comment) just over-treat the mod as registry-declaring,
+	# which costs nothing.
+	if not analysis["calls_bloader_api"]:
+		if "Loader.add_shelter(" in text or "Loader.add_map(" in text:
+			analysis["calls_bloader_api"] = true
 
 	# Detect base() calls -- Godot 3 pattern or removed parent method.
 	if not analysis["calls_base"]:

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -39,6 +39,7 @@ const Registry := {
 	INPUTS = "inputs",
 	SCENE_PATHS = "scene_paths",
 	SHELTERS = "shelters",
+	MAPS = "maps",
 	RANDOM_SCENES = "random_scenes",
 	AI_TYPES = "ai_types",
 	FISH_SPECIES = "fish_species",
@@ -88,6 +89,7 @@ func register(registry: String, id: String, data: Variant) -> bool:
 		"inputs": return _register_input(id, data)
 		"scene_paths": return _register_scene_path(id, data)
 		"shelters": return _register_shelter(id, data)
+		"maps": return _register_map(id, data)
 		"random_scenes": return _register_random_scene(id, data)
 		"ai_types": return _register_ai_type(id, data)
 		"fish_species": return _register_fish_species(id, data)
@@ -122,6 +124,9 @@ func override(registry: String, id: String, data: Variant) -> bool:
 		"scene_paths": return _override_scene_path(id, data)
 		"shelters":
 			push_warning("[Registry] override: 'shelters' doesn't support override (it's an append-only list; use register/remove)")
+			return false
+		"maps":
+			push_warning("[Registry] override: 'maps' doesn't support override (append-only; use register/remove, or override('scenes', ...) to swap the underlying scene)")
 			return false
 		"random_scenes":
 			push_warning("[Registry] override: 'random_scenes' doesn't support override (append-only list; use register/remove)")
@@ -187,7 +192,10 @@ func patch(registry: String, id: Variant, fields: Dictionary) -> bool:
 				return false
 			return _patch_scene_path(id, fields)
 		"shelters":
-			push_warning("[Registry] patch: 'shelters' doesn't support patch (entries are bare strings)")
+			push_warning("[Registry] patch: 'shelters' doesn't support patch (use remove + register to change fields, or patch('scene_paths', ...) for path-only edits)")
+			return false
+		"maps":
+			push_warning("[Registry] patch: 'maps' doesn't support patch (use remove + register to change fields, or patch('scene_paths', ...) for path-only edits)")
 			return false
 		"random_scenes":
 			push_warning("[Registry] patch: 'random_scenes' doesn't support patch (entries are bare paths)")
@@ -228,6 +236,7 @@ func remove(registry: String, id: String) -> bool:
 		"inputs": return _remove_input(id)
 		"scene_paths": return _remove_scene_path(id)
 		"shelters": return _remove_shelter(id)
+		"maps": return _remove_map(id)
 		"random_scenes": return _remove_random_scene(id)
 		"ai_types": return _remove_ai_type(id)
 		"fish_species": return _remove_fish_species(id)
@@ -293,6 +302,11 @@ func revert(registry: String, id: Variant, fields: Array = []) -> bool:
 				push_warning("[Registry] revert('shelters', ...): id must be a String")
 				return false
 			return _remove_shelter(id)
+		"maps":
+			if not (id is String):
+				push_warning("[Registry] revert('maps', ...): id must be a String")
+				return false
+			return _remove_map(id)
 		"random_scenes":
 			if not (id is String):
 				push_warning("[Registry] revert('random_scenes', ...): id must be a String")
@@ -361,7 +375,20 @@ func get_entry(registry: String, id: String) -> Variant:
 			return reg.get(id)
 		"shelters":
 			var reg: Dictionary = _registry_registered.get("shelters", {})
-			return reg.get(id)
+			var entry = reg.get(id)
+			# Filter cross-surface lookups: shelters get_entry returns null
+			# for ids that were registered via 'maps'.
+			if entry is Dictionary and entry.get("kind", "shelters") != "shelters":
+				return null
+			return entry
+		"maps":
+			# Maps share the 'shelters' storage bucket but only surface
+			# entries whose kind is "maps" through get_entry('maps').
+			var reg: Dictionary = _registry_registered.get("shelters", {})
+			var entry = reg.get(id)
+			if entry is Dictionary and entry.get("kind", "shelters") != "maps":
+				return null
+			return entry
 		"random_scenes":
 			var reg: Dictionary = _registry_registered.get("random_scenes", {})
 			return reg.get(id)

--- a/src/registry/loader.gd
+++ b/src/registry/loader.gd
@@ -256,67 +256,142 @@ func _revert_scene_path(id: String, fields: Array) -> bool:
 	_registry_patched["scene_paths"] = patched
 	return did_something
 
-# -------- shelters --------
+# -------- shelters / maps --------
 #
-# The shelters list holds bare strings. Registering a shelter also requires
-# a scene behind the name; if the mod provides `path`, we auto-register a
-# paired scene_paths entry so LoadScene(name) works. Otherwise we assume
-# the name is already resolvable (vanilla, or previously registered).
+# The shelters list holds bare strings (vanilla shelter names). Registering
+# a shelter or map also requires a scene behind the name; if the mod
+# provides `path`, we auto-register a paired scene_paths entry so
+# LoadScene(name) works. Otherwise we assume the name is already resolvable
+# (vanilla, or previously registered).
+#
+# The shelters and maps registries share storage and behavior -- they
+# differ only in the default `shelter` flag (true for shelters, false for
+# maps). The `shelter` flag controls TWO related things:
+#   1. gameData.shelter -- flipped during LoadScene's prelude (sets HUD/world state)
+#   2. Loader.LoadShelter(name) call in Compiler.Spawn() -- loads/saves
+#      per-shelter persistent state (furniture, stash). Maps don't get this.
+# The vanilla concept of "shelter" lumps both together; we follow suit.
+#
+# Full registration schema (all optional except `path` for newly-added
+# scenes):
+#   path             -- res:// path to the .tscn (auto-registers scene_paths)
+#   transition_text  -- override for the "Loading X..." label (defaults to id)
+#   exit_spawn       -- transition node name to spawn at when arriving in
+#                       this shelter (e.g. "Door_Apartment_Exit")
+#   entrance_spawn   -- transition node name in `connected_to` to spawn at
+#                       when leaving this shelter back to its parent map
+#   connected_to     -- vanilla map name where this shelter's entrance lives
+#   connected_content -- Array of {path, position, rotation} entries spawned
+#                        into /root/Map/Content when player enters connected_to
+#   shelter          -- bool, default true for shelters / false for maps
+#
+# This schema mirrors the B_Loader mod's add_shelter/add_map dict so
+# existing B_Loader-pattern mods migrate by changing one call site.
 
 func _register_shelter(id: String, data: Variant) -> bool:
+	return _register_shelter_or_map(id, data, true, "shelters")
+
+# Maps registry: same storage as shelters, just defaults shelter:false.
+# A "map" is a non-persistent area (no LoadShelter/SaveShelter); a
+# "shelter" gets the full save-file treatment.
+func _register_map(id: String, data: Variant) -> bool:
+	return _register_shelter_or_map(id, data, false, "maps")
+
+func _register_shelter_or_map(id: String, data: Variant, default_shelter: bool, label: String) -> bool:
 	var ldr := _loader_node()
 	if ldr == null:
 		return false
 	if not (data is Dictionary):
-		push_warning("[Registry] register('shelters', '%s', ...) expects Dictionary (can be empty if scene already registered)" % id)
+		push_warning("[Registry] register('%s', '%s', ...) expects Dictionary (can be empty if scene already registered)" % [label, id])
 		return false
 	var d: Dictionary = data
+	# Both 'shelters' and 'maps' write to the same _registry_registered
+	# bucket so collisions across the two surfaces fail loud (a name can
+	# only resolve to one entry in Compiler.Spawn).
 	var reg: Dictionary = _registry_registered.get("shelters", {})
 	if reg.has(id):
-		push_warning("[Registry] register('shelters', '%s'): already registered" % id)
+		push_warning("[Registry] register('%s', '%s'): already registered as shelter or map" % [label, id])
 		return false
 	if id in ldr.shelters:
-		push_warning("[Registry] register('shelters', '%s'): name already in shelters list (vanilla?)" % id)
+		push_warning("[Registry] register('%s', '%s'): name already in shelters list (vanilla?)" % [label, id])
 		return false
+	# Build the full entry that the Compiler.Spawn prelude reads.
+	var is_shelter: bool = bool(d.get("shelter", default_shelter))
+	var entry: Dictionary = {
+		"shelter": is_shelter,
+		"transition_text": String(d.get("transition_text", id)),
+		"exit_spawn": String(d.get("exit_spawn", "")),
+		"entrance_spawn": String(d.get("entrance_spawn", "")),
+		"connected_to": String(d.get("connected_to", "")),
+		"connected_content": d.get("connected_content", []),
+	}
 	# If a `path` is given, auto-register the scene_paths entry so the
-	# shelter name resolves to a real scene. Force the shelter gameData
-	# flag to true by default since it's a shelter.
+	# shelter/map name resolves to a real scene. Forward the shelter flag
+	# to gameData (LoadScene prelude reads `shelter` from the scene_paths
+	# entry) and the transition_text so the loading-screen label uses it.
 	var auto_scene_path := false
 	if d.has("path"):
-		var sp_data: Dictionary = d.duplicate()
-		# Default shelter flag to true; caller can explicitly pass shelter=false
-		# to opt out.
-		if not sp_data.has("shelter"):
-			sp_data["shelter"] = true
+		var sp_data: Dictionary = {}
+		sp_data["path"] = d["path"]
+		sp_data["shelter"] = is_shelter
+		# Forward optional gameData fields the caller might have set.
+		if d.has("menu"): sp_data["menu"] = d["menu"]
+		if d.has("permadeath"): sp_data["permadeath"] = d["permadeath"]
+		if d.has("tutorial"): sp_data["tutorial"] = d["tutorial"]
+		# transition_text lives on the scene_paths entry too -- the LoadScene
+		# prelude reassigns the `scene` arg from this so vanilla's label
+		# code shows the modded label.
+		sp_data["transition_text"] = entry["transition_text"]
 		if not _register_scene_path(id, sp_data):
-			# The scene_paths registration failed (probably a collision);
-			# abort the shelter register too to keep state consistent.
+			# scene_paths registration failed (probably collision); abort.
 			return false
 		auto_scene_path = true
 	ldr.shelters.append(id)
-	reg[id] = {"auto_scene_path": auto_scene_path, "data": d}
+	# Persist the full entry into the rewriter-injected dict on Loader so
+	# Compiler.Spawn's prelude can consult it.
+	if "_rtv_mod_shelters" in ldr:
+		ldr._rtv_mod_shelters[id] = entry
+	else:
+		push_warning("[Registry] register('%s', '%s'): Loader is missing _rtv_mod_shelters; rewriter didn't fire. Does any mod declare [registry]?" % [label, id])
+	reg[id] = {"auto_scene_path": auto_scene_path, "entry": entry, "kind": label}
 	_registry_registered["shelters"] = reg
-	_log_debug("[Registry] registered shelter '%s' (auto scene_path=%s)" % [id, auto_scene_path])
+	_log_debug("[Registry] registered %s '%s' (shelter=%s, connected_to='%s')" \
+			% [label, id, is_shelter, entry["connected_to"]])
 	return true
 
 func _remove_shelter(id: String) -> bool:
+	return _remove_shelter_or_map(id, "shelters")
+
+func _remove_map(id: String) -> bool:
+	return _remove_shelter_or_map(id, "maps")
+
+func _remove_shelter_or_map(id: String, label: String) -> bool:
 	var ldr := _loader_node()
 	if ldr == null:
 		return false
 	var reg: Dictionary = _registry_registered.get("shelters", {})
 	if not reg.has(id):
-		push_warning("[Registry] remove('shelters', '%s'): not a mod registration" % id)
+		push_warning("[Registry] remove('%s', '%s'): not a mod registration" % [label, id])
 		return false
-	var entry: Dictionary = reg[id]
+	var meta: Dictionary = reg[id]
+	# Cross-surface remove guard: don't let `remove('maps', X)` succeed if
+	# X was registered as a shelter (or vice versa). Less surprising than
+	# silently letting through.
+	if meta.get("kind", "shelters") != label:
+		push_warning("[Registry] remove('%s', '%s'): id was registered as '%s', use that registry to remove" \
+				% [label, id, meta.get("kind", "shelters")])
+		return false
 	var idx: int = ldr.shelters.find(id)
 	if idx >= 0:
 		ldr.shelters.remove_at(idx)
 	# Clean up the auto-created scene_paths entry too (if any).
-	if entry.get("auto_scene_path", false):
+	if meta.get("auto_scene_path", false):
 		_remove_scene_path(id)
+	if "_rtv_mod_shelters" in ldr:
+		ldr._rtv_mod_shelters.erase(id)
 	reg.erase(id)
 	_registry_registered["shelters"] = reg
-	_log_debug("[Registry] removed shelter '%s'" % id)
+	_log_debug("[Registry] removed %s '%s'" % [label, id])
 	return true
 
 # -------- random_scenes --------

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -461,6 +461,11 @@ func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, r
 			return _rtv_inject_prelude(lines, rename_prefix + "LoadScene", _rtv_loader_loadscene_prelude())
 		"FishPool.gd":
 			return _rtv_inject_prelude(lines, rename_prefix + "_ready", _rtv_fishpool_ready_prelude())
+		"Compiler.gd":
+			# Spawn's prelude assigns to vanilla's `spawnTarget` local, which
+			# is declared on the first body line. Insert after the run of
+			# leading var decls so spawnTarget is in scope.
+			return _rtv_inject_prelude(lines, rename_prefix + "Spawn", _rtv_compiler_spawn_prelude(), true)
 		_:
 			return lines
 
@@ -469,21 +474,47 @@ func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, r
 # renamed by the rewriter's pass 1, so callers pass the renamed name.
 # If the function has multiple blank lines at the top of its body, the
 # prelude slots in before them.
-func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_lines: PackedStringArray) -> PackedStringArray:
+#
+# `after_var_decls`: when true, insertion happens AFTER the run of leading
+# `var ...` and blank lines at the top of the body, rather than directly
+# under the signature. Use this when the prelude needs to reference a
+# local declared by vanilla (e.g. Compiler.Spawn's `spawnTarget`).
+func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_lines: PackedStringArray, after_var_decls: bool = false) -> PackedStringArray:
 	var needle := "func " + func_name + "("
-	var target := -1
+	var sig_target := -1
 	for i in lines.size():
 		var line: String = lines[i]
 		if line.begins_with(needle):
-			target = i
+			sig_target = i
 			break
-	if target < 0:
+	if sig_target < 0:
 		_log_info("[RTVCodegen] prelude injection: func %s not found (was it not parsed as hookable?)" % func_name)
 		return lines
+	var insert_after := sig_target
+	if after_var_decls:
+		# Advance past leading body lines that are blank or indented `var ...`
+		# declarations. Stop on the first indented line that isn't a var
+		# declaration. If we hit a top-level line first (next func or EOF),
+		# the function body was empty -- fall back to inserting at signature.
+		var j := sig_target + 1
+		while j < lines.size():
+			var ln: String = lines[j]
+			var stripped: String = ln.strip_edges()
+			if stripped == "":
+				j += 1
+				continue
+			# Top-level line means we ran out of body.
+			if not (ln.begins_with("\t") or ln.begins_with(" ")):
+				break
+			if stripped.begins_with("var "):
+				insert_after = j
+				j += 1
+				continue
+			break
 	var out: Array = []
 	for i in lines.size():
 		out.append(lines[i])
-		if i == target:
+		if i == insert_after:
 			for pl in prelude_lines:
 				out.append(pl)
 	var result := PackedStringArray()
@@ -530,23 +561,97 @@ func _rtv_loader_loadscene_prelude() -> PackedStringArray:
 	p.append("\t\tgameData.shelter = _rtv_scene_entry.get(\"shelter\", false)")
 	p.append("\t\tgameData.permadeath = _rtv_scene_entry.get(\"permadeath\", false)")
 	p.append("\t\tgameData.tutorial = _rtv_scene_entry.get(\"tutorial\", false)")
+	# B_Loader compat: if the entry carries a transition_text, reassign the
+	# `scene` arg so vanilla's `label.text = \"Loading \" + scene + \"...\"`
+	# below uses the modder's preferred display name. Vanilla never reads
+	# `scene` again after the label code, so it's safe to clobber.
+	p.append("\t\tvar _rtv_label: String = String(_rtv_scene_entry.get(\"transition_text\", \"\"))")
+	p.append("\t\tif _rtv_label != \"\":")
+	p.append("\t\t\tscene = _rtv_label")
 	p.append("\t# Fall through: vanilla if-elif won't match mod names; the tail")
 	p.append("\t# runs change_scene_to_file(scenePath) with our path set above.")
 	return p
 
 func _rtv_inject_loader_registry(indent: String) -> String:
-	# Loader.gd registry appendix. Adds the two mod-scene-path dicts and a
-	# snapshot of the vanilla shelters list for integrity/revert.
+	# Loader.gd registry appendix. Adds the mod-scene-path dicts, a snapshot
+	# of the vanilla shelters list for integrity/revert, and the rich
+	# shelter/map entries that Compiler.Spawn's prelude consults at world
+	# transition time (B_Loader-style add_shelter / add_map fields:
+	# transition_text, exit_spawn, entrance_spawn, connected_to,
+	# connected_content, shelter:bool).
+	#
+	# Also injects B_Loader compat shim methods (add_shelter / add_map) so
+	# mods written against the BitByteBytes B_Loader project keep working
+	# without requiring B_Loader as a dependency. The shim translates the
+	# legacy dict shape (map_name + scene_path) to our internal entry
+	# format and writes directly to _rtv_mod_shelters + shelters +
+	# _rtv_mod_scene_paths, mirroring what _register_shelter_or_map does on
+	# the RTVModLib side. Mods can migrate to lib.register at their own
+	# pace; until then, the existing call site Just Works.
 	#
 	# Note: _rtv_vanilla_shelters is captured at @onready time from the
 	# shelters var (which the const->var rewrite left populated with the
 	# vanilla list). The registry can diff shelters against this snapshot
 	# to tell vanilla entries apart from mod additions.
 	var I1 := indent
-	return "\n\n# --- Metro mod loader: Loader registry state ---\n" \
+	var I2 := indent + indent
+	var I3 := indent + indent + indent
+	var out: String = "\n\n# --- Metro mod loader: Loader registry state ---\n" \
 		+ "var _rtv_mod_scene_paths: Dictionary = {}\n" \
 		+ "var _rtv_override_scene_paths: Dictionary = {}\n" \
+		+ "var _rtv_mod_shelters: Dictionary = {}\n" \
 		+ "@onready var _rtv_vanilla_shelters: Array = shelters.duplicate()\n"
+	# B_Loader compat shim. Same dict shape as BitByteBytes/B_Loader README.
+	out += "\n# --- Metro mod loader: B_Loader compat shim ---\n"
+	out += "func add_shelter(d: Dictionary) -> bool:\n"
+	out += I1 + "return _rtv_bloader_compat_register(d, true)\n"
+	out += "\n"
+	out += "func add_map(d: Dictionary) -> bool:\n"
+	out += I1 + "return _rtv_bloader_compat_register(d, false)\n"
+	out += "\n"
+	out += "func _rtv_bloader_compat_register(d: Dictionary, default_shelter: bool) -> bool:\n"
+	out += I1 + "if not (d is Dictionary):\n"
+	out += I2 + "push_warning(\"[B_Loader compat] add_shelter/add_map expects a Dictionary\")\n"
+	out += I2 + "return false\n"
+	out += I1 + "var id: String = String(d.get(\"map_name\", \"\"))\n"
+	out += I1 + "if id == \"\":\n"
+	out += I2 + "push_warning(\"[B_Loader compat] dict is missing 'map_name'\")\n"
+	out += I2 + "return false\n"
+	out += I1 + "if _rtv_mod_shelters.has(id):\n"
+	out += I2 + "push_warning(\"[B_Loader compat] '\" + id + \"' already registered\")\n"
+	out += I2 + "return false\n"
+	out += I1 + "if id in shelters:\n"
+	out += I2 + "push_warning(\"[B_Loader compat] '\" + id + \"' already in vanilla shelters list\")\n"
+	out += I2 + "return false\n"
+	out += I1 + "var is_shelter: bool = bool(d.get(\"shelter\", default_shelter))\n"
+	# B_Loader uses 'scene_path'; our schema uses 'path'. Accept both.
+	out += I1 + "var scene_path: String = String(d.get(\"path\", d.get(\"scene_path\", \"\")))\n"
+	out += I1 + "var entry: Dictionary = {\n"
+	out += I2 + "\"shelter\": is_shelter,\n"
+	out += I2 + "\"transition_text\": String(d.get(\"transition_text\", id)),\n"
+	out += I2 + "\"exit_spawn\": String(d.get(\"exit_spawn\", \"\")),\n"
+	out += I2 + "\"entrance_spawn\": String(d.get(\"entrance_spawn\", \"\")),\n"
+	out += I2 + "\"connected_to\": String(d.get(\"connected_to\", \"\")),\n"
+	out += I2 + "\"connected_content\": d.get(\"connected_content\", []),\n"
+	out += I1 + "}\n"
+	out += I1 + "_rtv_mod_shelters[id] = entry\n"
+	out += I1 + "shelters.append(id)\n"
+	# Auto-register a scene_paths entry if a scene path was provided so the
+	# LoadScene prelude can route to it. Mirrors what _register_shelter_or_map
+	# does on the RTVModLib side.
+	out += I1 + "if scene_path != \"\":\n"
+	out += I2 + "var sp: Dictionary = {\n"
+	out += I3 + "\"path\": scene_path,\n"
+	out += I3 + "\"shelter\": is_shelter,\n"
+	out += I3 + "\"transition_text\": entry[\"transition_text\"],\n"
+	out += I2 + "}\n"
+	out += I2 + "if d.has(\"menu\"): sp[\"menu\"] = d[\"menu\"]\n"
+	out += I2 + "if d.has(\"permadeath\"): sp[\"permadeath\"] = d[\"permadeath\"]\n"
+	out += I2 + "if d.has(\"tutorial\"): sp[\"tutorial\"] = d[\"tutorial\"]\n"
+	out += I2 + "_rtv_mod_scene_paths[id] = sp\n"
+	out += I1 + "print(\"[B_Loader compat] registered '\" + id + \"' (shelter=\" + str(is_shelter) + \", connected_to='\" + entry[\"connected_to\"] + \"')\")\n"
+	out += I1 + "return true\n"
+	return out
 
 # AISpawner.gd transform: rewrite each `agent = <name>` inside _ready() so
 # the assignment goes through the _rtv_resolve_ai_type helper (defined in
@@ -593,6 +698,99 @@ func _rtv_fishpool_ready_prelude() -> PackedStringArray:
 	p.append("\t\tif _rtv_fe.pool_id == \"all\" or _rtv_fe.pool_id == name:")
 	p.append("\t\t\tif not (_rtv_fe.scene in species):")
 	p.append("\t\t\t\tspecies.append(_rtv_fe.scene)")
+	return p
+
+# Compiler.Spawn prelude: handles two B_Loader-style cases at function head.
+#
+#   1. Player just transitioned INTO a registered shelter or map. Run the
+#      vanilla load sequence (LoadWorld + LoadCharacter + optional
+#      LoadShelter + Simulation.simulate=true), set spawnTarget to the
+#      entry's exit_spawn, run the transition-pose loop ourselves, fire
+#      the gameData.* resets, and `return` so vanilla's if-elif chain
+#      doesn't double-process.
+#
+#   2. Player transitioned INTO a vanilla map that has at least one
+#      registered shelter/map hanging off it via `connected_to`. Spawn
+#      the connected_content props into /root/Map/Content additively. If
+#      the player is arriving FROM a registered shelter (previousMap is a
+#      mod entry name), pre-set spawnTarget to that entry's
+#      entrance_spawn -- vanilla's if-elif then runs LoadWorld/LoadChar
+#      etc as normal but its inner `if previousMap == ...` checks only
+#      know vanilla map names, so our spawnTarget survives. Fall through
+#      to vanilla so it handles the rest.
+#
+# Conditions for handling are checked against Loader._rtv_mod_shelters
+# (populated by _register_shelter_or_map). When the mod shelters dict is
+# empty (no relevant mod loaded), the prelude is effectively a tight
+# branch + early continue with no behavior change vs vanilla.
+func _rtv_compiler_spawn_prelude() -> PackedStringArray:
+	var p := PackedStringArray()
+	p.append("\t# --- Metro mod loader: shelters/maps registry prelude ---")
+	p.append("\tvar _rtv_map_node: Node = get_tree().current_scene.get_node_or_null(\"/root/Map\")")
+	p.append("\tif _rtv_map_node != null and \"_rtv_mod_shelters\" in Loader:")
+	p.append("\t\tvar _rtv_mn: String = String(_rtv_map_node.mapName)")
+	p.append("\t\tvar _rtv_entry: Dictionary = Loader._rtv_mod_shelters.get(_rtv_mn, {})")
+	# Case 1: arriving in a registered shelter / map.
+	p.append("\t\tif not _rtv_entry.is_empty():")
+	p.append("\t\t\tLoader.LoadWorld()")
+	p.append("\t\t\tLoader.LoadCharacter()")
+	p.append("\t\t\tif bool(_rtv_entry.get(\"shelter\", false)):")
+	p.append("\t\t\t\tLoader.LoadShelter(_rtv_mn)")
+	p.append("\t\t\tSimulation.simulate = true")
+	p.append("\t\t\tspawnTarget = String(_rtv_entry.get(\"exit_spawn\", \"\"))")
+	# Run the transition-pose loop ourselves so we can early-return. Reuses
+	# vanilla's `transitions` local declared above (the prelude lands after
+	# var decls thanks to after_var_decls=true on the inject call).
+	p.append("\t\t\tif spawnTarget != \"\":")
+	p.append("\t\t\t\tfor _rtv_t in transitions:")
+	p.append("\t\t\t\t\tif _rtv_t.owner.name == spawnTarget:")
+	p.append("\t\t\t\t\t\tvar _rtv_sp = _rtv_t.owner.spawn")
+	p.append("\t\t\t\t\t\tif _rtv_sp:")
+	p.append("\t\t\t\t\t\t\tcontroller.global_transform.basis = _rtv_sp.global_transform.basis")
+	p.append("\t\t\t\t\t\t\tcontroller.global_transform.basis = controller.global_transform.basis.rotated(Vector3.UP, deg_to_rad(180))")
+	p.append("\t\t\t\t\t\t\tcontroller.global_position = _rtv_sp.global_position")
+	p.append("\t\t\tgameData.isTransitioning = false")
+	p.append("\t\t\tgameData.isSleeping = false")
+	p.append("\t\t\tgameData.isOccupied = false")
+	p.append("\t\t\tgameData.freeze = false")
+	p.append("\t\t\treturn")
+	# Case 2: this map is connected_to for one or more registered shelters/maps.
+	p.append("\t\tfor _rtv_key in Loader._rtv_mod_shelters:")
+	p.append("\t\t\tvar _rtv_e: Dictionary = Loader._rtv_mod_shelters[_rtv_key]")
+	p.append("\t\t\tif String(_rtv_e.get(\"connected_to\", \"\")) != _rtv_mn:")
+	p.append("\t\t\t\tcontinue")
+	# Spawn connected_content additively.
+	p.append("\t\t\tvar _rtv_content: Node = get_tree().current_scene.get_node_or_null(\"/root/Map/Content\")")
+	p.append("\t\t\tif _rtv_content != null:")
+	p.append("\t\t\t\tvar _rtv_items: Array = _rtv_e.get(\"connected_content\", [])")
+	p.append("\t\t\t\tfor _rtv_item in _rtv_items:")
+	p.append("\t\t\t\t\tif not (_rtv_item is Dictionary):")
+	p.append("\t\t\t\t\t\tcontinue")
+	p.append("\t\t\t\t\tvar _rtv_p: String = String(_rtv_item.get(\"path\", \"\"))")
+	p.append("\t\t\t\t\tif _rtv_p == \"\":")
+	p.append("\t\t\t\t\t\tcontinue")
+	p.append("\t\t\t\t\tvar _rtv_packed = load(_rtv_p)")
+	p.append("\t\t\t\t\tif _rtv_packed == null:")
+	p.append("\t\t\t\t\t\tpush_warning(\"[Registry] connected_content: failed to load \" + _rtv_p)")
+	p.append("\t\t\t\t\t\tcontinue")
+	p.append("\t\t\t\t\tvar _rtv_inst = _rtv_packed.instantiate()")
+	p.append("\t\t\t\t\tif \"position\" in _rtv_item:")
+	p.append("\t\t\t\t\t\t_rtv_inst.position = _rtv_item[\"position\"]")
+	p.append("\t\t\t\t\tif \"rotation\" in _rtv_item:")
+	p.append("\t\t\t\t\t\t_rtv_inst.rotation_degrees = _rtv_item[\"rotation\"]")
+	p.append("\t\t\t\t\t_rtv_content.add_child(_rtv_inst)")
+	# Refresh the locals `transitions` and `waypoints`: vanilla captured
+	# them at the top of Spawn() BEFORE our connected_content was added,
+	# so any Transition / AI_WP node inside the freshly spawned scenes
+	# wouldn't be in the original snapshot. Without this, the tail's
+	# pose-loop misses the entrance_spawn target and any modded waypoint
+	# spawn never participates in the random-pick fallback.
+	p.append("\t\t\ttransitions = get_tree().get_nodes_in_group(\"Transition\")")
+	p.append("\t\t\twaypoints = get_tree().get_nodes_in_group(\"AI_WP\")")
+	# If player is arriving from this mod shelter, pre-set entrance_spawn.
+	p.append("\t\t\tif String(gameData.previousMap) == _rtv_key:")
+	p.append("\t\t\t\tspawnTarget = String(_rtv_e.get(\"entrance_spawn\", \"\"))")
+	p.append("\t# Fall through to vanilla if-elif (which handles vanilla maps).")
 	return p
 
 func _rtv_inject_aispawner_registry(indent: String) -> String:

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1134,11 +1134,34 @@ func show_mod_ui() -> void:
 	launch_btn.add_theme_stylebox_override("pressed", ls_p)
 	launch_btn.add_theme_color_override("font_color", Color(0.88, 0.88, 0.88))
 	launch_btn.add_theme_color_override("font_hover_color", Color(1.0, 1.0, 1.0))
+
+	# Always-visible self-version label sitting between the hint and Launch.
+	# Default state shows the installed version in dim gray; the
+	# _check_modloader_update_async coroutine flips it to orange and rewrites
+	# the text when ModWorkshop reports a newer release. Click opens the mod
+	# page in the system browser regardless of state.
+	var alert := LinkButton.new()
+	alert.text = "Mod Loader v" + MODLOADER_VERSION
+	alert.underline = LinkButton.UNDERLINE_MODE_ON_HOVER
+	alert.add_theme_font_size_override("font_size", 11)
+	alert.add_theme_color_override("font_color", Color(0.45, 0.45, 0.45))
+	alert.add_theme_color_override("font_hover_color", Color(0.78, 0.78, 0.78))
+	alert.pressed.connect(func():
+		OS.shell_open(MODWORKSHOP_PAGE_URL_TEMPLATE % str(MODLOADER_MODWORKSHOP_ID))
+	)
+	bottom.add_child(alert)
+	_ui_update_alert_btn = alert
+
 	bottom.add_child(launch_btn)
 	_ui_launch_btn = launch_btn
 
 	# Closing the window with X should behave the same as clicking Launch.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
+
+	# Fire-and-forget self-update check. Updates _ui_update_alert_btn and may
+	# pop the one-shot dialog when the API returns. Guards on
+	# is_instance_valid so a launcher close mid-flight is harmless.
+	_check_modloader_update_async()
 
 	var mods_tab := build_mods_tab(tabs)
 	mods_tab.name = "Mods"
@@ -1166,6 +1189,7 @@ func show_mod_ui() -> void:
 	_ui_window = null
 	_ui_hint_label = null
 	_ui_launch_btn = null
+	_ui_update_alert_btn = null
 	win.queue_free()
 
 # Pessimistic label: any enabled mod -> "(Restart)". Over-warn beats a
@@ -2170,3 +2194,80 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 					dl_btn.text = "Retry"
 					add_log.call(mod_name + " -- download failed.")
 			)
+
+# ----- modloader self-update check ----------------------------------------
+
+# Fire-and-forget from show_mod_ui. Hits the ModWorkshop versions API for
+# our own mod id, compares the result against MODLOADER_VERSION, and on a
+# newer release: reveals the launch-row LinkButton, and pops a one-shot
+# dialog the first session each new version is detected. All UI mutations
+# guard on is_instance_valid because the launcher may close before the
+# HTTP request returns.
+func _check_modloader_update_async() -> void:
+	if MODLOADER_MODWORKSHOP_ID <= 0:
+		return
+	var ids: Array[int] = [MODLOADER_MODWORKSHOP_ID]
+	var latest_map: Dictionary = await fetch_latest_modworkshop_versions(ids)
+	var raw = latest_map.get(str(MODLOADER_MODWORKSHOP_ID), null)
+	if raw == null:
+		return
+	var latest := str(raw)
+	if latest.is_empty():
+		return
+	_modloader_latest_version = latest
+	if compare_versions(latest, MODLOADER_VERSION) <= 0:
+		return  # installed is current or newer
+
+	if is_instance_valid(_ui_update_alert_btn):
+		_ui_update_alert_btn.text = "Mod Loader v%s -- v%s available, click to update" % [MODLOADER_VERSION, latest]
+		_ui_update_alert_btn.add_theme_color_override("font_color", Color(1.0, 0.55, 0.45))
+		_ui_update_alert_btn.add_theme_color_override("font_hover_color", Color(1.0, 0.78, 0.65))
+
+	# Pop the dialog only the first session this specific new version is
+	# seen. Stays quiet on subsequent launches until ModWorkshop ships a
+	# newer one. The launch-row alert remains visible regardless.
+	var last_seen := _modloader_update_last_seen_version()
+	if last_seen != latest:
+		_show_modloader_update_dialog(latest)
+
+func _modloader_update_last_seen_version() -> String:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return ""
+	return str(cfg.get_value("modloader_update", "last_seen_version", ""))
+
+func _modloader_update_mark_seen(latest: String) -> void:
+	var cfg := ConfigFile.new()
+	cfg.load(UI_CONFIG_PATH)
+	cfg.set_value("modloader_update", "last_seen_version", latest)
+	cfg.save(UI_CONFIG_PATH)
+
+# One-shot popup the first session each new modloader version is detected.
+# "Open Page" launches the ModWorkshop browser tab; either action writes the
+# latest version into mod_config.cfg so the dialog stays quiet on subsequent
+# launches until ModWorkshop ships another version.
+func _show_modloader_update_dialog(latest: String) -> void:
+	if not is_instance_valid(_ui_window):
+		return
+	var d := ConfirmationDialog.new()
+	d.title = "Mod Loader update available"
+	d.ok_button_text = "Open Page"
+	d.cancel_button_text = "Dismiss"
+	d.dialog_autowrap = true
+	d.min_size = Vector2(440, 120)
+	d.dialog_text = "A newer version of the Mod Loader is available on ModWorkshop.\n\n" \
+			+ "    Installed: v%s\n    Available: v%s\n\n" % [MODLOADER_VERSION, latest] \
+			+ "Open the ModWorkshop page to download?"
+	_attach_ui_dialog(d)
+	d.exclusive = true
+	d.always_on_top = true
+	_connect_dialog_exits(d,
+		func():
+			OS.shell_open(MODWORKSHOP_PAGE_URL_TEMPLATE % str(MODLOADER_MODWORKSHOP_ID))
+			_modloader_update_mark_seen(latest)
+			d.queue_free(),
+		func():
+			_modloader_update_mark_seen(latest)
+			d.queue_free()
+	)
+	d.popup_centered()


### PR DESCRIPTION
Extends [#66](https://github.com/ametrocavich/vostok-mod-loader/pull/66) which already brought 10 PRs to master. Two more PRs landed on `development` after that release PR merged and need to ship in the same v3.2.0 cycle.

## What's new in this PR (vs #66's already-merged state)

- [#67](https://github.com/ametrocavich/vostok-mod-loader/pull/67) **B_Loader compat shim** by @tetrahydroc -- mods that call `Loader.add_shelter` / `Loader.add_map` Just Work without B_Loader installed. Adds `Registry.MAPS` slot, `Compiler.Spawn` prelude for shelter / connected-map transitions, generalized `_rtv_inject_prelude` with `after_var_decls`. Reviewed against the actual B_Loader.vmz; vanilla `LoadWorld()` confirmed non-destructive so the prelude's content-spawn order is fine.
- [#70](https://github.com/ametrocavich/vostok-mod-loader/pull/70) **Launcher update indicator** -- inline self-update check in the launch row. Dim `Mod Loader vX.Y.Z` LinkButton by default; turns orange when ModWorkshop reports a newer version. One-shot dialog the first session each new version is detected, with `[modloader_update] last_seen_version` in `mod_config.cfg` to suppress repeats. Offline path: silent no-op.

## Effect on the in-flight v3.2.0 release

Release-please's chore PR [#68](https://github.com/ametrocavich/vostok-mod-loader/pull/68) is currently sized for the 10 PRs from #66. After this merges, the bot will refresh #68 to include #67 and #70 too. The CHANGELOG hand-edit grows by one entry (#67 needs a manual Features line because its squash dropped the `feat:` prefix; #70 keeps its prefix and will be auto-categorized).

## Test plan

- [ ] B_Loader compat: drop `B_Loader.vmz` (or any mod that calls `Loader.add_shelter` / `Loader.add_map`) into the mods folder; confirm the registry shim activates from the call-site detection without `[registry]` in `mod.txt`.
- [ ] B_Loader connected_to flow: trigger a transition into a vanilla map that has a registered mod-shelter `connected_to` it; confirm `connected_content` items spawn and the `entrance_spawn` target positions the player.
- [ ] Self-update indicator: launcher shows `Mod Loader vX.Y.Z` in the launch row; clicking opens https://modworkshop.net/mod/55623 in browser.
- [ ] Self-update with spoofed older `MODLOADER_VERSION`: confirm orange `vX -- vY available` text and the one-shot dialog fire; subsequent launches suppress the dialog.
- [ ] Offline path: launcher opens with API blocked, dim baseline `Mod Loader vX.Y.Z` stays.

## Merge note

Same as #66: merge as **merge commit** (master ruleset enforces this), not squash. Preserves the conventional commit messages so release-please can refresh #68's changelog.