### PR TITLE
docs: quote [hooks] and [script_extend] examples in mod.txt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ v3.0.1 uses an opt-in model: a modlist that declares nothing loads byte-identica
 
 ```ini
 [script_extend]
-res://Scripts/Camera.gd = res://MyMod/MyCamera.gd
+res://Scripts/Camera.gd = "res://MyMod/MyCamera.gd"
 
 [registry]
 ; declaring this section is enough to enable lib.register() / lib.override()
@@ -84,11 +84,13 @@ res://Scripts/Camera.gd = res://MyMod/MyCamera.gd
 
 ```ini
 [hooks]
-res://Scripts/Interface.gd = _ready, update_tooltip   # specific methods
-res://Scripts/Controller.gd = *                       # or wrap all methods
+res://Scripts/Interface.gd = "_ready, update_tooltip"   # specific methods
+res://Scripts/Controller.gd = "*"                       # or wrap all methods
 ```
 
-The `*` (or an empty value) wraps every hookable method in the script. Use it when you don't know up front which methods you'll hook or the list is long enough that enumerating is noise.
+Quote the value -- ConfigFile parses RHS as a Variant literal, so unquoted method lists or a bare `*` raise "Unexpected identifier" and the entire `mod.txt` fails to parse (silently breaking every mod that loads after yours). Our loader auto-wraps unquoted values for backward compat, but mods are more portable when written quoted.
+
+The `*` (or an empty value, written as `""`) wraps every hookable method in the script. Use it when you don't know up front which methods you'll hook or the list is long enough that enumerating is noise.
 
 Full schema (including `[rtvmodlib] needs=`, the `!` prefix semantics, and packaging gotchas): see the [Mod-Format wiki page](https://github.com/ametrocavich/vostok-mod-loader/wiki/Mod-Format).
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -67,10 +67,12 @@ For these, declare the vanilla script path in `mod.txt`:
 
 ```ini
 [hooks]
-res://Scripts/Interface.gd = _ready, update_tooltip   # specific methods
-res://Scripts/Controller.gd = *                       # wildcard -- all methods
-res://Scripts/Camera.gd =                             # empty value == *
+res://Scripts/Interface.gd = "_ready, update_tooltip"   # specific methods
+res://Scripts/Controller.gd = "*"                       # wildcard -- all methods
+res://Scripts/Camera.gd = ""                            # empty value == *
 ```
+
+Quote the value. ConfigFile parses RHS as a Variant literal, so unquoted method lists or a bare `*` raise "Unexpected identifier" and the entire `mod.txt` fails to parse (silently breaks every mod that loads after yours, since later sections never get read). Our loader auto-wraps unquoted values for backward compat, but mods are more portable when written quoted.
 
 Method names in the list are case-insensitive (normalized to lowercase on write). The wildcard leaves the inner mask empty, which the generator reads as "wrap every non-static method."
 

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -49,10 +49,10 @@ EarlyNode="!res://MyMod/Early.gd"
 modworkshop=12345
 
 [hooks]
-res://Scripts/Interface.gd = _ready, update_tooltip
+res://Scripts/Interface.gd = "_ready, update_tooltip"
 
 [script_extend]
-res://Scripts/Camera.gd = res://MyMod/MyCamera.gd
+res://Scripts/Camera.gd = "res://MyMod/MyCamera.gd"
 
 [registry]
 ; empty section is enough -- presence enables the registry API
@@ -116,10 +116,12 @@ Format:
 
 ```ini
 [hooks]
