### PR TITLE
fix: registry follow-ups from PR #69 review

### DIFF
--- a/src/registry.gd
+++ b/src/registry.gd
@@ -374,6 +374,14 @@ func _array_op_dispatch(registry: String, id: Variant, field: String, op: String
 	if field == "":
 		push_warning("[Registry] %s(%s, ...) called with empty field" % [op, registry])
 		return false
+	# Reject null up front. Without this, _coerce_to_array(null) returns
+	# [null] (not []), the empty-check passes, and the typed-array validator
+	# rejects null with a misleading "rejected by typed-array constraint"
+	# message that doesn't tell the caller the real problem.
+	if values == null:
+		push_warning("[Registry] %s('%s', %s): null is not a valid value (pass a value or an Array of values)" \
+				% [op, registry, str(id)])
+		return false
 	var arr: Array = _coerce_to_array(values)
 	if arr.is_empty():
 		push_warning("[Registry] %s('%s', ...): empty values is a no-op" % [op, registry])
@@ -671,8 +679,19 @@ func revert_many(registry: String, entries: Dictionary) -> Dictionary:
 	var results: Dictionary = {}
 	var all_ok := true
 	for id in entries.keys():
-		var fields_arg: Array = entries[id] if entries[id] is Array else []
-		var ok: bool = revert(registry, id, fields_arg)
+		var v: Variant = entries[id]
+		# Strict: a non-Array value (typo like {id: "field_name"} instead of
+		# {id: ["field_name"]}) used to silently coerce to [] and trigger a
+		# full revert, losing other unrelated patches on the same id. Reject
+		# instead so the caller sees the typo. Pass [] explicitly for full
+		# revert.
+		if not (v is Array):
+			push_warning("[Registry] revert_many('%s', '%s'): value must be an Array of field names (use [] for full revert); got %s. Skipping." \
+					% [registry, str(id), type_string(typeof(v))])
+			results[id] = false
+			all_ok = false
+			continue
+		var ok: bool = revert(registry, id, v)
 		results[id] = ok
 		if not ok:
 			all_ok = false

--- a/src/registry/aggregators.gd
+++ b/src/registry/aggregators.gd
@@ -387,7 +387,10 @@ func _register_furniture_bundle(id: String, data: Variant) -> Dictionary:
 		"trader_pool_count": 0,
 		"trader_pools": [],
 		"trader_pools_failed": [],
-		"recipe": false,
+		# null = recipe not requested; bool = requested + outcome.
+		# Matches register_weapon's `ai_loadout` convention so callers can
+		# distinguish "I never asked for one" from "I asked, it failed".
+		"recipe": null,
 	}
 	if not (data is Dictionary):
 		push_warning("[Registry] register_furniture('%s', ...) expects Dictionary" % id)


### PR DESCRIPTION
## Summary

Three small fixes addressing review feedback on #69 (Aggregators, new registry verbs, setup fan-out). Each was reproduced and verified with a runtime probe (Bug69Probe) that exercised the buggy paths and printed `FIX VERIFIED` after the changes.

- **`revert_many`: reject non-Array entries.** Previously `revert_many(reg, {id: \"field_name\"})` silently coerced the string to `[]` (the "full revert" sentinel), unwinding every patch on that id when the caller likely meant to revert just `\"field_name\"`. Now warns + skips with per-id `false`. To full-revert an id, pass `[]` explicitly.
- **`_array_op_dispatch`: reject `null` up front.** `append`/`prepend`/`remove_from` with `values=null` slipped past `_coerce_to_array` (which returned `[null]`, not `[]`), past the empty check, and into the typed-array validator. The user got a misleading `\"rejected by typed-array constraint\"` warning. Now warns `\"null is not a valid value (pass a value or an Array of values)\"` before any coercion runs.
- **`register_furniture`: `recipe` initial value `false` -> `null`.** A successful furniture register that didn't request a recipe returned `recipe: false`, indistinguishable from "recipe attempted, failed". Switched to `null` to match `register_weapon`'s `ai_loadout` convention (`null` = not requested, `bool` = requested + outcome).

Out of scope: the AI prelude idempotency concern from the review remained unconfirmed during testing (the probe AI was in Area05 / Bandit category but `weapons` count stayed stable across repeat `SelectWeapon` calls -- could be no bug, could be vanilla `SelectWeapon` reaping the prelude's add). Not addressed in this PR.

Also unaddressed but worth a follow-up: the wiki's `Registry.md` examples use the full `res://` path as the item id, but `_lookup_item` keys by the `file` field (e.g. `\"AKM\"` for AKM). Either the wiki should change all examples to the bare id or `_lookup_item` should accept both forms.

## Test plan

- [x] `revert_many({\"AKM\": \"damage\"})` after patching damage+weight on AKM -> warning fires, both fields stay patched, results.AKM = false
- [x] `register_furniture({\"x\": 12345})` -> result.results.x.recipe == null (not false)
- [x] `append(ITEMS, \"AKM\", \"compatible\", null)` -> warning text mentions \"null is not a valid value\"
- [ ] AI prelude idempotency: not verified (needs Bandit/Guard/Military zone load + before/after children list snapshot)