### PR TITLE
fix: dev-mode folder mods mount at res:// root, matching the shipped zip

### DIFF
--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -389,17 +389,25 @@ func _folder_dev_zip_current(tmp_zip_path: String) -> bool:
 		return false
 	var stored := f.get_as_text().strip_edges()
 	f.close()
-	return not stored.is_empty() and stored == str(_stable_path_mtime(tmp_zip_path))
+	return not stored.is_empty() and stored == _folder_dev_zip_stamp(tmp_zip_path)
+
+# Cache-validity stamp written to a folder's _dev.zip .src sidecar and re-checked
+# by _folder_dev_zip_current. Prefixed with a layout token so a change to the
+# zip's internal layout self-invalidates stale caches even without a
+# MODLOADER_VERSION bump: the pre-3.3.1 wrapped layout stored a bare number,
+# which can never equal "root:<n>", so any old cache forces a fresh unwrapped
+# re-zip. Bump the token if the on-disk layout ever changes again.
+func _folder_dev_zip_stamp(tmp_zip_path: String) -> String:
+	return "root:" + str(_stable_path_mtime(tmp_zip_path))
 
 func zip_folder_to_temp(folder_path: String) -> String:
-	var folder_name := folder_path.get_file()
 	var tmp_zip_path := _folder_dev_zip_path(folder_path)
 	# Capture the folder-state hash BEFORE zipping (_stable_path_mtime walks
 	# the SOURCE folder for *_dev.zip paths, so this is valid even before the
 	# zip exists). Stamping the pre-zip state means an editor save landing
 	# mid-zip mismatches on the next launch and forces a rebuild, instead of
 	# vouching for content the zip never captured.
-	var pre_zip_stamp := str(_stable_path_mtime(tmp_zip_path))
+	var pre_zip_stamp := _folder_dev_zip_stamp(tmp_zip_path)
 	# Drop the old sidecar before rewriting the zip so an interrupted build
 	# can never leave a stamp that vouches for mismatched content (same guard
 	# as _static_vmz_to_zip).
@@ -410,15 +418,18 @@ func zip_folder_to_temp(folder_path: String) -> String:
 	if zp.open(tmp_zip_path) != OK:
 		_log_critical("Failed to create temp zip: " + tmp_zip_path)
 		return ""
-	# Wrap zip entries under the folder name so res:// paths match what a
-	# conventionally-packed .zip mod produces. A folder at <mods>/MyMod/
-	# containing data/main.gd mounts as res://MyMod/data/main.gd, the same
-	# layout you'd get if MyMod/ were inside a .zip. Without this wrapper,
-	# folder mode dropped contents at res:// directly, so a mod.txt path of
-	# res://MyMod/data/main.gd worked from .zip but resolved nowhere from
-	# the folder. (Pre-v3.1.2 folder mods that relied on the unwrapped
-	# layout need their mod.txt paths re-prefixed with the folder name.)
-	var zip_ok := _zip_folder_recursive(zp, folder_path, folder_name)
+	# Zip the folder's CONTENTS at the archive root (no <folder>/ wrapper), so a
+	# dev folder mounts exactly like the mod you'll ship: a folder holding
+	# mod.txt + data/main.gd mounts as res://mod.txt + res://data/main.gd,
+	# identical to a .zip whose contents sit at its root. mod.txt paths are
+	# therefore root-relative (res://data/main.gd), the same whether the mod
+	# runs as a dev folder or as the shipped zip -- "work on the folder, zip it,
+	# upload it" with no path rewrites. (This reverses the v3.1.2 <folder>/ wrap:
+	# a mod authored against that wrap, using res://<folder>/... paths, must drop
+	# the <folder>/ prefix -- or add a real <folder>/ subfolder inside the mod if
+	# it wants that namespace. Namespacing is now the author's choice via their
+	# own folder layout, exactly like a zip mod.)
+	var zip_ok := _zip_folder_recursive(zp, folder_path, "")
 	zip_ok = zp.close() == OK and zip_ok
 	# Never stamp a zip that didn't fully write: a mid-zip failure can still
 	# close a structurally valid but incomplete zip, and the sidecar would

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -393,7 +393,7 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 		else:
 			warnings.append("mod.txt parse error at " + detail)
 	elif status.begins_with("nested:"):
-		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
+		warnings.append("Invalid mod -- mod.txt is in a subfolder, not at the zip root. Re-zip so mod.txt is at the root.")
 	return warnings
 
 func _parse_dependency_list(cfg: ConfigFile, key: String) -> Array[String]:

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -178,7 +178,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		if cfg == null and ext != "pck":
 			var status: String = c.get("mod_txt_status", "none")
 			if status.begins_with("nested:"):
-				_log_warning("  Invalid mod -- packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
+				_log_warning("  Invalid mod -- mod.txt is inside a subfolder (" + status.substr(7) + "), not at the zip root. Zip the mod's CONTENTS so mod.txt sits at the zip root, not the folder that holds them.")
 			elif status == "parse_error":
 				var detail: String = c.get("mod_txt_error", "")
 				if detail.is_empty():


### PR DESCRIPTION
## Problem
Dev mode zipped a mod folder wrapped under `<folder>/`, so a folder mounted at `res://<folder>/...` while the same mod shipped as a root-packed `.zip` mounted at `res://...`. Autoload/hook/script paths in `mod.txt` are used verbatim, so a path like `res://mods/Main.gd` that worked as a zip resolved to nothing as a dev folder -- the "work on the folder, zip it, upload it" workflow silently broke. (Reported by Pulse.)

## Fix
Zip the folder's **contents at the archive root** (drop the `<folder>/` wrapper), so a dev folder mounts exactly like an unzipped mod / a root-packed zip. `mod.txt` paths are root-relative either way. Authors who want a namespace add a real subfolder inside the mod -- same as a zip.

Also makes the `nested mod.txt` rejection actionable: it now tells the author to zip the mod's contents (mod.txt at the zip root), not the enclosing folder.

## Compatibility
Reverses the v3.1.2 wrap, but **only affects folder-DEV mode** -- shipped zips mount verbatim and are untouched. A dev folder previously authored with `res://<folder>/...` paths must drop the prefix; it gets a clear "path not found + similar paths" warning that points at the right path.

Verified: builds clean (39 files, no duplicate symbols), plain ASCII. Runtime test = a dev folder mod loading with root-relative paths.
