### PR TITLE
feat: add mod dependency declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Road to Vostok -- Community Mod Loader
 
-Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods, load order, and updates.
+Mod loader for Road to Vostok (Godot 4.6). Adds a main-menu manager for mods, load order, and updates.
 
 **Developer docs**: [Wiki](https://github.com/ametrocavich/vostok-mod-loader/wiki) -- architecture, hook internals, mod format schema, stability canaries, limitations.
 
@@ -17,21 +17,21 @@ Mod loader for Road to Vostok (Godot 4.6). Adds a pre-game UI for managing mods,
    ```
 2. Create a `mods` folder there if it doesn't exist.
 3. Drop `.vmz` files into `mods/`.
-4. Launch the game. The mod loader UI appears before the main menu.
+4. Launch the game. The saved profile loads automatically; use the main-menu **Mods** button to open the manager.
 
-## Launcher UI
+## Mod Manager
 
-Two tabs:
+The manager opens from the main-menu **Mods** button:
 
 - **Mods** -- detected mods with checkboxes and a priority spinbox. Higher priority loads later and wins file conflicts. Load-order preview on the right updates in real time.
 - **Updates** -- for mods with `[updates] modworkshop=<id>` in `mod.txt`, check for and download updates from ModWorkshop.
-- **Dependencies** -- for mods with `[dependencies] required=[...]` in `mod.txt`, identify missing/disabled requirements and skip mods whose required dependencies are not loadable.
+- Dependency notices appear in the Mods tab for mods with `[dependencies] required=[...]` in `mod.txt`; mods whose required dependencies are not loadable are skipped.
 
-Click **Launch Game** or close the window to start.
+Click **Close** or close the window to return to the game. If you changed the active profile, enabled state, priorities, or Developer Mode after boot, the button becomes **Apply & Restart** so the new mod set can take effect.
 
 ### Guardrails
 
-The launcher does a static scan of every mod's source for a small set of patterns that have been seen in actual malicious mods (obfuscated string decoding paired with process spawning, anti-debug crashes, ransomware-setup calls). Mods that match get a small red "suspicious code" tag in the list, and clicking **Launch Game** with one enabled pops a confirmation dialog before the game starts.
+The manager does a static scan of every mod's source for a small set of patterns that have been seen in actual malicious mods (obfuscated string decoding paired with process spawning, anti-debug crashes, ransomware-setup calls). Mods that match get a small red "suspicious code" tag in the list. Startup also logs a warning if any enabled mod has suspicious-code findings.
 
 This is **not** a virus scanner. It catches lazy / copy-paste attacks; a determined attacker with the modloader source can write around the patterns. Loading is never silently blocked -- you can confirm and launch any mod. The scanner exists to slow down the obvious cases, nothing more. Always install mods from sources you trust.
 
@@ -153,7 +153,7 @@ Full API reference, dispatch semantics, and three-entry pack recipe: [Hooks wiki
 
 ## Troubleshooting
 
-**From the UI**: click **Reset to Vanilla** in the pre-launch window. Wipes mod state (hook pack, override.cfg, pass state), unchecks every mod, restarts clean. Your mods stay in `mods/`.
+**From the UI**: click **Reset to Vanilla** in the manager window. Wipes mod state (hook pack, override.cfg, pass state), unchecks every mod, restarts clean. Your mods stay in `mods/`.
 
 **If the game crashes or won't launch**:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Two tabs:
 
 - **Mods** -- detected mods with checkboxes and a priority spinbox. Higher priority loads later and wins file conflicts. Load-order preview on the right updates in real time.
 - **Updates** -- for mods with `[updates] modworkshop=<id>` in `mod.txt`, check for and download updates from ModWorkshop.
+- **Dependencies** -- for mods with `[dependencies] required=[...]` in `mod.txt`, identify missing/disabled requirements and skip mods whose required dependencies are not loadable.
 
 Click **Launch Game** or close the window to start.
 
@@ -50,6 +51,10 @@ MyModMain="res://MyMod/Main.gd"
 
 [updates]
 modworkshop=12345
+
+[dependencies]
+required=["mod_configuration_menu"]
+optional=["some_soft_integration"]
 ```
 
 | Field | Description |
@@ -60,6 +65,7 @@ modworkshop=12345
 | `priority` | Higher loads later, wins file conflicts. Default 0 |
 | `[autoload]` | `Name="res://path.gd"` (or `.tscn`). Prefix value with `!` to load before the game's own autoloads |
 | `[updates] modworkshop` | ModWorkshop mod ID |
+| `[dependencies] required/optional` | Godot string arrays of mod IDs. Required deps must be installed, enabled, and load before the dependent mod |
 
 Mods without `mod.txt` still mount as resource packs -- their files override vanilla resources, but no autoloads run.
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -26,7 +26,7 @@ Defined at [src/boot.gd:32](https://github.com/ametrocavich/vostok-mod-loader/bl
 6. **Exe mtime check** -- if the game exe was updated since last session, wipe hook cache (vanilla scripts may have changed).
 7. **Archive existence scan** -- if any archive from last session is missing, write a clean `override.cfg` and reset.
 8. **Mount loop** -- each archive via `ProjectSettings.load_resource_pack`, with `.vmz -> .zip` fallback.
-9. **Hook pack preempt mount** ([boot.gd:200-260](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L200)) -- mount `user://modloader_hooks/framework_pack.zip` with `replace_files=true`, then force a fresh source-compile of each script in `hook_pack_wrapped_paths` via `ResourceLoader.load(..., CACHE_MODE_IGNORE)` + `take_over_path`. Scripts not in that set are left to Godot's lazy-compile path. When no mods are loaded at all the pack file doesn't exist and this step short-circuits; when mods are loaded but none opt into the hook surface, `hook_pack_wrapped_paths` narrows to just `res://Scripts/Menu.gd` (the core-owned wrap for the launcher's main-menu button) -- legacy loadouts boot with that one script preempted and nothing else.
+9. **Hook pack preempt mount** ([boot.gd:200-260](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/boot.gd#L200)) -- mount `user://modloader_hooks/framework_pack.zip` with `replace_files=true`, then force a fresh source-compile of each script in `hook_pack_wrapped_paths` via `ResourceLoader.load(..., CACHE_MODE_IGNORE)` + `take_over_path`. Scripts not in that set are left to Godot's lazy-compile path. Even when no user mods are loaded, `hook_pack_wrapped_paths` narrows to just `res://Scripts/Menu.gd` (the core-owned wrap for the manager's main-menu button) so users can still open the manager from the menu.
 10. **Test pack mount** (dev-only, gated on `user://test_pack_precedence.zip` presence).
 
 The hook pack preempt is the only way to rewire scripts Godot pre-compiles during `class_cache` population. Once pinned, runtime `source_code + reload()` and `CACHE_MODE_IGNORE + take_over_path` both fail against autoload-backed scripts (see [Limitations](Limitations)).
@@ -42,8 +42,7 @@ compile regex, build class_name lookup, load dev-mode setting
 collect_mod_metadata()          # scan <exe>/mods/ -- no mounting
 clean_stale_cache
 load_ui_config
-await show_mod_ui()             # user configures and clicks Launch Game
-save_ui_config
+save_ui_config                  # persist migrations/default profile; no startup UI
 load_all_mods()                 # mount archives, scan, queue autoloads
 _apply_script_overrides         # from [script_overrides] in mod.txt
 sections    = _build_autoload_sections()

--- a/docs/wiki/Config-Files.md
+++ b/docs/wiki/Config-Files.md
@@ -18,7 +18,7 @@ Three sentinel files live in the **game's install directory** (next to the `.exe
 
 ## `mod_config.cfg` -- your profiles and settings
 
-This is the user-facing config. The pre-launch UI reads and writes it. Plain INI, safe to inspect or edit by hand.
+This is the user-facing config. The main-menu manager UI reads and writes it. Plain INI, safe to inspect or edit by hand.
 
 ### Shape
 
@@ -97,7 +97,7 @@ Copy `mod_config.cfg` somewhere safe. That one file contains all profiles and se
 **Copy your setup to another install**
 Two ways:
 1. **Full config copy** -- copy `mod_config.cfg` and paste into the same path on the other machine. Carries every profile + settings.
-2. **Shareable profile payload** -- in-game, open the launcher, click **Share** on the profile, copy the `MTRPRF1....` string, paste into Discord / whatever, recipient clicks **Import** and pastes. Carries only that one profile. See [Profile-Format](Profile-Format) for the wire format.
+2. **Shareable profile payload** -- in-game, open the manager from the main-menu Mods button, click **Share** on the profile, copy the `MTRPRF1....` string, paste into Discord / whatever, recipient clicks **Import** and pastes. Carries only that one profile. See [Profile-Format](Profile-Format) for the wire format.
 
 **Reset one profile to empty**
 Delete its two sections (`[profile.<name>.enabled]` and `[profile.<name>.priority]`). Keep your other profiles.

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -53,7 +53,7 @@ v3.1.1 uses an opt-in model: **a modlist that declares nothing produces no wrap,
 | `[registry]` in `mod.txt` | Turn on the registry (see [Registry](Registry)) |
 | `[script_extend]` in `mod.txt` | Chain-by-extends overrides |
 
-The rewrite surface equals the union of those triggers. When no user mod declares anything, the loader logs `[RTVCodegen] No user opt-in declarations ([hooks] / .hook() / [registry]) -- user mods run against unmodified vanilla (v2.1.0-equivalent). Pack contains core hooks only.` at boot. User mods' vanilla targets stay byte-identical; the pack contains only a core-owned wrap on `Menu.gd :: _ready` that injects the launcher's "Mods" button into the main menu. When no mods are loaded at all, pack generation is skipped entirely (no file written).
+The rewrite surface equals the union of those triggers. When no user mod declares anything, the loader logs `[RTVCodegen] No user opt-in declarations ([hooks] / .hook() / [registry]) -- user mods' vanilla targets run unmodified (v2.1.0-equivalent). Pack contains core hooks only.` at boot. User mods' vanilla targets stay byte-identical; the pack contains only a core-owned wrap on `Menu.gd :: _ready` that injects the manager's "Mods" button into the main menu. When no mods are loaded at all, the pack still contains that core hook so the manager remains reachable.
 
 ### `[hooks]` escape hatch
 
@@ -334,7 +334,7 @@ Each rewritten vanilla script ships as three zip entries in the hook pack:
 
 This entire recipe lives in `user://modloader_hooks/framework_pack.zip`. The pack mounts with `replace_files=true`, which makes our entries win over the PCK's same-path entries in Godot's VFS layering.
 
-Under the cutover, pack generation is skipped entirely when no mods are loaded. When mods are loaded but none opt into the hook surface, the pack still ships -- but it contains only the core-owned wrap on `Menu.gd :: _ready` for the launcher's main-menu "Mods" button. `hook_pack_wrapped_paths` in pass state narrows to just `res://Scripts/Menu.gd`, so next session's static-init preempt touches that single script and nothing else. User mods' targets stay unmodified.
+Under the cutover, pack generation still writes a core-only pack when no mods are loaded, because the startup manager no longer appears. The pack contains only the core-owned wrap on `Menu.gd :: _ready` for the manager's main-menu "Mods" button. `hook_pack_wrapped_paths` in pass state narrows to just `res://Scripts/Menu.gd`, so next session's static-init preempt touches that single script and nothing else. User mods' targets stay unmodified.
 
 ## Activation + fallback
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -129,7 +129,7 @@ For mods that register hooks alongside registry mutations as a single installati
 | `skip_super() -> void` | Inside a replace callback: prevent the vanilla body from running on return |
 | `seq() -> int` | Monotonic dispatch counter, useful for tests |
 | `has_mod(id, min_version="") -> bool` | True if a mod with the given id is loaded; optional `min_version` does a numeric semver compare (`>=`) |
-| `mod_info(id) -> Dictionary` | `{mod_id, mod_name, version, file_name, priority}` for a loaded mod, `{}` if absent. Returns a duplicate -- callers can mutate freely |
+| `mod_info(id) -> Dictionary` | `{mod_id, mod_name, version, file_name, priority, required_dependencies, optional_dependencies}` for a loaded mod, `{}` if absent. Returns a duplicate -- callers can mutate freely |
 | `loaded_mods() -> Array[String]` | All loaded mod ids. Order is not guaranteed |
 | `static version() -> String` | `MODLOADER_VERSION` |
 | `static major_version() -> int` | Parse major from `MODLOADER_VERSION` |

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -48,6 +48,10 @@ EarlyNode="!res://MyMod/Early.gd"
 [updates]
 modworkshop=12345
 
+[dependencies]
+required=["mod_configuration_menu"]
+optional=["some_soft_integration"]
+
 [hooks]
 res://Scripts/Interface.gd = "_ready, update_tooltip"
 
@@ -58,7 +62,7 @@ res://Scripts/Camera.gd = "res://MyMod/MyCamera.gd"
 ; empty section is enough -- presence enables the registry API
 ```
 
-Only `[mod]` is required. `[autoload]`, `[updates]`, `[hooks]`, `[script_extend]`, `[registry]` are all optional; use the ones your mod needs.
+Only `[mod]` is required. `[autoload]`, `[updates]`, `[dependencies]`, `[hooks]`, `[script_extend]`, `[registry]` are all optional; use the ones your mod needs.
 
 ### `[mod]` section
 
@@ -71,6 +75,25 @@ Only `[mod]` is required. `[autoload]`, `[updates]`, `[hooks]`, `[script_extend]
 | `author` | string | `""` | Optional author/credit string. Parsed and stored on the entry dict; no UI surface yet (added 3.1.2) |
 
 **VostokMods compat**: if the archive filename matches `^(-?\d+)-(.*)`, the numeric prefix is used as a fallback priority when `[mod] priority` isn't set. Example: `100-BetterAI.vmz` loads with `priority=100`. See [mod_discovery.gd:130-154](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/mod_discovery.gd#L130).
+
+### `[dependencies]` section
+
+Declares other mods by `[mod] id` so the launcher can identify missing requirements and the runtime loader can avoid starting mods that cannot work.
+
+```ini
+[dependencies]
+required=["mod_configuration_menu", "rtv_shared_lib"]
+optional=["happy_fireplace"]
+```
+
+Use Godot `ConfigFile` string arrays. Bare CSV (`required=a, b`) is not valid `ConfigFile` syntax and causes the whole `mod.txt` parse to fail.
+
+| Key | Type | Meaning |
+|---|---|---|
+| `required` | string array | Mods that must be installed and enabled. If any required dependency is missing, disabled, or not loadable, this mod is skipped. |
+| `optional` | string array | Soft integrations. Parsed and displayed by the launcher; absence does not block loading. |
+
+Required dependencies should load before the dependent mod. If the current priority/name ordering would load a dependency later than its dependent, the launcher and boot log report a load-order warning. Set the dependent mod's priority higher than its required dependency to resolve it.
 
 ### `[autoload]` section
 

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -28,7 +28,7 @@ mods/MyMod/                  Resulting res:// paths after mount
 
 A matching `mod.txt` autoload entry: `MyMod="res://MyMod/Main.gd"`.
 
-**Breaking change in 3.1.2**: pre-3.1.2 folder mode dropped contents at `res://` directly with no wrapper, so existing folder mods that relied on that layout need their `mod.txt` paths re-prefixed with the folder name. Folder mode is dev-only (gated behind the developer-mode toggle in the launcher) and the prior unwrapped behavior was undocumented; the inconsistency between folder and `.zip` was the actual bug.
+**Breaking change in 3.1.2**: pre-3.1.2 folder mode dropped contents at `res://` directly with no wrapper, so existing folder mods that relied on that layout need their `mod.txt` paths re-prefixed with the folder name. Folder mode is dev-only (gated behind the developer-mode toggle in the manager) and the prior unwrapped behavior was undocumented; the inconsistency between folder and `.zip` was the actual bug.
 
 ## mod.txt
 
@@ -78,7 +78,7 @@ Only `[mod]` is required. `[autoload]`, `[updates]`, `[dependencies]`, `[hooks]`
 
 ### `[dependencies]` section
 
-Declares other mods by `[mod] id` so the launcher can identify missing requirements and the runtime loader can avoid starting mods that cannot work.
+Declares other mods by `[mod] id` so the manager can identify missing requirements and the runtime loader can avoid starting mods that cannot work.
 
 ```ini
 [dependencies]
@@ -91,9 +91,9 @@ Use Godot `ConfigFile` string arrays. Bare CSV (`required=a, b`) is not valid `C
 | Key | Type | Meaning |
 |---|---|---|
 | `required` | string array | Mods that must be installed and enabled. If any required dependency is missing, disabled, or not loadable, this mod is skipped. |
-| `optional` | string array | Soft integrations. Parsed and displayed by the launcher; absence does not block loading. |
+| `optional` | string array | Soft integrations. Parsed and displayed by the manager; absence does not block loading. |
 
-Required dependencies should load before the dependent mod. If the current priority/name ordering would load a dependency later than its dependent, the launcher and boot log report a load-order warning. Set the dependent mod's priority higher than its required dependency to resolve it.
+Required dependencies should load before the dependent mod. If the current priority/name ordering would load a dependency later than its dependent, the manager and boot log report a load-order warning. Set the dependent mod's priority higher than its required dependency to resolve it.
 
 ### `[autoload]` section
 

--- a/docs/wiki/Modules.md
+++ b/docs/wiki/Modules.md
@@ -51,7 +51,7 @@ See [Architecture](Architecture) for the control flow.
 
 Lightweight static scanner. Reads each file inside a candidate mod (`.vmz`/`.zip`, `.pck`, or developer-mode folder) WITHOUT mounting it and looks for combinations of GDScript patterns that are nearly diagnostic of known malware.
 
-Not a virus scanner. Catches lazy / copy-paste attacks (the dropper screenshot that motivated this branch); a determined attacker with the modloader source can write around the rules. Loading is never blocked. The launcher shows a "suspicious code" tag on flagged mods and pops a confirmation dialog at Launch time.
+Not a virus scanner. Catches lazy / copy-paste attacks (the dropper screenshot that motivated this branch); a determined attacker with the modloader source can write around the rules. Loading is never blocked. The manager shows a "suspicious code" tag on flagged mods, asks for confirmation when closing/applying with flagged mods enabled, and logs a startup warning if flagged mods are already enabled.
 
 - `scan_mod` -- top-level entry called from `_build_archive_entry` / `_build_folder_entry`
 - 13 rules grouped into solo red triggers (`os_crash`, `disable_save_safety`), process-spawn, runtime-code-build, and obfuscation families
@@ -90,12 +90,12 @@ Override verification:
 
 ### [ui.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd)
 
-Pre-game launcher window. Two tabs (Mods, Updates), dark theme, Reset-to-Vanilla action. Closing the window equals clicking Launch Game.
+Manager window opened from the main-menu Mods button. Two tabs (Mods, Updates), dark theme, Reset-to-Vanilla action. Closing the window returns to the game; post-boot changes restart cleanly when applied.
 
 - `show_mod_ui` at [ui.gd:930](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L930)
 - `build_mods_tab` / `build_updates_tab` -- tab content
 - `make_dark_theme` -- Theme resource with pure-black backgrounds
-- `refresh_launch_button_label` at [ui.gd:1063](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L1063) -- pessimistic label: switches between `"Launch with Mods (Restart)"` and `"Launch Unmodded"` depending on whether any enabled mod exists. Called on init, per-checkbox toggle, and profile/dev-mode tab rebuilds. Over-warns in the rare hash-match no-restart case
+- `refresh_launch_button_label` at [ui.gd:1063](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L1063) -- post-boot label switches between `"Close"` and `"Apply & Restart"` depending on whether the manager changed runtime mod state. Legacy pre-boot fallback still uses the old launch labels.
 - `_reset_to_vanilla_and_restart` at [ui.gd:479](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/ui.gd#L479) -- unchecks every mod, calls `_static_force_vanilla_state`, strips `--modloader-restart` from cmdline so the relaunch is a clean Pass 1
 
 ## Public API
@@ -160,7 +160,7 @@ See [Hooks](Hooks) for details.
 
 Orchestrates the full rewrite pipeline:
 
-1. **Opt-in gate**: if no mods are loaded, early-return (no pack file written). If mods are loaded but `_hooked_methods` is empty and no mod declared `[registry]`, log the "no user opt-in declarations" banner and proceed with a minimal pack containing only the core-owned `Menu.gd :: _ready` wrap (launcher main-menu button injection). User mods' vanilla targets stay unmodified either way.
+1. **Opt-in gate**: core hooks are seeded even when no mods are loaded so the main-menu Mods button remains available. If mods are loaded but `_hooked_methods` is empty and no mod declared `[registry]`, log the "no user opt-in declarations" banner and proceed with a minimal pack containing only the core-owned `Menu.gd :: _ready` wrap. User mods' vanilla targets stay unmodified either way.
 2. Verify GDSC tokenizer version (STABILITY canary B)
 3. Enumerate game scripts
 4. Pre-read mod sibling scripts (before `ZIPPacker.open` invalidates existing VFS handles)
@@ -185,7 +185,7 @@ See [Architecture](Architecture).
 
 ### [main_menu_hook.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/main_menu_hook.gd)
 
-Injects a "Mods" button into RTV's main menu (`res://Scripts/Menu.gd`) so users can reopen the launcher post-boot without restarting the game. Uses the same hook machinery mods use:
+Injects a "Mods" button into RTV's main menu (`res://Scripts/Menu.gd`) so users can open the manager post-boot without restarting the game. Uses the same hook machinery mods use:
 
 - `_seed_core_hooks` pre-populates `_hooked_methods["res://Scripts/Menu.gd"]["_ready"]` so the rewriter wraps `Menu.gd :: _ready` even when no user mod asked for it. Called from each finish path and from Pass 1's pre-restart pack generation so every code path that produces a hook pack includes this wrap.
 - `_register_core_hooks` subscribes `_on_menu_ready` to `menu-_ready-post` via the public `hook()` API, fired from `_emit_frameworks_ready` in [hooks_api.gd](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/hooks_api.gd).

--- a/docs/wiki/Stability-Canaries.md
+++ b/docs/wiki/Stability-Canaries.md
@@ -89,7 +89,7 @@ Boot-time probes that alarm loudly when something the loader depends on silently
 
 ### UI Reset-to-Vanilla button
 
-**Location**: bottom bar of the launcher UI, left of Launch Game.
+**Location**: bottom bar of the manager UI, left of the Close / Apply & Restart action.
 
 **Effect**: unchecks every mod in memory, saves config, calls `_static_force_vanilla_state` (same cleanup as the disabled sentinel), strips `--modloader-restart` from cmdline args, and restarts the game clean.
 

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -438,12 +438,13 @@ func _ensure_early_autoload_on_disk(res_path: String, mod_name: String) -> Strin
 
 func _collect_enabled_archive_paths() -> PackedStringArray:
 	var paths := PackedStringArray()
-	var candidates: Array[Dictionary] = []
+	var candidates: Array = []
 	for entry in _ui_mod_entries:
 		if not entry["enabled"]:
 			continue
 		candidates.append(entry.duplicate())
 	candidates.sort_custom(_compare_load_order)
+	candidates = _filter_dependency_ready_candidates(candidates, false)
 	for c in candidates:
 		if c["ext"] == "folder":
 			# Folder mods are zipped to a temp cache during load_all_mods().

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -43,7 +43,7 @@ const VANILLA_CACHE_DIR := "user://modloader_hooks/vanilla"
 const MODWORKSHOP_VERSIONS_URL := "https://api.modworkshop.net/mods/versions"
 const MODWORKSHOP_DOWNLOAD_URL_TEMPLATE := "https://api.modworkshop.net/mods/%s/download"
 const MODWORKSHOP_PAGE_URL_TEMPLATE := "https://modworkshop.net/mod/%s"
-# ModWorkshop ID for this modloader itself. Used by the launcher's self-update
+# ModWorkshop ID for this modloader itself. Used by the manager's self-update
 # check to flag when the installed MODLOADER_VERSION is older than what's
 # published on ModWorkshop. Set to <= 0 to disable the check entirely.
 const MODLOADER_MODWORKSHOP_ID := 55623
@@ -105,10 +105,10 @@ var _developer_mode := false
 var _active_profile := "Default"
 var _ui_window: Window = null
 # Bottom-bar label used as a makeshift status hint because Godot's native
-# tooltips get layered behind our always_on_top launcher and aren't visible.
+# tooltips get layered behind our always_on_top manager window and aren't visible.
 var _ui_hint_label: Label = null
-# Launch button kept on self so refresh_launch_button_label can reach it
-# from the mod-enable toggle handler.
+# Bottom action button kept on self so refresh_launch_button_label can reach it
+# from mod-enable/profile handlers.
 var _ui_launch_btn: Button = null
 # Self-update check state. _modloader_latest_version is populated by
 # _check_modloader_update_async once the API responds; empty until then or
@@ -128,7 +128,7 @@ var _last_mod_txt_error := ""
 var _database_replaced_by := ""
 # Post-boot UI re-open state. _boot_complete flips true once Pass 1 / Pass 2 /
 # single-pass finish paths finalize. Once true, any mutation of mod_config.cfg
-# via the launcher UI sets _dirty_since_boot, which the main-menu reopen flow
+# via the manager UI sets _dirty_since_boot, which the main-menu reopen flow
 # uses to decide whether to restart on UI close.
 var _boot_complete: bool = false
 var _dirty_since_boot: bool = false
@@ -215,9 +215,9 @@ var _applied_script_overrides: Dictionary = {}         # vanilla_path -> true
 
 # Opt-in declarations (v3.0.1 cutover). Populated by the [hooks] parser in
 # mod_loading.gd and by .hook() call scanning. Drives the wrap surface in
-# _generate_hook_pack. If both are empty AND _any_mod_declared_registry is
-# false, _generate_hook_pack early-returns and no hook pack is produced --
-# the modlist behaves byte-identical to pre-hook-system (v2.1.0) behavior.
+# _generate_hook_pack. If both are empty AND _any_mod_declared_registry is false,
+# user mods' vanilla targets stay byte-identical to pre-hook-system (v2.1.0)
+# behavior; core-owned hooks may still generate the main-menu Mods button.
 var _hooked_methods: Dictionary = {}             # res_path -> {method_name: true}
 var _any_mod_declared_registry: bool = false     # set by [registry] parser
 

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -12,6 +12,7 @@
 # x-release-please-start-version
 const MODLOADER_VERSION := "3.2.1"
 # x-release-please-end
+const MODLOADER_BUILD_TAG := "Joao feat/mod-dependencies"
 
 const MODLOADER_RES_PATH := "res://modloader.gd"
 const MOD_DIR := "mods"
@@ -152,7 +153,7 @@ var _hidden_folder_ids: Dictionary = {}
 var _pending_autoloads: Array[Dictionary] = []
 var _report_lines: Array[String] = []
 # Loaded mods, keyed by mod_id. Value is a Dictionary with at least
-# {version, file_name, priority, mod_name}; populated by mod_loading.
+# {version, file_name, priority, mod_name, dependencies}; populated by mod_loading.
 # Public read API: lib.has_mod(id, ?min_version), lib.mod_info(id),
 # lib.loaded_mods(). Code that just checks presence still works via
 # Dict.has() since the key membership is unchanged from when the value

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -155,7 +155,7 @@ func read_mod_config(path: String) -> ConfigFile:
 	# Reset diagnostic alongside status: paths below (empty mod.txt, missing
 	# mod.txt, ZIPReader open failure) set parse_error without going through
 	# _parse_mod_txt, so without this reset the prior mod's error message
-	# would leak into the next mod's launcher warning.
+	# would leak into the next mod's manager warning.
 	_last_mod_txt_error = ""
 	var zr := ZIPReader.new()
 	if zr.open(path) != OK:
@@ -221,7 +221,7 @@ func _parse_mod_txt(text: String) -> ConfigFile:
 		# The Variant-parser failure code from cfg.parse() doesn't carry the
 		# offending line number. Walk the source per-line to locate it; the
 		# diagnostic flows through _last_mod_txt_error -> mod_txt_error on
-		# the entry -> launcher warning + boot log so authors see the broken
+		# the entry -> manager warning + boot log so authors see the broken
 		# section/line instead of a generic "re-download" hint.
 		_last_mod_txt_error = _diagnose_parse_failure(preprocessed)
 		return null
@@ -296,7 +296,7 @@ func _quote_unquoted_hooks_values(text: String) -> String:
 
 # Locate the first line that ConfigFile.parse() would reject. Used only on
 # the failure path -- the per-line probe is O(N) parses but only fires when
-# the mod is already broken, and the result lets the launcher tell authors
+# the mod is already broken, and the result lets the manager tell authors
 # *which* line/section to look at instead of "Invalid mod, re-download".
 func _diagnose_parse_failure(text: String) -> String:
 	var current_section := ""

--- a/src/header.gd
+++ b/src/header.gd
@@ -1,7 +1,8 @@
 ## Metro Mod Loader -- community mod loader for Road to Vostok (Godot 4.6+).
-## Loads .vmz/.pck archives from <game>/mods/ via a pre-game config window.
+## Loads .vmz/.pck archives from <game>/mods/ using the saved profile.
+## The manager opens from the main-menu Mods button.
 ## Unpacked folder mods are also recognized when Developer Mode is enabled
-## (toggle in the launcher's Mods tab).
+## (toggle in the manager's Mods tab).
 ## Two-pass architecture: mounts archives at file-scope, optionally restarts to
 ## prepend mod autoloads before the game's own autoloads via [autoload_prepend].
 ##

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -87,9 +87,6 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		_log_info("[STABILITY] Detokenizer compatible: GDSC v%d on Godot %s" \
 				% [tok_version, Engine.get_version_info().get("string", "unknown")])
 
-	if _loaded_mod_ids.is_empty():
-		return ""
-
 	# OPT-IN GATE (v3.0.1): user mods run against unmodified vanilla unless
 	# at least one mod declares [hooks] / .hook() / [registry]. Prior
 	# versions' inference triggers (extends_paths, take_over_literal_paths,
@@ -105,13 +102,16 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# would hook against, so it's effectively v2.1.0-equivalent from a
 	# mod-author perspective.
 	var user_wrap_empty: bool = _hooked_methods.is_empty() and not _any_mod_declared_registry
+	var no_loaded_mods := _loaded_mod_ids.is_empty()
 
 	# Seed core-owned hook declarations (e.g. Menu.gd _ready for the main-menu
-	# Mods button). Done after the no-mods short-circuit above so pure-vanilla
-	# sessions generate no pack, but before the legacy-mode log below so the
-	# pack includes the core wrap when at least one mod is loaded.
+	# Mods button). This always runs now: startup no longer shows the manager,
+	# so even pure-vanilla sessions need the main-menu button as the recovery
+	# path back into mod/profile management.
 	_seed_core_hooks()
 
+	if no_loaded_mods:
+		_log_info("[RTVCodegen] No mods loaded -- pack contains core hooks only for the main-menu Mods button.")
 	if user_wrap_empty:
 		_log_info("[RTVCodegen] No user opt-in declarations ([hooks] / .hook() / [registry]) -- user mods' vanilla targets run unmodified (v2.1.0-equivalent). Pack contains core hooks only.")
 

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -203,8 +203,9 @@ func has_mod(mod_id: String, min_version: String = "") -> bool:
 
 
 ## Returns the full info dict for a loaded mod, or {} if not loaded.
-## Shape: {mod_id, mod_name, version, file_name, priority}. Stable enough
-## for mods to inspect for debug prints / MCM displays.
+## Shape: {mod_id, mod_name, version, file_name, priority,
+## required_dependencies, optional_dependencies}. Stable enough for mods to
+## inspect for debug prints / MCM displays.
 func mod_info(mod_id: String) -> Dictionary:
 	var info = _loaded_mod_ids.get(mod_id, null)
 	if info is Dictionary:

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -1,8 +1,8 @@
 ## ----- lifecycle.gd -----
 ## Top-level orchestration: _ready is the entrypoint, dispatches to
-## _run_pass_1 (first launch, show UI) or _run_pass_2 (post-restart).
-## _finish_* helpers wrap up either path by instantiating queued autoloads
-## and emitting frameworks_ready.
+## _run_pass_1 (normal launch, saved profile auto-loads) or _run_pass_2
+## (post-restart). _finish_* helpers wrap up either path by instantiating
+## queued autoloads and emitting frameworks_ready.
 
 func _ready() -> void:
 	if _has_loaded:
@@ -72,7 +72,7 @@ func _preserve_engine_driver_args(args: Array) -> void:
 			args.append("--rendering-method")
 			args.append(method)
 
-# Public entry point for the main-menu "Mods" button. Re-shows the launcher UI
+# Public entry point for the main-menu "Mods" button. Re-shows the manager UI
 # post-boot; if any mutation sets _dirty_since_boot, quits + restarts into a
 # clean Pass 1. Noop when the UI is already open.
 func reopen_mod_ui() -> void:
@@ -101,7 +101,10 @@ func _run_pass_1() -> void:
 	_ui_mod_entries = collect_mod_metadata()
 	_clean_stale_cache()
 	_load_ui_config()
-	await show_mod_ui()
+	_log_info("Startup manager skipped -- use the main-menu Mods button to change mod selections.")
+	var red_mods := _enabled_red_mods()
+	if not red_mods.is_empty():
+		_log_warning("[Security] %d enabled mod(s) have suspicious-code findings. Open Mods from the main menu to review them." % red_mods.size())
 	_save_ui_config()
 
 	load_all_mods()
@@ -172,7 +175,7 @@ func _finish_with_existing_mounts() -> void:
 	# check; no need to re-apply from pass state.
 	_boot_complete = true
 	_register_rtv_modlib_meta()
-	_generate_hook_pack()
+	var hook_pack := _generate_hook_pack()
 	for entry in _pending_autoloads:
 		if get_tree().root.has_node(entry["name"]):
 			_log_info("  Autoload '%s' already in tree -- skipped" % entry["name"])
@@ -184,7 +187,7 @@ func _finish_with_existing_mounts() -> void:
 		_write_conflict_report()
 	_emit_frameworks_ready()
 	_delete_heartbeat()
-	if not _filescope_mounted.is_empty() or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+	if hook_pack != "" or not _filescope_mounted.is_empty() or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var err := get_tree().reload_current_scene()
 		if err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(err))
@@ -193,7 +196,7 @@ func _finish_with_existing_mounts() -> void:
 func _finish_single_pass() -> void:
 	_boot_complete = true
 	_register_rtv_modlib_meta()
-	_generate_hook_pack()
+	var hook_pack := _generate_hook_pack()
 	for entry in _pending_autoloads:
 		_instantiate_autoload(entry["mod_name"], entry["name"], entry["path"])
 	if _developer_mode:
@@ -202,7 +205,7 @@ func _finish_single_pass() -> void:
 		_write_conflict_report()
 	_emit_frameworks_ready()
 	_delete_heartbeat()
-	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+	if hook_pack != "" or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var err := get_tree().reload_current_scene()
 		if err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(err))
@@ -242,7 +245,7 @@ func _run_pass_2() -> void:
 
 	load_all_mods("Pass 2")
 	_register_rtv_modlib_meta()
-	_generate_hook_pack()
+	var hook_pack := _generate_hook_pack()
 	# After load_all_mods re-mounts mod archives (wiping our IXP/Controller
 	# override), remount the already-generated test pack to re-apply.
 	# NOTE: Godot dedupes load_resource_pack by path, so mounting the same
@@ -287,7 +290,7 @@ func _run_pass_2() -> void:
 	# want the marker gone; the state we wrote IS consistent at this point.
 	if FileAccess.file_exists(PASS2_DIRTY_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS2_DIRTY_PATH))
-	if not _filescope_mounted.is_empty() or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
+	if hook_pack != "" or not _filescope_mounted.is_empty() or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var err := get_tree().reload_current_scene()
 		if err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(err))

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -85,7 +85,7 @@ func reopen_mod_ui() -> void:
 		_modloader_restart(true)
 
 func _run_pass_1() -> void:
-	_log_info("Metro Mod Loader v" + MODLOADER_VERSION)
+	_log_info("Metro Mod Loader v" + MODLOADER_VERSION + " -- " + MODLOADER_BUILD_TAG)
 	_check_crash_recovery()
 	_check_safe_mode()
 	_compile_regex()

--- a/src/main_menu_hook.gd
+++ b/src/main_menu_hook.gd
@@ -1,6 +1,6 @@
 ## ----- main_menu_hook.gd -----
 ## Injects a "Mods" button into RTV's main menu (res://Scripts/Menu.gd) that
-## re-opens the launcher UI post-boot. Any mutation to mod_config.cfg while
+## re-opens the manager UI post-boot. Any mutation to mod_config.cfg while
 ## the UI is open flips _dirty_since_boot; on close we restart into a clean
 ## Pass 1 so the new mod set takes effect.
 ##

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -127,6 +127,8 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 	var author   := ""
 	var priority := 0
 	var has_mod_id := false
+	var required_dependencies: Array[String] = []
+	var optional_dependencies: Array[String] = []
 
 	# VostokMods compat: parse "100-ModName.vmz" filename priority prefix.
 	# The prefix is stripped from mod_name/mod_id defaults and used as fallback priority.
@@ -153,6 +155,8 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 			priority = int(str(cfg.get_value("mod", "priority")))
 		elif has_filename_priority:
 			priority = filename_priority
+		required_dependencies = _parse_dependency_list(cfg, "required")
+		optional_dependencies = _parse_dependency_list(cfg, "optional")
 	elif has_filename_priority:
 		priority = filename_priority
 	priority = clampi(priority, PRIORITY_MIN, PRIORITY_MAX)
@@ -169,6 +173,10 @@ func _entry_from_config(cfg: ConfigFile, file_name: String, full_path: String, e
 		"author": author,
 		"profile_key": profile_key,
 		"priority": priority, "enabled": true,
+		"required_dependencies": required_dependencies,
+		"optional_dependencies": optional_dependencies,
+		"dependency_warnings": [], "dependency_blockers": [],
+		"dependencies_satisfied": true,
 		"cfg": cfg, "mod_txt_status": _last_mod_txt_status,
 		"mod_txt_error": _last_mod_txt_error,
 	}
@@ -195,6 +203,44 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
 	return warnings
 
+func _parse_dependency_list(cfg: ConfigFile, key: String) -> Array[String]:
+	var deps: Array[String] = []
+	if cfg == null or not cfg.has_section_key("dependencies", key):
+		return deps
+	var raw: Variant = cfg.get_value("dependencies", key)
+	if raw is Array:
+		for item in (raw as Array):
+			_append_dependency_id(deps, str(item))
+		return deps
+	if typeof(raw) == TYPE_PACKED_STRING_ARRAY:
+		for item in (raw as PackedStringArray):
+			_append_dependency_id(deps, str(item))
+		return deps
+
+	# Support whole-value strings like "foo, bar" for older author tools.
+	# Godot ConfigFile already parsed strict array syntax into Array above.
+	var text := str(raw).strip_edges()
+	if text.begins_with("[") and text.ends_with("]") and text.length() >= 2:
+		text = text.substr(1, text.length() - 2)
+	for part in text.split(","):
+		_append_dependency_id(deps, part)
+	return deps
+
+func _append_dependency_id(deps: Array[String], raw_id: String) -> void:
+	var dep_id := raw_id.strip_edges()
+	if dep_id.length() >= 2:
+		var quoted := (dep_id.begins_with("\"") and dep_id.ends_with("\"")) \
+				or (dep_id.begins_with("'") and dep_id.ends_with("'"))
+		if quoted:
+			dep_id = dep_id.substr(1, dep_id.length() - 2).strip_edges()
+	if dep_id == "":
+		return
+	var dep_key := dep_id.to_lower()
+	for existing in deps:
+		if existing.to_lower() == dep_key:
+			return
+	deps.append(dep_id)
+
 # Config persistence
 
 
@@ -207,6 +253,144 @@ func _compare_load_order(a: Dictionary, b: Dictionary) -> bool:
 		return a_name < b_name
 	# Filename tiebreaker for stable sort.
 	return (a["file_name"] as String).to_lower() < (b["file_name"] as String).to_lower()
+
+func _entry_mod_key(entry: Dictionary) -> String:
+	return str(entry.get("mod_id", "")).strip_edges().to_lower()
+
+func _entries_by_mod_id(entries: Array) -> Dictionary:
+	var by_id: Dictionary = {}
+	for entry in entries:
+		var key := _entry_mod_key(entry)
+		if key == "":
+			continue
+		if not by_id.has(key):
+			by_id[key] = entry
+	return by_id
+
+func _dependency_display(entry: Dictionary) -> String:
+	var name := str(entry.get("mod_name", "")).strip_edges()
+	var mod_id := str(entry.get("mod_id", "")).strip_edges()
+	if name != "" and mod_id != "" and name != mod_id:
+		return name + " (" + mod_id + ")"
+	if mod_id != "":
+		return mod_id
+	return name
+
+func _join_string_items(items: Array, sep: String = ", ") -> String:
+	var out := PackedStringArray()
+	for item in items:
+		out.append(str(item))
+	return sep.join(out)
+
+func _filter_dependency_ready_candidates(candidates: Array,
+		log_skips: bool = false) -> Array:
+	var active_by_id := _entries_by_mod_id(candidates)
+	var installed_by_id := _entries_by_mod_id(_ui_mod_entries)
+	var blocked: Dictionary = {}
+	var changed := true
+	while changed:
+		changed = false
+		for entry in candidates:
+			var entry_key := _entry_mod_key(entry)
+			if entry_key == "" or blocked.has(entry_key):
+				continue
+			for raw_dep in entry.get("required_dependencies", []):
+				var dep_id := str(raw_dep).strip_edges()
+				if dep_id == "":
+					continue
+				var dep_key := dep_id.to_lower()
+				if dep_key == entry_key:
+					blocked[entry_key] = {"dependency": dep_id, "status": "self"}
+					changed = true
+					break
+				if active_by_id.has(dep_key) and not blocked.has(dep_key):
+					continue
+				var status := "not_installed"
+				if active_by_id.has(dep_key) and blocked.has(dep_key):
+					status = "not_loaded"
+				elif installed_by_id.has(dep_key):
+					var installed: Dictionary = installed_by_id[dep_key]
+					status = "disabled" if not bool(installed.get("enabled", false)) else "not_loaded"
+				blocked[entry_key] = {"dependency": dep_id, "status": status}
+				changed = true
+				break
+
+	var ready: Array = []
+	for entry in candidates:
+		var entry_key := _entry_mod_key(entry)
+		if entry_key != "" and blocked.has(entry_key):
+			if log_skips:
+				var info: Dictionary = blocked[entry_key]
+				_log_critical("Skipping %s -- required dependency %s is %s" \
+						% [_dependency_display(entry), info["dependency"],
+						   _dependency_status_label(str(info["status"]))])
+			continue
+		ready.append(entry)
+	return ready
+
+func _dependency_status_label(status: String) -> String:
+	match status:
+		"self":
+			return "declared as itself"
+		"disabled":
+			return "installed but disabled"
+		"not_loaded":
+			return "not loadable"
+		_:
+			return "not installed"
+
+func _refresh_dependency_status() -> void:
+	var installed_by_id := _entries_by_mod_id(_ui_mod_entries)
+	var enabled_candidates: Array[Dictionary] = []
+	for entry in _ui_mod_entries:
+		entry["dependency_warnings"] = []
+		entry["dependency_blockers"] = []
+		entry["dependencies_satisfied"] = true
+		if bool(entry.get("enabled", false)):
+			enabled_candidates.append(entry)
+
+	enabled_candidates.sort_custom(_compare_load_order)
+	var loadable := _filter_dependency_ready_candidates(enabled_candidates, false)
+	var loadable_by_id := _entries_by_mod_id(loadable)
+	var order_index: Dictionary = {}
+	for i in loadable.size():
+		order_index[_entry_mod_key(loadable[i])] = i
+
+	for entry in _ui_mod_entries:
+		if not bool(entry.get("enabled", false)):
+			continue
+		var warnings: Array[String] = []
+		var blockers: Array[String] = []
+		var entry_key := _entry_mod_key(entry)
+		for raw_dep in entry.get("required_dependencies", []):
+			var dep_id := str(raw_dep).strip_edges()
+			if dep_id == "":
+				continue
+			var dep_key := dep_id.to_lower()
+			if dep_key == entry_key:
+				warnings.append("invalid required dependency: " + dep_id)
+				blockers.append(dep_id)
+				continue
+			if not installed_by_id.has(dep_key):
+				warnings.append("missing required dependency: " + dep_id)
+				blockers.append(dep_id)
+				continue
+			var dep_entry: Dictionary = installed_by_id[dep_key]
+			if not bool(dep_entry.get("enabled", false)):
+				warnings.append("required dependency disabled: " + _dependency_display(dep_entry))
+				blockers.append(dep_id)
+				continue
+			if not loadable_by_id.has(dep_key):
+				warnings.append("required dependency not loadable: " + _dependency_display(dep_entry))
+				blockers.append(dep_id)
+				continue
+			if order_index.has(dep_key) and order_index.has(entry_key) \
+					and int(order_index[dep_key]) > int(order_index[entry_key]):
+				warnings.append("load order: " + _dependency_display(dep_entry)
+						+ " must load before this mod")
+		entry["dependency_warnings"] = warnings
+		entry["dependency_blockers"] = blockers
+		entry["dependencies_satisfied"] = blockers.is_empty()
 
 # Returns -1/0/1 for version comparison (a < b, equal, a > b).
 func compare_versions(a: String, b: String) -> int:

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -21,7 +21,7 @@ func load_all_mods(pass_label: String = "") -> void:
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
 
-	var candidates: Array[Dictionary] = []
+	var candidates: Array = []
 	for entry in _ui_mod_entries:
 		if not entry["enabled"]:
 			continue
@@ -31,6 +31,11 @@ func load_all_mods(pass_label: String = "") -> void:
 	if candidates.is_empty():
 		_log_info("No mods enabled.")
 		return
+	candidates = _filter_dependency_ready_candidates(candidates, true)
+	if candidates.is_empty():
+		_log_warning("No enabled mods are loadable after dependency checks.")
+		return
+	_log_dependency_order_warnings(candidates)
 
 	# Warn about duplicate mod names -- likely a packaging mistake or fork.
 	# The sort is still deterministic (file_name tiebreaker), but users should know.
@@ -164,6 +169,8 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		"version":   String(c.get("version", "")),
 		"file_name": file_name,
 		"priority":  int(c.get("priority", 0)),
+		"required_dependencies": c.get("required_dependencies", []),
+		"optional_dependencies": c.get("optional_dependencies", []),
 	}
 
 	# [hooks] static declaration (v3.0.1 opt-in model). Escape hatch for
@@ -320,6 +327,28 @@ func _register_claim(res_path: String, mod_name: String, archive: String,
 	_override_registry[res_path].append({
 		"mod_name": mod_name, "archive": archive, "load_index": load_index,
 	})
+
+func _log_dependency_order_warnings(candidates: Array) -> void:
+	var by_id := _entries_by_mod_id(candidates)
+	var order_index: Dictionary = {}
+	for i in candidates.size():
+		order_index[_entry_mod_key(candidates[i])] = i
+	for dependent in candidates:
+		var dependent_key := _entry_mod_key(dependent)
+		if dependent_key == "":
+			continue
+		for raw_dep in dependent.get("required_dependencies", []):
+			var dep_id := str(raw_dep).strip_edges()
+			if dep_id == "":
+				continue
+			var dep_key := dep_id.to_lower()
+			if not by_id.has(dep_key):
+				continue
+			if order_index.has(dep_key) and order_index.has(dependent_key) \
+					and int(order_index[dep_key]) > int(order_index[dependent_key]):
+				var msg := "Dependency load order issue: %s requires %s, " \
+						+ "but the dependency currently loads later. Raise the dependent's priority."
+				_log_warning(msg % [_dependency_display(dependent), _dependency_display(by_id[dep_key])])
 
 
 # Apply [script_overrides] / [script_extend] entries via take_over_path.

--- a/src/security_scan.gd
+++ b/src/security_scan.gd
@@ -9,8 +9,8 @@
 ## (see the Road to Vostok dropper that motivated this branch); a
 ## determined attacker with the modloader source can evade specific
 ## patterns. Loading is never blocked. Only mods that hit a red trigger
-## get a "suspicious code" tag in the launcher and a confirmation
-## dialog at Launch time.
+## get a "suspicious code" tag in the manager and a confirmation dialog
+## when the user closes/applies with them enabled.
 
 # Source files we run regex content scans on (GDScript text + text-form
 # Godot resources that can embed inline GDScript).

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -116,6 +116,7 @@ func _apply_profile_to_entries(cfg: ConfigFile, profile: String) -> void:
 			entry["enabled"] = profile == "Default"
 		if resolved_key != "" and cfg.has_section_key(pr_sec, resolved_key):
 			entry["priority"] = int(str(cfg.get_value(pr_sec, resolved_key)))
+	_refresh_dependency_status()
 
 # Per-profile UI settings live in profile.<name>.settings, separate from the
 # .enabled / .priority sections so _save_ui_config's erase-and-rewrite pass
@@ -1040,7 +1041,7 @@ func _show_delete_confirm(tabs: TabContainer) -> void:
 
 func show_mod_ui() -> void:
 	var win := Window.new()
-	win.title = "Road to Vostok -- Mod Loader"
+	win.title = "Road to Vostok -- MML " + MODLOADER_BUILD_TAG
 	win.size = Vector2i(960, 640)
 	win.min_size = Vector2i(640, 420)
 	win.wrap_controls = false
@@ -1105,7 +1106,7 @@ func show_mod_ui() -> void:
 
 	var hint := Label.new()
 	hint.text = "Higher number loads later and wins when mods share files.\n" \
-			+ "Developer Mode: verbose logging, conflict report, and loose folder loading."
+			+ "Required dependencies from mod.txt must be enabled and load first."
 	hint.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	hint.add_theme_font_size_override("font_size", 11)
@@ -1141,7 +1142,7 @@ func show_mod_ui() -> void:
 	# the text when ModWorkshop reports a newer release. Click opens the mod
 	# page in the system browser regardless of state.
 	var alert := LinkButton.new()
-	alert.text = "Mod Loader v" + MODLOADER_VERSION
+	alert.text = "MML v" + MODLOADER_VERSION + " -- " + MODLOADER_BUILD_TAG
 	alert.underline = LinkButton.UNDERLINE_MODE_ON_HOVER
 	alert.add_theme_font_size_override("font_size", 11)
 	alert.add_theme_color_override("font_color", Color(0.45, 0.45, 0.45))
@@ -1410,6 +1411,7 @@ func make_dark_theme() -> Theme:
 	return t
 
 func build_mods_tab(tabs: TabContainer) -> Control:
+	_refresh_dependency_status()
 	var outer := VBoxContainer.new()
 	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
@@ -1673,24 +1675,41 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 	# Rebuilds the right-side order list from current entry state.
 	var refresh_order := func():
+		_refresh_dependency_status()
 		for child in order_list.get_children():
 			child.queue_free()
 		var sorted := _ui_mod_entries.filter(func(e): return e["enabled"])
 		sorted.sort_custom(_compare_load_order)
+		var loadable := _filter_dependency_ready_candidates(sorted, false)
 		if sorted.is_empty():
 			var lbl := Label.new()
 			lbl.text = "(none enabled)"
 			lbl.modulate = Color(0.5, 0.5, 0.5)
 			order_list.add_child(lbl)
 			return
-		for i in sorted.size():
-			var e: Dictionary = sorted[i]
+		if loadable.is_empty():
+			var lbl := Label.new()
+			lbl.text = "(enabled mods blocked by dependencies)"
+			lbl.modulate = Color(1.0, 0.6, 0.2)
+			lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+			order_list.add_child(lbl)
+			return
+		for i in loadable.size():
+			var e: Dictionary = loadable[i]
 			var lbl := Label.new()
 			lbl.text = str(i + 1) + ".  " + e["mod_name"]
 			lbl.add_theme_font_size_override("font_size", 12)
 			lbl.modulate = Color(0.80, 0.80, 0.80)
 			lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			order_list.add_child(lbl)
+		var blocked_count := sorted.size() - loadable.size()
+		if blocked_count > 0:
+			var blocked_lbl := Label.new()
+			blocked_lbl.text = str(blocked_count) + " enabled mod(s) blocked by required dependencies"
+			blocked_lbl.modulate = Color(1.0, 0.6, 0.2)
+			blocked_lbl.add_theme_font_size_override("font_size", 11)
+			blocked_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+			order_list.add_child(blocked_lbl)
 
 	# -- Missing from this profile --------------------------------------------
 	# Mods the active profile references but that aren't on disk. Shown at the
@@ -1815,11 +1834,32 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			dev_lbl.modulate = Color(0.9, 0.3, 0.3)
 			dev_lbl.add_theme_font_size_override("font_size", 11)
 			name_col.add_child(dev_lbl)
+		var dep_summary := PackedStringArray()
+		var required_deps: Array = entry.get("required_dependencies", [])
+		var optional_deps: Array = entry.get("optional_dependencies", [])
+		if required_deps.size() > 0:
+			dep_summary.append("requires: " + _join_string_items(required_deps))
+		if optional_deps.size() > 0:
+			dep_summary.append("optional: " + _join_string_items(optional_deps))
+		if dep_summary.size() > 0:
+			var dep_lbl := Label.new()
+			dep_lbl.text = "; ".join(dep_summary)
+			dep_lbl.modulate = Color(0.45, 0.55, 0.70)
+			dep_lbl.add_theme_font_size_override("font_size", 11)
+			dep_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+			name_col.add_child(dep_lbl)
 		for warn_text: String in entry.get("warnings", []):
 			var warn := Label.new()
 			warn.text = warn_text
 			warn.modulate = Color(1.0, 0.6, 0.2)
 			warn.add_theme_font_size_override("font_size", 11)
+			name_col.add_child(warn)
+		for warn_text: String in entry.get("dependency_warnings", []):
+			var warn := Label.new()
+			warn.text = warn_text
+			warn.modulate = Color(1.0, 0.6, 0.2)
+			warn.add_theme_font_size_override("font_size", 11)
+			warn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			name_col.add_child(warn)
 
 		# Older same-id archives the dedup pass hid. Surface the filename
@@ -1886,18 +1926,17 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 		# Capture entry by reference (Dictionaries are reference types in GDScript)
 		var e := entry
-		var nlbl := name_lbl
 		check.toggled.connect(func(on: bool):
 			e["enabled"] = on
-			nlbl.modulate = Color(0.58, 0.82, 0.38) if on else Color(0.5, 0.5, 0.5)
-			refresh_order.call()
-			refresh_launch_button_label()
+			_refresh_dependency_status()
 			_save_ui_config()
+			_rebuild_mods_tab(tabs)
 		)
 		spin.value_changed.connect(func(val: float):
 			e["priority"] = int(val)
-			refresh_order.call()
+			_refresh_dependency_status()
 			_save_ui_config()
+			_rebuild_mods_tab(tabs)
 		)
 
 	# Filter narrowed every row out -- distinguish from "no mods installed"
@@ -2219,7 +2258,7 @@ func _check_modloader_update_async() -> void:
 		return  # installed is current or newer
 
 	if is_instance_valid(_ui_update_alert_btn):
-		_ui_update_alert_btn.text = "Mod Loader v%s -- v%s available, click to update" % [MODLOADER_VERSION, latest]
+		_ui_update_alert_btn.text = "MML v%s -- %s -- v%s available, click to update" % [MODLOADER_VERSION, MODLOADER_BUILD_TAG, latest]
 		_ui_update_alert_btn.add_theme_color_override("font_color", Color(1.0, 0.55, 0.45))
 		_ui_update_alert_btn.add_theme_color_override("font_hover_color", Color(1.0, 0.78, 0.65))
 

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1,5 +1,5 @@
 ## ----- ui.gd -----
-## The launcher window shown before the game starts.
+## The manager window opened from the main-menu Mods button.
 ##   - Mods tab: per-mod enable checkbox + load-order spin, profile selector
 ##     (switch / create / delete) with a Vanilla entry that confirms then
 ##     resets + restarts, and a live load-order preview.
@@ -8,8 +8,8 @@
 ##     `profile.<name>.priority`; the active profile is stored in
 ##     `[settings] active_profile`. VANILLA_PROFILE is a sentinel meaning
 ##     "all mods off" and keeps stored profiles untouched on reset.
-## Closing the window (or clicking Launch Game) hands control back to
-## _run_pass_1.
+## Closing the window (or clicking the bottom action button) hands control back
+## to the game; post-boot config changes restart so the new profile can load.
 
 func _load_developer_mode_setting() -> void:
 	var cfg := ConfigFile.new()
@@ -66,7 +66,7 @@ func _load_ui_config() -> void:
 	# a silent-overwrite gap where an imported profile named "Default"
 	# would write without the overwrite confirm (since _list_profiles()
 	# wouldn't yet include the untoggled placeholder). Writing the section
-	# here makes Default a persistent profile like every other launcher
+	# here makes Default a persistent profile like every other game manager
 	# (Firefox, Minecraft, Steam). Users can rename or delete it if they
 	# want.
 	#
@@ -215,7 +215,7 @@ func _save_ui_config() -> void:
 
 	# Skip profile-section writes while the Vanilla sentinel is active -- it's
 	# not a real profile and must not materialize stored sections, even from
-	# the Launch-time save in lifecycle.gd.
+	# the startup save in lifecycle.gd.
 	if _active_profile != VANILLA_PROFILE:
 		# Rewrite the active profile's sections fresh so removed mods don't linger.
 		var en_sec := "profile." + _active_profile + ".enabled"
@@ -584,7 +584,7 @@ func _rebuild_mods_tab(tabs: TabContainer) -> void:
 	# hitting the per-row checkbox handler.
 	refresh_launch_button_label()
 
-# Parent a dialog on the launcher window (fallback: tree root) so it layers
+# Parent a dialog on the manager window (fallback: tree root) so it layers
 # over our always_on_top Window, and copy our dark theme onto it since theme
 # lookup doesn't cross Window boundaries reliably.
 func _attach_ui_dialog(d: Window) -> void:
@@ -603,7 +603,7 @@ func _connect_dialog_exits(d: ConfirmationDialog, on_confirm: Callable, on_dismi
 
 # Make a Control swap the bottom-bar hint label to `text` while hovered and
 # restore the original on exit. Stand-in for Godot tooltips, which are popups
-# that render behind our always_on_top launcher window.
+# that render behind our always_on_top manager window.
 func _wire_hint(c: Control, text: String) -> void:
 	if _ui_hint_label == null:
 		return
@@ -705,16 +705,16 @@ func _enabled_red_mods() -> Array:
 			out.append(entry)
 	return out
 
-# Launch-time confirmation when one or more enabled mods are scored RED.
-# Returns true if the user confirms launch, false if they go back. Loading
-# is never silently bypassed; the user must explicitly acknowledge.
+# Confirmation when one or more enabled mods are scored RED. Returns true if
+# the user confirms, false if they go back. Loading is never silently bypassed;
+# the user must explicitly acknowledge.
 #
 # Uses plain dialog_text so Godot auto-sizes the window to its content.
 # A custom VBoxContainer body would let the window grow off-screen.
 func _confirm_red_launch(red_mods: Array) -> bool:
 	var d := ConfirmationDialog.new()
 	d.title = "Suspicious mods enabled"
-	d.ok_button_text = "Launch anyway"
+	d.ok_button_text = "Continue anyway"
 	d.cancel_button_text = "Go back"
 	d.dialog_autowrap = true
 	# Width floor so the autowrap doesn't squeeze the text into a narrow
@@ -722,19 +722,19 @@ func _confirm_red_launch(red_mods: Array) -> bool:
 	d.min_size = Vector2(560, 120)
 
 	var lines := PackedStringArray()
-	lines.append("The scanner found patterns in the following mod(s) that are commonly used by malware. If you don't trust them, go back and disable them before launching.")
+	lines.append("The scanner found patterns in the following mod(s) that are commonly used by malware. If you don't trust them, go back and disable them before continuing.")
 	lines.append("")
 	for entry: Dictionary in red_mods:
 		lines.append("    " + str(entry.get("mod_name", "?")))
 	d.dialog_text = "\n".join(lines)
 
 	_attach_ui_dialog(d)
-	# Force dialog above the always_on_top launcher. Without this, clicking
-	# the launcher's X (which routes to the same Launch handler) sometimes
-	# parents-off the dialog behind the launcher and leaves input frozen.
+	# Force dialog above the always_on_top manager. Without this, clicking
+	# the manager's X (which routes to the same action handler) sometimes
+	# parents-off the dialog behind the manager and leaves input frozen.
 	d.exclusive = true
 	d.always_on_top = true
-	# Red text on the destructive button so "Launch anyway" reads as the
+	# Red text on the destructive button so "Continue anyway" reads as the
 	# risky option. Same modulate trick as _show_vanilla_confirm.
 	d.get_ok_button().modulate = Color(1.0, 0.55, 0.55)
 
@@ -1099,7 +1099,7 @@ func show_mod_ui() -> void:
 
 	root.add_child(HSeparator.new())
 
-	# Bottom bar: instructions + launch button
+	# Bottom bar: status hint + close/apply button
 	var bottom := HBoxContainer.new()
 	bottom.add_theme_constant_override("separation", 10)
 	root.add_child(bottom)
@@ -1117,7 +1117,7 @@ func show_mod_ui() -> void:
 	_ui_hint_label = hint
 
 	var launch_btn := Button.new()
-	launch_btn.text = "  Launch Game  "
+	launch_btn.text = "  Close  "
 	launch_btn.custom_minimum_size = Vector2(130, 36)
 	var ls_n := StyleBoxFlat.new()
 	ls_n.bg_color = Color(0.05, 0.05, 0.05)
@@ -1136,7 +1136,7 @@ func show_mod_ui() -> void:
 	launch_btn.add_theme_color_override("font_color", Color(0.88, 0.88, 0.88))
 	launch_btn.add_theme_color_override("font_hover_color", Color(1.0, 1.0, 1.0))
 
-	# Always-visible self-version label sitting between the hint and Launch.
+	# Always-visible self-version label sitting between the hint and action.
 	# Default state shows the installed version in dim gray; the
 	# _check_modloader_update_async coroutine flips it to orange and rewrites
 	# the text when ModWorkshop reports a newer release. Click opens the mod
@@ -1156,12 +1156,12 @@ func show_mod_ui() -> void:
 	bottom.add_child(launch_btn)
 	_ui_launch_btn = launch_btn
 
-	# Closing the window with X should behave the same as clicking Launch.
+	# Closing the window with X should behave the same as clicking the action.
 	win.close_requested.connect(func(): launch_btn.pressed.emit())
 
 	# Fire-and-forget self-update check. Updates _ui_update_alert_btn and may
 	# pop the one-shot dialog when the API returns. Guards on
-	# is_instance_valid so a launcher close mid-flight is harmless.
+	# is_instance_valid so a manager close mid-flight is harmless.
 	_check_modloader_update_async()
 
 	var mods_tab := build_mods_tab(tabs)
@@ -1174,10 +1174,10 @@ func show_mod_ui() -> void:
 
 	refresh_launch_button_label()
 
-	# Launch loop. If any enabled mod has the scanner's RED risk_level,
-	# show a confirmation dialog before proceeding. Cancel returns the
-	# user to the launcher so they can disable the flagged mod or
-	# reconsider; confirm proceeds. No gate when no red mods are enabled.
+	# Close/apply loop. If any enabled mod has the scanner's RED risk_level,
+	# show a confirmation dialog before proceeding. Cancel returns the user to
+	# the manager so they can disable the flagged mod or reconsider; confirm
+	# proceeds. No gate when no red mods are enabled.
 	while true:
 		await launch_btn.pressed
 		var red_mods := _enabled_red_mods()
@@ -1193,12 +1193,17 @@ func show_mod_ui() -> void:
 	_ui_update_alert_btn = null
 	win.queue_free()
 
-# Pessimistic label: any enabled mod -> "(Restart)". Over-warn beats a
-# surprise close/reopen; the rare hash-match no-restart case just launches
-# faster than promised.
 func refresh_launch_button_label() -> void:
 	if not is_instance_valid(_ui_launch_btn):
 		return
+	if _boot_complete:
+		if _dirty_since_boot:
+			_ui_launch_btn.text = "  Apply & Restart  "
+		else:
+			_ui_launch_btn.text = "  Close  "
+		return
+	# Legacy pre-boot fallback, kept in case a future recovery path opens the
+	# manager before the main menu exists.
 	var any_enabled := false
 	for entry in _ui_mod_entries:
 		if entry.get("enabled", false):
@@ -1382,7 +1387,7 @@ func make_dark_theme() -> Theme:
 
 	# -- Tooltip (hover hint panel) --------------------------------------------
 	# Without these our tooltips render with the default light theme and get
-	# lost behind the always_on_top launcher window.
+	# lost behind the always_on_top manager window.
 	var tt_panel := StyleBoxFlat.new()
 	tt_panel.bg_color = Color(0.10, 0.10, 0.10)
 	tt_panel.border_color = C_BORD
@@ -2238,9 +2243,9 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 
 # Fire-and-forget from show_mod_ui. Hits the ModWorkshop versions API for
 # our own mod id, compares the result against MODLOADER_VERSION, and on a
-# newer release: reveals the launch-row LinkButton, and pops a one-shot
+# newer release: reveals the bottom-row LinkButton, and pops a one-shot
 # dialog the first session each new version is detected. All UI mutations
-# guard on is_instance_valid because the launcher may close before the
+# guard on is_instance_valid because the manager may close before the
 # HTTP request returns.
 func _check_modloader_update_async() -> void:
 	if MODLOADER_MODWORKSHOP_ID <= 0:
@@ -2264,7 +2269,7 @@ func _check_modloader_update_async() -> void:
 
 	# Pop the dialog only the first session this specific new version is
 	# seen. Stays quiet on subsequent launches until ModWorkshop ships a
-	# newer one. The launch-row alert remains visible regardless.
+	# newer one. The bottom-row alert remains visible regardless.
 	var last_seen := _modloader_update_last_seen_version()
 	if last_seen != latest:
 		_show_modloader_update_dialog(latest)


### PR DESCRIPTION
## Summary
- parse `[dependencies] required` and `optional` from `mod.txt`
- surface dependency summaries/warnings in the launcher and load-order preview
- skip enabled mods whose required dependencies are missing, disabled, or otherwise not loadable
- document the new dependency schema and expose dependency lists through `mod_info()`

## Testing
- `git diff --check`
- rebuilt `modloader.gd` locally with the repository source order sanity checks

I'm building a Mod Manager that allows modders to set dependencies for their Mods. This allow the MML to detect and display those dependencies during the load process.