-res://Scripts/Interface.gd = _ready, update_tooltip   # specific methods
-res://Scripts/Controller.gd = *                       # wildcard -- all methods
-res://Scripts/Camera.gd =                             # empty == *
+res://Scripts/Interface.gd = "_ready, update_tooltip"   # specific methods
+res://Scripts/Controller.gd = "*"                       # wildcard -- all methods
+res://Scripts/Camera.gd = ""                            # empty == *
 ```
+
+Quote the value (right-hand side). ConfigFile parses RHS as a Variant literal, so unquoted method lists like `_ready, update_tooltip` and bare `*` are rejected as "Unexpected identifier". Our loader auto-wraps unquoted values for backward compat, but mods are more portable (other loaders, raw `ConfigFile.parse()`) when written quoted from the start.
 
 Method names are case-insensitive (normalized to lowercase on write to match the rewriter's comparison). The wildcard leaves the inner mask empty; the generator reads that as "wrap every non-static method."
 
@@ -131,8 +133,10 @@ Full-script replacement that chains via Godot's `extends` resolution.
 
 ```ini
 [script_extend]
-res://Scripts/Camera.gd = res://MyMod/MyCamera.gd
+res://Scripts/Camera.gd = "res://MyMod/MyCamera.gd"
 ```
+
+Quote the value -- ConfigFile parses RHS as a Variant, and `res://...` unquoted tokenizes as the identifier `res` and errors. Unlike `[hooks]`, `[script_extend]` values are *not* auto-wrapped by the loader, so quoting here is mandatory, not just a portability nicety.
 
 The mod script is expected to `extends "res://Scripts/Camera.gd"`. Applied in priority order (lowest first). Each subsequent override's `extends` resolves to the previous chain tip, forming `ModC -> ModB -> ModA -> (rewritten_)vanilla`.
 


### PR DESCRIPTION
## Summary

The wiki and README examples for `[hooks]` and `[script_extend]` were shown unquoted, e.g. `res://Scripts/Interface.gd = _ready, update_tooltip`. ConfigFile.parse parses RHS as a Variant literal -- bare `_ready` or `res://...` raises **\"Unexpected identifier\"** and the entire `mod.txt` fails to parse, silently breaking every mod that loads after the offending one. (This is the exact failure tetra hit reading NPCESP's `mod.txt` without his MML's preprocessor in the loop.)

Why our docs got it wrong: our loader has a `[hooks]`-only preprocessor (`_quote_unquoted_hooks_values` in `modloader.gd:521`) that auto-wraps unquoted values, so mods written against our examples work here. But they don't work against tetra's MML or raw `ConfigFile.parse()`. `[script_extend]` has no preprocessor, so quoting there is mandatory.

Edits:
- README -- `[hooks]` and `[script_extend]` example blocks
- `docs/wiki/Mod-Format.md` -- overview snippet + `[hooks]` and `[script_extend]` section examples
- `docs/wiki/Hooks.md` -- `[hooks]` escape hatch example

Each block now shows the quoted form plus a one-paragraph note explaining the parser behavior and the auto-wrap caveat.

## Verification

Ran the proposed forms through real Godot 4.6.1 `ConfigFile.parse()`:

| Form | Result |
|---|---|
| `path = _ready, update_tooltip` | ERR `Unexpected identifier '_ready'` |
| `path = *` | ERR `Expected value, got 'ERROR'` |
| `path =` | ERR `Expected value, got 'EOF'` |
| `path = res://MyMod/Foo.gd` | ERR `Unexpected identifier 'res'` |
| `path = \"_ready, update_tooltip\"` | OK |
| `path = \"*\"` | OK |
| `path = \"\"` | OK |
| `path = \"res://MyMod/Foo.gd\"` | OK |

The `Unexpected identifier` errors map to `core/variant/variant_parser.cpp:1619`. AI Overhaul's deployed `mod.txt` already uses the quoted form (`res://Scripts/Character.gd = \"Health, ...\"`), confirming it's the right canonical shape.

## Test plan

- [ ] Author writing a mod against the new docs gets a `mod.txt` that parses under raw ConfigFile (and therefore under any other loader, including tetra's MML).
- [ ] Existing mods written against the old (unquoted) wiki continue to load on our loader -- the `_quote_unquoted_hooks_values` preprocessor still wraps `[hooks]` automatically; no behavior change for those.
- [ ] After merge, push the wiki source to the GitHub wiki repo so the rendered pages match.