### PR TITLE
fix: 3.3.1 -- rendering, flow, and error-message fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ This is **not** a virus scanner. It catches lazy / copy-paste attacks; a determi
 
 Package your mod as a `.vmz` archive (rename a `.zip` to `.vmz`) with a `mod.txt` at the root. All string values must be quoted.
 
+Zip the mod's **contents**, not the folder that holds them -- `mod.txt` has to be
+at the top level of the archive, and a `mod.txt` buried one folder down is the
+most common reason a mod is rejected as packaged incorrectly. Put your code in a
+subfolder beside it, named after your mod, so your `res://` paths can't collide
+with the game or another mod:
+
+```
+MyMod.vmz
+  mod.txt              <- at the root
+  MyMod/Main.gd        <- mounts as res://MyMod/Main.gd
+```
+
+Developer Mode folders use the same layout and the same `mod.txt` -- a folder's
+contents mount at `res://` just like the zip, so nothing changes when you package
+it up.
+
 ```ini
 [mod]
 name="My Mod"

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check.sh -- parse-check the built modloader.gd with the real GDScript compiler.
+#
+# Why this exists: modloader.gd is 24k+ lines assembled from 39 files that share
+# one namespace, and it only ever runs inside the game. Hand-reading catches
+# typos but not "this function does not exist" or "this type does not line up"
+# -- exactly the errors a refactor introduces. Godot's own front end catches
+# both in a couple of seconds.
+#
+# This NEVER opens a window and NEVER touches the game: --headless, and the
+# script is copied into a throwaway project under the system temp dir so Godot
+# has no reason to look at this repo (which is not a Godot project) or at the
+# Road to Vostok install.
+#
+# What it does NOT do: run anything. --check-only parses and type-checks, then
+# exits. It cannot tell you whether mods actually mount -- that is still a
+# smoke test in the real game.
+#
+# Usage:
+#   ./check.sh                      # build.sh must have run first
+#   GODOT=/path/to/godot ./check.sh # override the engine binary
+#
+# Exit code is Godot's: 0 = clean parse, non-zero = errors printed above.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+OUT=modloader.gd
+
+# Prefer an explicit GODOT, then PATH, then the known local install. Use the
+# _console build on Windows: the plain .exe detaches from the terminal and its
+# output never reaches us.
+DEFAULT_GODOT="/c/Users/ametr/Downloads/Godot_v4.6.1-stable_win64.exe/Godot_v4.6.1-stable_win64_console.exe"
+GODOT="${GODOT:-}"
+if [[ -z "$GODOT" ]]; then
+    if command -v godot >/dev/null 2>&1; then
+        GODOT=$(command -v godot)
+    else
+        GODOT="$DEFAULT_GODOT"
+    fi
+fi
+
+if [[ ! -x "$GODOT" && ! -f "$GODOT" ]]; then
+    echo "ERROR: Godot not found at: $GODOT" >&2
+    echo "Set GODOT=/path/to/godot and re-run." >&2
+    exit 127
+fi
+
+if [[ ! -f "$OUT" ]]; then
+    echo "ERROR: $OUT not found -- run ./build.sh first." >&2
+    exit 1
+fi
+
+# Throwaway project outside the repo. Rebuilt every run so a stale copy can
+# never be what gets checked.
+WORK="${TMPDIR:-/tmp}/modloader-gdcheck"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+printf 'config_version=5\n\n[application]\n\nconfig/name="gdcheck"\n' > "$WORK/project.godot"
+cp "$OUT" "$WORK/$OUT"
+
+"$GODOT" --headless --path "$WORK" --check-only --script "$OUT" 2>&1 | grep -v '^Godot Engine v' | grep -v '^$'
+status=${PIPESTATUS[0]}
+
+if [[ $status -eq 0 ]]; then
+    echo "OK: $OUT parses clean ($(wc -l < "$OUT") lines)"
+else
+    echo "FAILED: $OUT has parse/type errors (see above)" >&2
+fi
+exit $status

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -6,8 +6,23 @@ The hook system lets mods intercept vanilla method calls -- run code before/afte
 
 If your mod calls `.hook("controller-jump-pre", my_callback)` directly in its own source, **you don't need any `mod.txt` declaration**. The loader scans your `.gd` files at load time, sees the `.hook()` call, and enrolls `Controller.gd :: jump` in the wrap surface automatically. At pack generation the vanilla `Controller.jump` gets a dispatch wrapper, and your callback fires.
 
+Package it like this -- `mod.txt` at the archive ROOT, your code in a subfolder
+next to it:
+
+```
+BigJump.vmz            (a .zip renamed to .vmz)
+  mod.txt              <- must be at the root, NOT inside BigJump/
+  BigJump/Main.gd      <- mounts as res://BigJump/Main.gd
+```
+
+`mod.txt` at the root is what makes it a mod -- if it is inside a subfolder the
+loader rejects the archive as packaged incorrectly. Everything else mounts
+verbatim, so the subfolder is what your `res://` paths are relative to. Give it
+your mod's name: `res://` is shared with the game, and a bare `res://Main.gd`
+can collide with another mod.
+
 ```gdscript
-# res://MyMod/Main.gd
+# res://BigJump/Main.gd
 extends Node
 
 var _lib = null
@@ -29,17 +44,30 @@ func _on_jump(_delta):
 ```
 
 ```ini
-# res://MyMod/mod.txt
+# mod.txt, at the archive root
 [mod]
 name="Big Jump"
 id="big_jump"
 version="1.0.0"
 
 [autoload]
-BigJump="res://MyMod/Main.gd"
+BigJump="res://BigJump/Main.gd"
 ```
 
 That's the whole mod. No `[hooks]` section. No framework imports. The scanner does the enrollment.
+
+Working from an unpacked folder in [Developer Mode](Developer-Mode)? Use the same
+layout and the same `mod.txt` -- a folder's contents mount at `res://` exactly
+like the zip you'll ship, so `mods/BigJump/` holds `mod.txt` and `BigJump/Main.gd`
+and no paths change when you zip it up. (Before 3.3.1 a dev folder was wrapped
+under its own name, so folder mods needed an extra prefix that broke the moment
+you zipped them. If you have a folder mod authored against that, drop the extra
+prefix.)
+
+If the mod loads but nothing happens in game, check the console log: an
+`Autoload path not found in archive` line means the `mod.txt` path does not match
+where the file actually landed, and the loader prints the similar paths it did
+find so you can see the correct prefix.
 
 ## Opt-in model
 

--- a/docs/wiki/Mod-Format.md
+++ b/docs/wiki/Mod-Format.md
@@ -9,26 +9,53 @@ A mod is an archive (`.vmz`, `.zip`, or `.pck`, plus unpacked folders in develop
 | `.vmz` | Copied to `user://vmz_mount_cache/<name>.zip` then `ProjectSettings.load_resource_pack` | Yes | Yes | Yes |
 | `.zip` | `ProjectSettings.load_resource_pack` directly | Yes | Yes | Yes |
 | `.pck` | `ProjectSettings.load_resource_pack` directly | No | No | No |
-| folder | Zipped to `user://vmz_mount_cache/<name>_dev.zip` then mounted. Zip entries are wrapped under the folder name (see [Folder mode wrapper](#folder-mode-wrapper)). **Developer mode only** | Yes | Yes | Yes |
+| folder | Zipped to `user://vmz_mount_cache/<name>_dev.zip` then mounted. The folder's *contents* are zipped at the archive root, so it mounts identically to the zip you would ship (see [Folder mode layout](#folder-mode-layout)). **Developer mode only** | Yes | Yes | Yes |
 
 `.vmz` is the historical community convention -- Godot's ZIPReader won't open files with `.vmz` extension directly, so the loader copies them to `<name>.zip` in the cache dir first (see [fs_archive.gd `_static_vmz_to_zip`](https://github.com/ametrocavich/vostok-mod-loader/blob/development/src/fs_archive.gd)). Re-extraction triggers when the source `.vmz` mtime is newer than the cache. `.zip` archives skip the cache step and mount directly.
 
-### Folder mode wrapper
+### Packaging layout
 
-A folder mod at `<game>/mods/MyMod/` containing `data/main.gd` mounts as `res://MyMod/data/main.gd` -- the folder name is added as a wrapper so the layout matches what a conventionally-packed `.zip` produces. Without this, the same source files would mount at `res://data/main.gd` from the folder but at `res://MyMod/data/main.gd` from a `.zip` of the same mod, and a single `mod.txt` could not satisfy both.
+`mod.txt` must sit at the **root** of the archive. An archive whose `mod.txt` is
+buried in a subfolder is rejected as packaged incorrectly -- this is the single
+most common packaging mistake, and it happens when you zip the folder that holds
+the mod instead of the mod's contents.
 
-The rule, in one line: **the path inside `mod.txt` is whatever it would be inside the equivalent `.zip` -- prefix with the folder name.**
+Everything else mounts verbatim, so put your code in a subfolder named after your
+mod: `res://` is shared with the game and every other mod, and a bare
+`res://Main.gd` invites a collision.
+
+```
+MyMod.vmz                    Resulting res:// paths after mount
+  mod.txt                    (read at the root; not a path you reference)
+  MyMod/Main.gd              res://MyMod/Main.gd
+  MyMod/data/items.json      res://MyMod/data/items.json
+```
+
+A matching `mod.txt` autoload entry: `MyModMain="res://MyMod/Main.gd"`.
+
+### Folder mode layout
+
+A dev-mode folder mod uses the **same layout and the same `mod.txt`**: the
+folder's contents are zipped at the archive root, so `<game>/mods/MyMod/` holding
+`mod.txt` and `MyMod/Main.gd` mounts exactly like the `.zip` above. Work on the
+folder, zip its contents, upload it -- no path rewrites at any step.
 
 ```
 mods/MyMod/                  Resulting res:// paths after mount
-  mod.txt                    (n/a -- mod.txt is read once, not mounted)
-  Main.gd                    res://MyMod/Main.gd
-  data/items.json            res://MyMod/data/items.json
+  mod.txt                    (read at the root; not a path you reference)
+  MyMod/Main.gd              res://MyMod/Main.gd
+  MyMod/data/items.json      res://MyMod/data/items.json
 ```
 
-A matching `mod.txt` autoload entry: `MyMod="res://MyMod/Main.gd"`.
-
-**Breaking change in 3.1.2**: pre-3.1.2 folder mode dropped contents at `res://` directly with no wrapper, so existing folder mods that relied on that layout need their `mod.txt` paths re-prefixed with the folder name. Folder mode is dev-only (gated behind the developer-mode toggle in the launcher) and the prior unwrapped behavior was undocumented; the inconsistency between folder and `.zip` was the actual bug.
+**Breaking change in 3.3.1**: 3.1.2 through 3.3.0 wrapped a dev folder's entries
+under the folder name, so a folder mod needed an extra `res://<folder>/` prefix
+that stopped working the moment the mod was zipped and shipped. 3.3.1 removes the
+wrapper so folder and `.zip` agree. A folder mod authored against the wrap must
+drop the extra prefix (or add a real subfolder inside the mod if it wants that
+namespace, same as a zip). A stale path is not silent: the loader logs
+`Autoload path not found in archive` along with the similar paths it did find.
+The `_dev.zip` cache self-invalidates on upgrade, so no manual cache clear is
+needed. Folder mode is dev-only, gated behind the developer-mode toggle.
 
 ## mod.txt
 

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -247,6 +247,13 @@ var _last_mod_txt_status := "none"
 # see *which* line/section broke instead of a generic "Invalid mod" prompt.
 # Empty when status != "parse_error".
 var _last_mod_txt_error := ""
+# Side channel: the archive's full file list as res:// paths, captured by
+# read_mod_config while the ZIPReader is still open. Read ONLY by
+# _build_entry_warnings, which mod_discovery calls immediately after the
+# matching read_mod_config, so it always describes the entry being built.
+# Deliberately not copied into the entry -- a big mod has thousands of paths
+# and every entry is held for the session. Empty for .pck and folder mods.
+var _last_mod_txt_files := {}
 var _database_replaced_by := ""
 # Post-boot UI re-open state. _boot_complete flips true once Pass 1 / Pass 2 /
 # single-pass finish paths finalize. Once true, any mutation of mod_config.cfg

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -97,6 +97,11 @@ const MWS_API_BASE := "https://api.modworkshop.net"
 const MWS_STORAGE_BASE := "https://storage.modworkshop.net"
 const MWS_RTV_GAME_ID := 864
 const MWS_PAGE_LIMIT := 50
+# Buffer cap for JSON API responses (list pages run ~100KB at limit=50).
+const MWS_JSON_BODY_LIMIT := 8 * 1024 * 1024
+# The API caps the search query at 150 chars and answers longer values with a
+# 422, which our non-2xx handling would report as a connection problem.
+const MWS_QUERY_MAX_LEN := 150
 const MWS_USER_AGENT_TEMPLATE := "vostok-mod-loader/%s (+https://github.com/ametrocavich/vostok-mod-loader)"
 
 # --- Profile / modpack snapshot storage ---

--- a/src/constants.gd
+++ b/src/constants.gd
@@ -462,3 +462,22 @@ var _rebuilding_tab_in_place: bool = false
 # window so it's at most one attempt per mod per minute regardless of churn.
 var _mods_mws_meta_by_id: Dictionary = {}       # mod_id -> mod object (successes only)
 var _mods_mws_meta_retry_at: Dictionary = {}    # mod_id -> ticks_msec before which not to refetch
+
+# Persisted-meta bookkeeping for the memo above. _mods_mws_meta_saved_at maps
+# mod_id -> unix time the entry was last confirmed by a real /mods/{id} fetch;
+# only ids present here are written to the on-disk sidecar (snapshot-sourced
+# memo entries stay session-only, matching their pre-sidecar behavior), and a
+# stale stamp (> _MODS_META_REFRESH_SEC) triggers the background soft refresh.
+# _mods_meta_sidecar_loaded gates the lazy one-time disk read.
+var _mods_mws_meta_saved_at: Dictionary = {}
+var _mods_meta_sidecar_loaded: bool = false
+
+# Live Mods-tab row nodes for MWS meta painting, keyed by mod_id. Each value is
+# an Array of {thumb: TextureRect, name_col: VBoxContainer, holder: Dictionary}
+# -- an Array because several installed rows can declare the same workshop id.
+# Rebuilt from scratch by build_mods_tab on every (re)build, so an async meta
+# fetch that completes AFTER a rebuild paints the CURRENT row via
+# _mods_apply_mws_meta instead of writing into the freed nodes it captured at
+# call time (which memoized the result but never displayed it). Cleared on
+# launcher close.
+var _mods_meta_nodes: Dictionary = {}

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -389,17 +389,25 @@ func _folder_dev_zip_current(tmp_zip_path: String) -> bool:
 		return false
 	var stored := f.get_as_text().strip_edges()
 	f.close()
-	return not stored.is_empty() and stored == str(_stable_path_mtime(tmp_zip_path))
+	return not stored.is_empty() and stored == _folder_dev_zip_stamp(tmp_zip_path)
+
+# Cache-validity stamp written to a folder's _dev.zip .src sidecar and re-checked
+# by _folder_dev_zip_current. Prefixed with a layout token so a change to the
+# zip's internal layout self-invalidates stale caches even without a
+# MODLOADER_VERSION bump: the pre-3.3.1 wrapped layout stored a bare number,
+# which can never equal "root:<n>", so any old cache forces a fresh unwrapped
+# re-zip. Bump the token if the on-disk layout ever changes again.
+func _folder_dev_zip_stamp(tmp_zip_path: String) -> String:
+	return "root:" + str(_stable_path_mtime(tmp_zip_path))
 
 func zip_folder_to_temp(folder_path: String) -> String:
-	var folder_name := folder_path.get_file()
 	var tmp_zip_path := _folder_dev_zip_path(folder_path)
 	# Capture the folder-state hash BEFORE zipping (_stable_path_mtime walks
 	# the SOURCE folder for *_dev.zip paths, so this is valid even before the
 	# zip exists). Stamping the pre-zip state means an editor save landing
 	# mid-zip mismatches on the next launch and forces a rebuild, instead of
 	# vouching for content the zip never captured.
-	var pre_zip_stamp := str(_stable_path_mtime(tmp_zip_path))
+	var pre_zip_stamp := _folder_dev_zip_stamp(tmp_zip_path)
 	# Drop the old sidecar before rewriting the zip so an interrupted build
 	# can never leave a stamp that vouches for mismatched content (same guard
 	# as _static_vmz_to_zip).
@@ -410,15 +418,18 @@ func zip_folder_to_temp(folder_path: String) -> String:
 	if zp.open(tmp_zip_path) != OK:
 		_log_critical("Failed to create temp zip: " + tmp_zip_path)
 		return ""
-	# Wrap zip entries under the folder name so res:// paths match what a
-	# conventionally-packed .zip mod produces. A folder at <mods>/MyMod/
-	# containing data/main.gd mounts as res://MyMod/data/main.gd, the same
-	# layout you'd get if MyMod/ were inside a .zip. Without this wrapper,
-	# folder mode dropped contents at res:// directly, so a mod.txt path of
-	# res://MyMod/data/main.gd worked from .zip but resolved nowhere from
-	# the folder. (Pre-v3.1.2 folder mods that relied on the unwrapped
-	# layout need their mod.txt paths re-prefixed with the folder name.)
-	var zip_ok := _zip_folder_recursive(zp, folder_path, folder_name)
+	# Zip the folder's CONTENTS at the archive root (no <folder>/ wrapper), so a
+	# dev folder mounts exactly like the mod you'll ship: a folder holding
+	# mod.txt + data/main.gd mounts as res://mod.txt + res://data/main.gd,
+	# identical to a .zip whose contents sit at its root. mod.txt paths are
+	# therefore root-relative (res://data/main.gd), the same whether the mod
+	# runs as a dev folder or as the shipped zip -- "work on the folder, zip it,
+	# upload it" with no path rewrites. (This reverses the v3.1.2 <folder>/ wrap:
+	# a mod authored against that wrap, using res://<folder>/... paths, must drop
+	# the <folder>/ prefix -- or add a real <folder>/ subfolder inside the mod if
+	# it wants that namespace. Namespacing is now the author's choice via their
+	# own folder layout, exactly like a zip mod.)
+	var zip_ok := _zip_folder_recursive(zp, folder_path, "")
 	zip_ok = zp.close() == OK and zip_ok
 	# Never stamp a zip that didn't fully write: a mid-zip failure can still
 	# close a structurally valid but incomplete zip, and the sidecar would

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -195,6 +195,9 @@ func read_mod_config(path: String) -> ConfigFile:
 	# _parse_mod_txt, so without this reset the prior mod's error message
 	# would leak into the next mod's launcher warning.
 	_last_mod_txt_error = ""
+	# Same leak rationale as _last_mod_txt_error: every early return below
+	# would otherwise leave the previous mod's file list in place.
+	_last_mod_txt_files.clear()
 	var zr := ZIPReader.new()
 	if zr.open(path) != OK:
 		return null
@@ -208,6 +211,12 @@ func read_mod_config(path: String) -> ConfigFile:
 		zr.close()
 		return null
 	var raw := zr.read_file("mod.txt")
+	# Capture the file list while the reader is still open -- the warning
+	# builder checks declared autoload paths against it so a path that resolves
+	# nowhere shows on the row before launch, instead of only as a boot-log
+	# line after the mod mounted and quietly did nothing.
+	for zf: String in zr.get_files():
+		_last_mod_txt_files["res://" + zf] = true
 	zr.close()
 	if raw.size() == 0:
 		_last_mod_txt_status = "parse_error"
@@ -223,6 +232,7 @@ func read_mod_config(path: String) -> ConfigFile:
 func read_mod_config_folder(folder_path: String) -> ConfigFile:
 	_last_mod_txt_status = "none"
 	_last_mod_txt_error = ""  # see read_mod_config for rationale
+	_last_mod_txt_files.clear()  # folder mods carry no captured file list
 	var mod_txt_path := folder_path.path_join("mod.txt")
 	if not FileAccess.file_exists(mod_txt_path):
 		return null

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -962,7 +962,7 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 		var fa: Dictionary = Engine.get_meta("_rtv_probe_first_args", {})
 		# Dispatch counts (dev mode only). Show top 20 hot methods. No generic
 		# threshold -- hud/interface/character _physics_process legitimately
-		# hit 90K+ calls/sec × 30s instance counts, a count-based RUNAWAY
+		# hit 90K+ calls/sec x 30s instance counts, a count-based RUNAWAY
 		# flag would drown real anomalies in expected noise.
 		#
 		# Instead, call out _ready / _enter_tree / _init specifically: those

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -340,4 +340,16 @@ func _run_pass_2() -> void:
 		if err != OK:
 			_log_critical("reload_current_scene() failed with error " + str(err))
 			return
+	# Windows hands foreground away when the Pass-1 process dies, so the
+	# relaunched window comes up behind whatever grabbed it (nothing in the
+	# boot path ever asks for it back). Wait a couple of frames so the OS has
+	# mapped the window, then ask for focus once. grab_focus can be denied by
+	# Windows foreground-activation rules; request_attention is the fallback
+	# (flashes the taskbar button instead).
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var win := get_window()
+	if win != null:
+		win.grab_focus()
+		win.request_attention()
 

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -998,6 +998,7 @@ func fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 	for chunk_ids in _chunk_int_array(ids, MODWORKSHOP_BATCH_SIZE):
 		var req := HTTPRequest.new()
 		req.timeout = API_CHECK_TIMEOUT
+		req.download_body_size_limit = MWS_JSON_BODY_LIMIT
 		add_child(req)
 		# The API reads mod_ids as repeated ?mod_ids[]= query params, NOT a GET
 		# request body -- a JSON body is ignored and returns 422, silently
@@ -1007,7 +1008,7 @@ func fetch_latest_modworkshop_versions(ids: Array[int]) -> Dictionary:
 		for mid in chunk_ids:
 			qparts.append("mod_ids[]=" + str(mid))
 		var err := req.request(MODWORKSHOP_VERSIONS_URL + "?" + "&".join(qparts),
-			PackedStringArray(["Accept: application/json"]),
+			_mws_default_headers(),
 			HTTPClient.METHOD_GET)
 		if err != OK:
 			req.queue_free()
@@ -1155,7 +1156,12 @@ func download_and_replace_mod(target_path: String, modworkshop_id: int) -> Dicti
 	req.timeout = API_DOWNLOAD_TIMEOUT
 	req.download_body_size_limit = 256 * 1024 * 1024
 	add_child(req)
-	var err := req.request(MODWORKSHOP_DOWNLOAD_URL_TEMPLATE % str(modworkshop_id))
+	# The API answers a default/empty User-Agent with a bodyless 403 (see the
+	# note at the top of mws_api.gd), so this legacy route needs the same UA
+	# the _mws_get_json chokepoint sends. No Accept header -- this is a file
+	# download, not a JSON route.
+	var err := req.request(MODWORKSHOP_DOWNLOAD_URL_TEMPLATE % str(modworkshop_id),
+		PackedStringArray(["User-Agent: " + (MWS_USER_AGENT_TEMPLATE % MODLOADER_VERSION)]))
 	if err != OK:
 		req.queue_free()
 		failure["error"] = "Could not start the download request (error %d)" % err
@@ -1318,12 +1324,17 @@ func download_new_mod(modworkshop_id: int, version: String = "", allow_rename_on
 	var err := req.request(download_url, headers)
 	if err != OK:
 		req.queue_free()
-		failure["error"] = "Failed to start download"
+		failure["error"] = "Could not start the download request (error %d)" % err
 		return failure
 	var res: Array = await req.request_completed
 	req.queue_free()
 	if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
-		failure["error"] = "Download failed (HTTP " + str(res[1]) + ")"
+		# Transport failures never produce a status code -- res[1] is 0 there, so
+		# formatting it would report a meaningless "HTTP 0". Split the branches.
+		if res[0] != HTTPRequest.RESULT_SUCCESS:
+			failure["error"] = "Download failed (connection error or timeout) -- check your network and retry"
+		else:
+			failure["error"] = mws_error_status("Download failed (HTTP %d)" % int(res[1]))
 		return failure
 	var resp_headers: PackedStringArray = res[2]
 	var body: PackedByteArray = res[3]

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -393,7 +393,7 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 		else:
 			warnings.append("mod.txt parse error at " + detail)
 	elif status.begins_with("nested:"):
-		warnings.append("Invalid mod -- packaged incorrectly. Try re-downloading.")
+		warnings.append("Invalid mod -- mod.txt is in a subfolder, not at the zip root. Re-zip so mod.txt is at the root.")
 	return warnings
 
 func _parse_dependency_list(cfg: ConfigFile, key: String) -> Array[String]:

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -781,15 +781,23 @@ func _enable_required_deps(entry: Dictionary) -> Dictionary:
 	return {"enabled_names": enabled_names, "unfixed": unfixed}
 
 # Display name for a dependency id: the installed mod's name when we have
-# it, the raw id otherwise.
-func _dependency_display_for_id(dep_id: String) -> String:
+# it, the raw id otherwise. Callers in a loop should pass a prebuilt
+# _entries_by_mod_id map -- the null fallback rebuilds the whole map
+# (O(installed mods) inserts) on every call.
+func _dependency_display_for_id(dep_id: String, installed_by_id: Variant = null) -> String:
 	var dep_key := dep_id.strip_edges().to_lower()
-	var installed_by_id := _entries_by_mod_id(_ui_mod_entries)
-	if installed_by_id.has(dep_key):
-		return str((installed_by_id[dep_key] as Dictionary).get("mod_name", dep_id))
+	var by_id: Dictionary = installed_by_id if installed_by_id is Dictionary \
+			else _entries_by_mod_id(_ui_mod_entries)
+	if by_id.has(dep_key):
+		return str((by_id[dep_key] as Dictionary).get("mod_name", dep_id))
 	return dep_id
 
-func _refresh_dependency_status() -> void:
+# Returns the _loadable_enabled_entries pick it computed mid-pass, so hot
+# callers (the order panel's refresh_order, fired per held spin-arrow step)
+# can reuse it instead of running the sort + topological-order + blocked-set
+# pipeline a second time. Callers that only want the entry-side effects can
+# ignore the return value.
+func _refresh_dependency_status() -> Dictionary:
 	var installed_by_id := _entries_by_mod_id(_ui_mod_entries)
 	var enabled_by_id := _entries_by_mod_id(_ui_mod_entries.filter(
 			func(e): return bool((e as Dictionary).get("enabled", false))))
@@ -866,6 +874,7 @@ func _refresh_dependency_status() -> void:
 		else:
 			entry["dependency_blockers"] = blockers
 			entry["dependencies_satisfied"] = blockers.is_empty()
+	return pick
 
 # Returns -1/0/1 for version comparison (a < b, equal, a > b).
 func compare_versions(a: String, b: String) -> int:

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -91,6 +91,7 @@ func _build_archive_entry(mods_dir: String, file_name: String, ext: String) -> D
 	var full_path := mods_dir.path_join(file_name)
 	if ext == "pck":
 		_last_mod_txt_status = "pck"
+		_last_mod_txt_files.clear()  # no read_mod_config call to reset it
 	var cfg: ConfigFile = read_mod_config(full_path) if ext != "pck" else null
 	var entry := _entry_from_config(cfg, file_name, full_path, ext)
 	entry["warnings"] = _build_entry_warnings(entry)
@@ -394,6 +395,41 @@ func _build_entry_warnings(entry: Dictionary) -> Array[String]:
 			warnings.append("mod.txt parse error at " + detail)
 	elif status.begins_with("nested:"):
 		warnings.append("Invalid mod -- mod.txt is in a subfolder, not at the zip root. Re-zip so mod.txt is at the root.")
+	elif status == "ok":
+		warnings.append_array(_autoload_path_warnings(entry))
+	return warnings
+
+# Catch autoload paths that point nowhere inside the mod. Such a mod mounts,
+# reports success, and then does absolutely nothing -- the most confusing
+# failure an author can hit, and until now the only trace was an
+# "Autoload path not found in archive" line in the boot log they had no reason
+# to open.
+#
+# Reads the _last_mod_txt_files side channel, which is why this must stay
+# immediately downstream of the entry's own read_mod_config (see constants.gd).
+#
+# Deliberately conservative: warns ONLY when the same filename exists at a
+# different path inside the archive, i.e. the prefix is wrong and we can name
+# the right one. A path with no counterpart is left alone, since pointing an
+# autoload at a vanilla res:// script (or at a file another mod provides) is
+# legitimate and must not be flagged.
+func _autoload_path_warnings(entry: Dictionary) -> Array[String]:
+	var warnings: Array[String] = []
+	var cfg: ConfigFile = entry.get("cfg")
+	if cfg == null or not cfg.has_section("autoload") or _last_mod_txt_files.is_empty():
+		return warnings
+	for autoload_name: String in cfg.get_section_keys("autoload"):
+		# Strip the early-load marker; it is not part of the path.
+		var res_path := str(cfg.get_value("autoload", autoload_name, "")).lstrip("!")
+		if res_path.is_empty() or _last_mod_txt_files.has(res_path):
+			continue
+		var target := res_path.get_file().to_lower()
+		for p: String in _last_mod_txt_files:
+			if p.get_file().to_lower() == target:
+				warnings.append("Autoload \"" + autoload_name + "\" points at "
+					+ res_path + ", which is not in this mod -- did you mean "
+					+ p + "?")
+				break
 	return warnings
 
 func _parse_dependency_list(cfg: ConfigFile, key: String) -> Array[String]:

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -178,7 +178,7 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 		if cfg == null and ext != "pck":
 			var status: String = c.get("mod_txt_status", "none")
 			if status.begins_with("nested:"):
-				_log_warning("  Invalid mod -- packaged incorrectly (nested mod.txt at " + status.substr(7) + ")")
+				_log_warning("  Invalid mod -- mod.txt is inside a subfolder (" + status.substr(7) + "), not at the zip root. Zip the mod's CONTENTS so mod.txt sits at the zip root, not the folder that holds them.")
 			elif status == "parse_error":
 				var detail: String = c.get("mod_txt_error", "")
 				if detail.is_empty():

--- a/src/modpacks.gd
+++ b/src/modpacks.gd
@@ -849,14 +849,35 @@ func _get_missing_mods_for_modpack(entry: Dictionary) -> Array:
 	return missing
 
 
+# Wait out an armed ModWorkshop rate-limit cooldown before starting the next
+# download. Once a 429 (or a spent rate budget) arms the cooldown, every
+# metadata lookup fails fast in milliseconds -- without this pause, one
+# mid-apply rate limit turns every remaining mod in the pack into a failure
+# row. Ticks once per second so the progress dialog can show a live
+# countdown ("rate_wait" action with wait_s) and a Cancel click is honored
+# promptly. This only delays the NEXT attempt until the window reopens; it
+# never retries a request itself, so it cannot loop forever.
+func _await_mws_rate_cooldown(progress: Callable, current: int, total: int) -> void:
+	while not _modpack_apply_cancelled:
+		var wait_s := mws_rate_cooldown_seconds()
+		if wait_s <= 0:
+			return
+		if progress.is_valid():
+			progress.call({"current": current, "total": total, "mod_name": "", "action": "rate_wait", "wait_s": wait_s})
+		if get_tree() == null:
+			return
+		await get_tree().create_timer(1.0).timeout
+
+
 # Apply a discovered modpack. Snapshots current state to a backup slot,
 # downloads any missing mods declared in `sources`, materializes the
 # modpack into a profile (creates from zip on first apply, resumes on
 # subsequent applies preserving user edits), switches to it, and marks
 # active. progress is an optional Callable(info: Dictionary) invoked per
 # step with {current: int, total: int, mod_name: String, action: String}
-# where action is one of "downloading" | "skipped" | "applying" (mod_name
-# is "" for "applying"), so the UI can show download progress. Returns
+# where action is one of "downloading" | "skipped" | "applying" |
+# "rate_wait" (mod_name is "" for "applying"/"rate_wait"; "rate_wait"
+# carries an extra wait_s), so the UI can show download progress. Returns
 # {ok, error, downloaded, failed_downloads}.
 func apply_modpack(entry: Dictionary, tabs: TabContainer, progress: Callable = Callable()) -> Dictionary:
 	# Concurrency guard. apply_modpack awaits during downloads; without this
@@ -919,6 +940,13 @@ func _apply_modpack_inner(entry: Dictionary, tabs: TabContainer, progress: Calla
 		_log_info("[Modpack] applying " + sanitized + ": " + str(missing.size()) + " mod(s) to install")
 		var total := missing.size()
 		for i in range(total):
+			# If a rate-limit cooldown is armed, wait it out BEFORE the next
+			# download instead of letting its metadata lookups fail fast --
+			# otherwise one mid-apply 429 mass-fails every remaining mod in
+			# milliseconds. The wait ticks per second, reports a countdown
+			# via progress, and returns early on cancel (caught just below).
+			if mws_rate_cooldown_seconds() > 0:
+				await _await_mws_rate_cooldown(progress, i + 1, total)
 			# Check the cancel flag BEFORE each download so an in-flight one
 			# completes (no way to interrupt HTTPRequest mid-await cleanly
 			# without refactoring download_new_mod) but no further ones
@@ -1246,8 +1274,12 @@ func unload_modpack(tabs: TabContainer) -> Dictionary:
 # Re-attempt the failed downloads from a previous apply. The active modpack
 # is unchanged; this just runs the download step again for items that
 # failed the first time. After any new successes, re-runs collect to get
-# the new mod files into _ui_mod_entries. Returns {downloaded, failures}
-# where failures has the same shape as apply's (still-failed items only).
+# the new mod files into _ui_mod_entries. Honors _modpack_apply_cancelled
+# at each loop top (set by the retry progress dialog's Cancel button):
+# not-yet-attempted items stay in the failures list so the follow-up
+# failure dialog re-lists them -- nothing is silently dropped. Returns
+# {downloaded, failures, cancelled} where failures has the same shape as
+# apply's (still-failed items only).
 func retry_failed_downloads(failures: Array, progress: Callable = Callable()) -> Dictionary:
 	var still_failed: Array = []
 	var newly_downloaded: int = 0
@@ -1255,12 +1287,24 @@ func retry_failed_downloads(failures: Array, progress: Callable = Callable()) ->
 		var item = failures[i]
 		if not (item is Dictionary):
 			continue
+		# Cancelled: keep the remaining items as still-failed instead of
+		# attempting them, mirroring _apply_modpack_inner's loop-top check.
+		if _modpack_apply_cancelled:
+			still_failed.append(item)
+			continue
 		var pk: String = str(item.get("profile_key", "?"))
 		var mws_id: int = int(item.get("mws_id", 0))
 		var version: String = str(item.get("version", ""))
 		if mws_id <= 0:
 			still_failed.append(item)
 			continue
+		# Same rate-limit pause as the apply loop: wait out an armed cooldown
+		# instead of fail-fasting the rest of the retry pass.
+		if mws_rate_cooldown_seconds() > 0:
+			await _await_mws_rate_cooldown(progress, i + 1, failures.size())
+			if _modpack_apply_cancelled:
+				still_failed.append(item)
+				continue
 		if progress.is_valid():
 			progress.call({"current": i + 1, "total": failures.size(), "mod_name": pk, "action": "retrying"})
 		_log_info("[Modpack][Retry] " + pk + " (mws_id=" + str(mws_id) + ")")
@@ -1282,7 +1326,7 @@ func retry_failed_downloads(failures: Array, progress: Callable = Callable()) ->
 		var cfg := ConfigFile.new()
 		cfg.load(UI_CONFIG_PATH)
 		_apply_profile_to_entries(cfg, _active_profile)
-	return {"downloaded": newly_downloaded, "failures": still_failed}
+	return {"downloaded": newly_downloaded, "failures": still_failed, "cancelled": _modpack_apply_cancelled}
 
 
 # Save the named profile as a modpack zip in <game>/mods/. Used by the

--- a/src/mws_api.gd
+++ b/src/mws_api.gd
@@ -98,6 +98,10 @@ func _mws_get_json(url: String, cache_ttl_ms: int = 0, allow_rate_wait: bool = t
 
 	var req := HTTPRequest.new()
 	req.timeout = API_CHECK_TIMEOUT
+	# JSON list responses run ~100KB at limit=50. Cap the buffer so a captive
+	# portal or a misbehaving proxy streaming a huge 2xx body can't grow
+	# unbounded for the whole timeout window.
+	req.download_body_size_limit = MWS_JSON_BODY_LIMIT
 	add_child(req)
 
 	var err := req.request(url, _mws_default_headers(), HTTPClient.METHOD_GET)
@@ -235,11 +239,20 @@ func _mws_discover_snapshot_store(data: Dictionary) -> void:
 	# Best-effort disk write-through: a failed write just means the grace
 	# window is memory-only this session, never an error the user sees.
 	DirAccess.make_dir_recursive_absolute(_MWS_DISCOVER_SNAPSHOT_PATH.get_base_dir())
-	var f := FileAccess.open(_MWS_DISCOVER_SNAPSHOT_PATH, FileAccess.WRITE)
+	# Write-then-rename: a crash mid-write would otherwise truncate the live
+	# snapshot in place, losing the offline grace window in exactly the crash
+	# case it exists to cover.
+	var tmp_path := _MWS_DISCOVER_SNAPSHOT_PATH + ".tmp"
+	var f := FileAccess.open(tmp_path, FileAccess.WRITE)
 	if f == null:
 		return
-	f.store_string(JSON.stringify(_mws_discover_snapshot))
+	var wrote := f.store_string(JSON.stringify(_mws_discover_snapshot))
+	var werr := f.get_error()
 	f.close()
+	if not wrote or werr != OK:
+		DirAccess.remove_absolute(tmp_path)
+		return
+	DirAccess.rename_absolute(tmp_path, _MWS_DISCOVER_SNAPSHOT_PATH)
 
 # Last-good discover payload: {"data": {popular, latest}, "saved_at_unix":
 # int}, or {} when none exists yet. Memory first, then a lazy one-time disk
@@ -340,7 +353,9 @@ func _mws_data_rows(resp: Variant) -> Array:
 func mws_list_mods(query: String = "", sort: String = "bumped_at", category_id: int = 0, page: int = 1) -> Variant:
 	var params := PackedStringArray()
 	if query != "":
-		params.append("query=" + query.uri_encode())
+		# Clamp rather than let the API 422 -- an over-limit query would surface
+		# as "check your connection", a diagnosis no retry can ever fix.
+		params.append("query=" + query.substr(0, MWS_QUERY_MAX_LEN).uri_encode())
 	params.append("sort=" + sort)
 	params.append("limit=" + str(MWS_PAGE_LIMIT))
 	params.append("page=" + str(page))

--- a/src/mws_api.gd
+++ b/src/mws_api.gd
@@ -71,7 +71,7 @@ func _mws_cache_put(url: String, data: Variant, ttl_ms: int) -> void:
 # body, otherwise null. Caller awaits this -- it spawns its own HTTPRequest as a
 # child of the modloader autoload, queue_frees on completion. Pass cache_ttl_ms
 # > 0 to read/write the in-memory response cache; 0 bypasses caching entirely.
-func _mws_get_json(url: String, cache_ttl_ms: int = 0, allow_rate_wait: bool = true) -> Variant:
+func _mws_get_json(url: String, cache_ttl_ms: int = 0, allow_rate_wait: bool = true, allow_transport_retry: bool = true) -> Variant:
 	_mws_last_transport_failed = false
 	if cache_ttl_ms > 0:
 		var cached: Variant = _mws_cache_get(url)
@@ -110,8 +110,16 @@ func _mws_get_json(url: String, cache_ttl_ms: int = 0, allow_rate_wait: bool = t
 	req.queue_free()
 
 	if res[0] != HTTPRequest.RESULT_SUCCESS:
-		# No HTTP response at all -- offline / DNS / timeout. Flag it so download
-		# callers can distinguish this from a 404 and show connection copy.
+		# No HTTP response at all -- offline / DNS / timeout.
+		if allow_transport_retry and get_tree() != null:
+			# Single retry for a transient transport flake (cold DNS/TLS often
+			# fails the very first request after launch). The retry passes
+			# allow_transport_retry=false so it can never loop: a second
+			# failure falls through to the flagged null below.
+			await get_tree().create_timer(1.0).timeout
+			return await _mws_get_json(url, cache_ttl_ms, allow_rate_wait, false)
+		# Flag it so download callers can distinguish this from a 404 and show
+		# connection copy.
 		_mws_last_transport_failed = true
 		return null
 	var status: int = res[1]
@@ -281,6 +289,13 @@ func mws_discover_snapshot() -> Dictionary:
 func mws_get_popular_and_latest() -> Variant:
 	var popular: Variant = await mws_list_mods("", "weekly_score", 0, 1)
 	var latest: Variant = await mws_list_mods("", "bumped_at", 0, 1)
+	# One flake out of two sequential requests must not kill the whole landing:
+	# re-issue only the failed leg once before giving up. The healthy leg's
+	# result is kept as-is (never re-fetched), so this adds at most one request.
+	if not (popular is Dictionary):
+		popular = await mws_list_mods("", "weekly_score", 0, 1)
+	if not (latest is Dictionary):
+		latest = await mws_list_mods("", "bumped_at", 0, 1)
 	# Treat EITHER query failing as a failed fetch. The two run sequentially,
 	# so the guest budget can expire between them (popular 2xx arms the
 	# cooldown, latest fails fast at the gate) -- returning a half payload

--- a/src/security_scan.gd
+++ b/src/security_scan.gd
@@ -214,6 +214,36 @@ func _any_present(present: Dictionary, rules: Array) -> bool:
 # Compiled regex cache, indexed by rule id. Lazy-populated on first scan.
 var _security_compiled: Dictionary = {}
 
+# Scan-result cache. scan_mod re-runs on every mods-dir rescan (dev-mode
+# toggle, install/delete, modpack apply, profile refresh), and re-opening
+# every archive to run 13 regexes over every script/resource made those
+# rescans freeze the UI. Key: the mod's full_path. Value:
+# {"stamp": String, "findings": Array}. The stamp covers everything that
+# can change the scanned bytes (see _security_scan_stamp), so any content
+# change misses the cache and rescans. Process-lifetime only, never
+# persisted; bounded by the number of mods on disk.
+var _security_scan_cache: Dictionary = {}
+
+# Cheap change-detection stamp for a mod path. Archives: mtime + size.
+# Folder mods: the same recursive walk boot.gd's _stable_path_mtime uses
+# for folder-mod state hashing -- newest mtime alone misses deletions and
+# renames, so fold in the file count and the per-file path@mtime set hash
+# gathered on the same pass. Returns "" when the path can't be stat'd;
+# callers treat that as uncacheable so a vanished file never pins a stale
+# result.
+func _security_scan_stamp(full_path: String, ext: String) -> String:
+	if ext == "folder":
+		var stats := {"count": 0, "set_hash": 0}
+		var newest := _folder_recursive_mtime(full_path, stats)
+		return "f:%d:%d:%d" % [newest, int(stats["count"]), int(stats["set_hash"])]
+	var mtime := FileAccess.get_modified_time(full_path)
+	var f := FileAccess.open(full_path, FileAccess.READ)
+	if f == null:
+		return ""
+	var size := f.get_length()
+	f.close()
+	return "a:%d:%d" % [mtime, size]
+
 func _security_compile_rules() -> void:
 	if not _security_compiled.is_empty():
 		return
@@ -229,6 +259,14 @@ func _security_compile_rules() -> void:
 #   {rule, file, line, preview, description}
 func scan_mod(full_path: String, ext: String) -> Array:
 	_security_compile_rules()
+	var stamp := _security_scan_stamp(full_path, ext)
+	if not stamp.is_empty():
+		var cached: Dictionary = _security_scan_cache.get(full_path, {})
+		if not cached.is_empty() and str(cached.get("stamp", "")) == stamp:
+			# duplicate(true) so every caller owns its findings array, same
+			# as the uncached path -- mod entries must never alias each
+			# other's (or the cache's) finding dicts.
+			return (cached.get("findings", []) as Array).duplicate(true)
 	var findings: Array = []
 	match ext:
 		"vmz", "zip":
@@ -238,6 +276,11 @@ func scan_mod(full_path: String, ext: String) -> Array:
 		"folder":
 			_security_scan_folder(full_path, "", findings)
 	findings.sort_custom(_security_sort_findings)
+	if not stamp.is_empty():
+		_security_scan_cache[full_path] = {
+			"stamp": stamp,
+			"findings": findings.duplicate(true),
+		}
 	return findings
 
 # Sort by file then line so the log reads top-to-bottom.

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -548,6 +548,15 @@ func _live_entry_for_profile_key(profile_key: String, fallback: Dictionary) -> D
 # file so _ui_mod_entries reflects on-disk reality before the Mods tab rebuilds.
 # Callers keep their own (divergent) _rebuild_mods_tab guard after this returns.
 func _reload_entries_for_active_profile() -> void:
+	# Flush a pending debounced priority edit BEFORE reloading. A load-order
+	# drag arms the 0.4s _schedule_priority_save timer and the edit lives only
+	# in _ui_mod_entries until it fires; the reload below replaces those dicts
+	# from the on-disk config, so an async download completing mid-window would
+	# silently revert the edit -- and the late timer would then persist the
+	# reverted state. Same flush _switch_profile does for the same race.
+	if _priority_save_pending:
+		_priority_save_pending = false
+		_save_ui_config()
 	_ui_mod_entries = collect_mod_metadata()
 	var cfg := ConfigFile.new()
 	cfg.load(UI_CONFIG_PATH)
@@ -884,8 +893,9 @@ func _show_save_modpack_dialog(profile_to_save: String, orphans: Array, tabs: Ta
 	d.title = "Save partial modpack?" if has_orphans else "Save as modpack"
 	# Sized so name + author + description all fit without the outer scroll
 	# swallowing the description (the name field pushed content past the old
-	# 220px). Still capped to sit inside the 640-tall launcher.
-	d.min_size = Vector2i(600, 520 if has_orphans else 420)
+	# 220px). Clamped to the live launcher size -- the fixed 600x520 was
+	# taller than the launcher's 640x420 minimum and got clipped.
+	d.min_size = _dialog_fit_size(Vector2i(600, 520 if has_orphans else 420))
 	d.max_size = Vector2i(780, 600)
 
 	var outer_scroll := ScrollContainer.new()
@@ -996,6 +1006,19 @@ func _show_save_modpack_dialog(profile_to_save: String, orphans: Array, tabs: Ta
 			list.add_child(lbl)
 
 	d.ok_button_text = "Save anyway" if has_orphans else "Save modpack"
+	# Keep the dialog open until the save actually succeeds: freeing the
+	# form BEFORE validating meant a name collision (or invalid name)
+	# destroyed the typed name/author/description and the user had to
+	# retype everything. Same inline-error pattern as New/Rename profile.
+	d.dialog_hide_on_ok = false
+	# Error label OUTSIDE the scroll (sibling of it) so it is always
+	# visible above the button bar regardless of scroll position.
+	var err_lbl := Label.new()
+	err_lbl.add_theme_color_override("font_color", COL_ERR)
+	err_lbl.add_theme_font_size_override("font_size", FS_BODY)
+	err_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	err_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	d.add_child(err_lbl)
 	_attach_ui_dialog(d)
 	# "Save anyway" is a caution (this modpack cannot fully auto-download),
 	# not an encouraged action -- keep the danger voice on the orphan path.
@@ -1008,17 +1031,21 @@ func _show_save_modpack_dialog(profile_to_save: String, orphans: Array, tabs: Ta
 			var pack_name := name_input.text.strip_edges()
 			var desc := desc_input.text
 			var author := author_input.text.strip_edges()
-			d.queue_free()
 			if pack_name == "":
 				pack_name = profile_to_save
 			# Remember author across saves -- avoids forcing the user to
 			# retype their handle every modpack. Cleared if they explicitly
 			# blank it out.
 			_save_preferred_author(author)
+			# Validate/save BEFORE freeing the dialog (dialog_hide_on_ok is
+			# false): on any failure -- name collision, invalid name, export
+			# error -- the form survives with everything typed and the error
+			# shows inline instead of in a dialog over a destroyed form.
 			var result := save_profile_as_modpack(profile_to_save, pack_name, desc, author)
 			if not bool(result.get("ok", false)):
-				_show_error_dialog("Could not save modpack", str(result.get("error", "unknown")))
+				err_lbl.text = str(result.get("error", "unknown"))
 				return
+			d.queue_free()
 			_rebuild_modpacks_tab(tabs)
 			# Confirm what happened, where the file is, and how to share it --
 			# the save is otherwise silent, leaving the user unsure it worked.
@@ -1458,6 +1485,12 @@ func _rebuild_updates_tab(tabs: TabContainer) -> void:
 	var old := tabs.get_node_or_null(UI_TAB_UPDATES)
 	if old == null:
 		return
+	# Carry the list scroll across the teardown (same pattern as
+	# _rebuild_mods_tab) -- without this, switching away and back snapped a
+	# long list back to the top.
+	var saved_scroll := 0
+	if is_instance_valid(_ui_updates_scroll):
+		saved_scroll = _ui_updates_scroll.scroll_vertical
 	_rebuilding_tab_in_place = true
 	var idx := old.get_index()
 	var current_tab_node := tabs.get_tab_control(tabs.current_tab) if tabs.get_tab_count() > 0 else null
@@ -1474,6 +1507,17 @@ func _rebuild_updates_tab(tabs: TabContainer) -> void:
 			tabs.current_tab = i
 			break
 	_rebuilding_tab_in_place = false
+	if saved_scroll > 0:
+		_restore_updates_scroll(saved_scroll)
+
+# Restore one frame later: the fresh rows haven't been laid out yet when
+# _rebuild_updates_tab returns, so setting scroll_vertical immediately clamps
+# against a zero-height list and lands back at the top (same as
+# _restore_mods_scroll).
+func _restore_updates_scroll(saved_scroll: int) -> void:
+	await get_tree().process_frame
+	if is_instance_valid(_ui_updates_scroll):
+		_ui_updates_scroll.scroll_vertical = saved_scroll
 
 # Modpack-apply failure summary with per-mod rows. Each failure shows the
 # profile_key + reason + an "Open MWS page" button (when an mws_id is
@@ -1486,7 +1530,9 @@ func _show_modpack_failure_dialog(downloaded: int, failures: Array, tabs: TabCon
 	var d := AcceptDialog.new()
 	d.title = "Modpack applied with issues"
 	d.ok_button_text = "Close"
-	d.min_size = Vector2i(540, 420)
+	# Clamped to the launcher: at the 640x420 window minimum a fixed
+	# 540x420 dialog was clipped by the embedder (button bar cut off).
+	d.min_size = _dialog_fit_size(Vector2i(540, 420))
 
 	var box := VBoxContainer.new()
 	box.add_theme_constant_override("separation", SP_M)
@@ -1497,7 +1543,9 @@ func _show_modpack_failure_dialog(downloaded: int, failures: Array, tabs: TabCon
 	box.add_child(hdr)
 
 	var scroll := ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(520, 280)
+	# Track the (possibly clamped) dialog size, keeping the original
+	# 20x140 chrome allowance (540x420 dialog held a 520x280 scroll).
+	scroll.custom_minimum_size = Vector2(d.min_size - Vector2i(20, 140))
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	box.add_child(scroll)
@@ -1575,26 +1623,27 @@ func _show_modpack_failure_dialog(downloaded: int, failures: Array, tabs: TabCon
 # dialog during, then re-shows the failure dialog if anything still failed
 # (with one fewer entry typically -- successfully retried mods drop off).
 func _run_modpack_retry(failures: Array, tabs: TabContainer) -> void:
-	var pd := AcceptDialog.new()
-	pd.title = "Retrying failed downloads"
-	pd.min_size = Vector2i(440, 120)
-	# Build content BEFORE _attach so the helper reparents it into the
-	# root VBox with the injected title -- adding after _attach would
-	# leave the status label outside the layout.
-	var status_lbl := Label.new()
-	status_lbl.text = "Preparing..."
-	status_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	status_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	status_lbl.custom_minimum_size.x = 400
-	pd.add_child(status_lbl)
-	_attach_ui_dialog(pd)
-	# Swallow ESC while downloads run, same as the apply progress dialog:
-	# a hidden (not cancelled) exclusive dialog would lift the input block
-	# and let the user Launch / apply another modpack mid-retry.
-	pd.dialog_close_on_escape = false
-	var pd_ok := pd.get_ok_button()
-	if pd_ok != null:
-		pd_ok.visible = false
+	# Reuse the apply progress dialog so the retry pass gets the same
+	# ProgressBar + Cancel affordance. The old hand-rolled dialog swallowed
+	# ESC (correctly -- a hidden exclusive dialog lifts the input block) but
+	# offered NO cancel control, trapping the user for the whole sequential
+	# download run (up to 300s per item on a bad connection). Cancel sets
+	# the shared _modpack_apply_cancelled flag, which
+	# retry_failed_downloads checks at each loop top.
+	_modpack_apply_cancelled = false
+	var progress_ui := _build_modpack_progress_dialog("", "Retrying failed downloads")
+	var pd: AcceptDialog = progress_ui["dialog"]
+	var pd_bar: ProgressBar = progress_ui["bar"]
+	var status_lbl: Label = progress_ui["status"]
+	var pd_cancel: Button = progress_ui["cancel"]
+	pd_cancel.pressed.connect(func():
+		if is_instance_valid(status_lbl):
+			status_lbl.text = "Cancelling after current download..."
+		if is_instance_valid(pd_cancel):
+			pd_cancel.disabled = true
+			pd_cancel.text = "Cancelling..."
+		_modpack_apply_cancelled = true
+	)
 	pd.popup_centered()
 
 	var progress_cb := func(p: Dictionary):
@@ -1603,6 +1652,12 @@ func _run_modpack_retry(failures: Array, tabs: TabContainer) -> void:
 		var cur := int(p.get("current", 0))
 		var tot := int(p.get("total", 0))
 		var nm := str(p.get("mod_name", ""))
+		var act := str(p.get("action", ""))
+		if is_instance_valid(pd_bar) and tot > 0:
+			pd_bar.value = float(cur) / float(tot) * 100.0
+		if act == "rate_wait":
+			status_lbl.text = "Rate limited by ModWorkshop -- resuming in %ds" % int(p.get("wait_s", 0))
+			return
 		if nm != "":
 			status_lbl.text = "Retrying %d of %d:\n%s" % [cur, tot, nm]
 		else:
@@ -1667,6 +1722,21 @@ func _show_error_dialog(title: String, message: String) -> void:
 func _show_info_toast(message: String) -> void:
 	_show_accept_dialog("Mod Loader", message, "Close")
 
+
+# Clamp a dialog's desired min_size to fit inside the live launcher window.
+# Dialogs are embedded sub-windows (gui_embed_subwindows) so they can never
+# be larger than the launcher: a fixed min_size above the launcher's own
+# minimum size (640x420 logical) gets clipped by the embedder near that
+# minimum, cutting off content and the bottom button bar with no way to
+# resize the borderless dialog. Sizes here are in the launcher's LOGICAL
+# (content-scaled) coordinates -- the same space embedded windows are laid
+# out in -- so divide the physical window size by content_scale_factor.
+func _dialog_fit_size(desired: Vector2i) -> Vector2i:
+	if _ui_window == null or not is_instance_valid(_ui_window):
+		return desired
+	var scale: float = maxf(_ui_window.content_scale_factor, 0.001)
+	var avail := Vector2i(Vector2(_ui_window.size) / scale) - Vector2i(24, 24)
+	return Vector2i(mini(desired.x, maxi(avail.x, 200)), mini(desired.y, maxi(avail.y, 150)))
 
 # All launcher dialogs flow through this. Renders as a borderless dark
 # card: theme applied, OS chrome dropped, title + dialog_text consumed
@@ -2520,6 +2590,12 @@ func _apply_modpack_with_ui_flow(entry: Dictionary, tabs: TabContainer) -> void:
 				var act := str(p.get("action", ""))
 				if is_instance_valid(pd_bar) and tot > 0:
 					pd_bar.value = float(cur) / float(tot) * 100.0
+				# Rate-limit pause: the apply loop is waiting out the MWS
+				# cooldown, not downloading -- show the live countdown so
+				# the dialog doesn't look hung. Cancel stays available.
+				if act == "rate_wait":
+					pd_status.text = "Rate limited by ModWorkshop -- resuming in %ds" % int(p.get("wait_s", 0))
+					return
 				var prefix := "Downloading"
 				if act == "skipped": prefix = "Skipping (manual install)"
 				elif act == "applying": prefix = "Applying modpack"
@@ -2597,9 +2673,11 @@ func _apply_modpack_with_ui_flow(entry: Dictionary, tabs: TabContainer) -> void:
 # Cancel button. Returns the dialog plus references to the controls so
 # callers can wire signals + update them. Build content BEFORE _attach_ui_dialog
 # so the helper's reparent-children step folds them into the root VBox.
-func _build_modpack_progress_dialog(raw_name: String) -> Dictionary:
+# title_override lets the retry pass reuse the same dialog (same Cancel
+# affordance) under its own title.
+func _build_modpack_progress_dialog(raw_name: String, title_override: String = "") -> Dictionary:
 	var pd := AcceptDialog.new()
-	pd.title = "Applying modpack \"" + raw_name + "\""
+	pd.title = title_override if title_override != "" else "Applying modpack \"" + raw_name + "\""
 	pd.min_size = Vector2i(520, 200)
 	pd.ok_button_text = "Close"
 
@@ -2671,10 +2749,14 @@ func _show_modpack_detail_dialog(entry: Dictionary, active_modpack: String, tabs
 	var d := AcceptDialog.new()
 	d.title = str(entry.get("raw_name", "?"))
 	d.ok_button_text = "Close"
-	d.min_size = Vector2i(660, 540)
+	# Clamped to the launcher: the fixed 660x540 exceeded the launcher's
+	# 640x420 minimum in BOTH axes and got clipped by the embedder.
+	d.min_size = _dialog_fit_size(Vector2i(660, 540))
 
 	var scroll := ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(640, 480)
+	# Track the (possibly clamped) dialog size, keeping the original
+	# 20x60 chrome allowance (660x540 dialog held a 640x480 scroll).
+	scroll.custom_minimum_size = Vector2(d.min_size - Vector2i(20, 60))
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	d.add_child(scroll)
@@ -3299,6 +3381,8 @@ func show_mod_ui() -> void:
 	_ui_update_alert_btn = null
 	_ui_mods_scroll = null
 	_ui_modpacks_scroll = null
+	_ui_updates_scroll = null
+	_ui_updates_check_btn = null
 	# Drop the Browse-tab API response cache. It's a session optimization,
 	# not durable state -- the modloader autoload survives across launcher
 	# open/close (rare in practice) and we don't want the dict to accumulate
@@ -3996,15 +4080,82 @@ func _mods_apply_mws_meta(mod_id: int, data: Dictionary) -> void:
 					name_col.add_child(author_lbl)
 					name_col.move_child(author_lbl, 1)  # right under the name
 
+# Paint the "load failed" overlay onto every current Mods-tab row for mod_id
+# when its meta fetch failed outright (offline, mod gone). Same paint-time
+# _mods_meta_nodes lookup as _mods_apply_mws_meta, so a rebuild mid-fetch is
+# safe. Without this the cell stayed a permanently ambiguous gray panel --
+# indistinguishable from still-loading. Callers must only invoke this when no
+# memoized data exists for the id (a failed soft refresh must not caption an
+# already-painted texture).
+func _mods_paint_meta_failed(mod_id: int) -> void:
+	var rows_v: Variant = _mods_meta_nodes.get(mod_id)
+	if not (rows_v is Array):
+		return
+	for nodes_v in (rows_v as Array):
+		if not (nodes_v is Dictionary):
+			continue
+		var thumb_v: Variant = (nodes_v as Dictionary).get("thumb")
+		if is_instance_valid(thumb_v) and thumb_v is TextureRect:
+			_set_thumb_failed(thumb_v as TextureRect, true)
+
+# Serialized background meta fetches (rate-budget guard). A first launch with
+# an empty sidecar used to fire one parallel mws_get_mod per MWS-linked row at
+# window open -- on top of the Browse landing's list + categories calls --
+# which could drain the guest 90 req/min budget and arm the rate cooldown
+# through no user action. Ids queue here instead; one drain loop fetches them
+# sequentially and stops while a cooldown is armed (the per-id 60s retry
+# window in _mods_load_mws_meta lets a later rebuild re-enqueue them).
+var _mods_meta_fetch_queue: Array[int] = []
+var _mods_meta_fetch_active := false
+
+func _mods_meta_fetch_enqueue(mod_id: int) -> void:
+	# No dedupe needed: enqueue points sit behind _mods_mws_meta_retry_at,
+	# which is armed before the enqueue, so the same id can't queue twice
+	# within its retry window.
+	_mods_meta_fetch_queue.append(mod_id)
+	if _mods_meta_fetch_active:
+		return
+	_mods_meta_fetch_active = true
+	while not _mods_meta_fetch_queue.is_empty():
+		if mws_rate_cooldown_seconds() > 0:
+			# Don't spend the recovery window on background meta -- user-facing
+			# surfaces (Browse, downloads) need the budget more.
+			_mods_meta_fetch_queue.clear()
+			break
+		var next_id: int = int(_mods_meta_fetch_queue.pop_front())
+		var fetched: Variant = await mws_get_mod(next_id)
+		var fetch_ok := false
+		if fetched is Dictionary:
+			var obj: Variant = (fetched as Dictionary).get("data", fetched)
+			if obj is Dictionary and not (obj as Dictionary).is_empty():
+				fetch_ok = true
+				_mods_mws_meta_by_id[next_id] = obj
+				# Persist real fetches so the next launch renders without a
+				# request.
+				_mods_meta_sidecar_store(next_id)
+				# Paint-time node lookup -- safe even if the row (or the whole
+				# launcher) is gone by now; it just memoizes.
+				_mods_apply_mws_meta(next_id, obj)
+		if not fetch_ok:
+			# Cold-path failure (no memo to fall back on): caption the cell
+			# "load failed" instead of leaving it ambiguous gray. A failed
+			# SOFT refresh keeps its already-painted memoized texture -- no
+			# overlay there.
+			var memo_v: Variant = _mods_mws_meta_by_id.get(next_id)
+			if not (memo_v is Dictionary) or (memo_v as Dictionary).is_empty():
+				_mods_paint_meta_failed(next_id)
+	_mods_meta_fetch_active = false
+
 # Populate an installed mod row's ModWorkshop thumbnail + author, and stash the
 # mod object so the name link can open the Browse detail dialog (description +
 # file history). Memo-first (seeded from the on-disk sidecar, so relaunches and
-# offline render instantly), then the Browse snapshot, then a by-id fetch only
-# for mods neither covers. All async and best-effort: offline or a failed
-# fetch just leaves the gray placeholder and the name link shows a gentle
-# notice -- no error, no log spam. Painting goes through _mods_apply_mws_meta,
-# which resolves the row's CURRENT nodes from _mods_meta_nodes at paint time,
-# so a fetch that outlives a tab rebuild still lands on screen.
+# offline render instantly), then the Browse snapshot, then a QUEUED by-id
+# fetch only for mods neither covers. All async and best-effort: offline or a
+# failed fetch just leaves the gray placeholder and the name link shows a
+# gentle notice -- no error, no log spam. Painting goes through
+# _mods_apply_mws_meta, which resolves the row's CURRENT nodes from
+# _mods_meta_nodes at paint time, so a fetch that outlives a tab rebuild still
+# lands on screen.
 func _mods_load_mws_meta(mod_id: int) -> void:
 	_mods_meta_sidecar_load()
 	var data: Dictionary = _mods_mws_meta_by_id.get(mod_id, {})
@@ -4022,42 +4173,30 @@ func _mods_load_mws_meta(mod_id: int) -> void:
 				or int(Time.get_unix_time_from_system()) - saved_at < _MODS_META_REFRESH_SEC:
 			return
 		# Same retry window as the cold path, so racing rebuilds share one
-		# refresh request per mod per minute.
+		# refresh request per mod per minute. The queue serializes the actual
+		# fetch (memo + sidecar + repaint happen on completion there).
 		if Time.get_ticks_msec() < int(_mods_mws_meta_retry_at.get(mod_id, 0)):
 			return
 		_mods_mws_meta_retry_at[mod_id] = Time.get_ticks_msec() + 60000
-		var refreshed: Variant = await mws_get_mod(mod_id)
-		if refreshed is Dictionary:
-			var obj_v: Variant = (refreshed as Dictionary).get("data", refreshed)
-			if obj_v is Dictionary and not (obj_v as Dictionary).is_empty():
-				_mods_mws_meta_by_id[mod_id] = obj_v
-				_mods_meta_sidecar_store(mod_id)
-				_mods_apply_mws_meta(mod_id, obj_v)
+		_mods_meta_fetch_enqueue(mod_id)
 		return
-	# Skip if a recent attempt failed or is still in flight. The retry window
-	# is armed BEFORE the await, so quick racing rebuilds don't each fire a
-	# request; successes are memoed for the session below.
+	# Skip if a recent attempt failed or is still queued/in flight. The retry
+	# window is armed BEFORE the enqueue, so quick racing rebuilds don't each
+	# queue a request; successes are memoed by the drain loop.
 	if Time.get_ticks_msec() < int(_mods_mws_meta_retry_at.get(mod_id, 0)):
 		return
 	_mods_mws_meta_retry_at[mod_id] = Time.get_ticks_msec() + 60000
 	data = _mods_cached_summary_by_id(mod_id)
 	if data.is_empty():
-		var fetched: Variant = await mws_get_mod(mod_id)
-		if fetched is Dictionary:
-			var obj: Variant = (fetched as Dictionary).get("data", fetched)
-			if obj is Dictionary:
-				data = obj
-		if not data.is_empty():
-			_mods_mws_meta_by_id[mod_id] = data
-			# Persist real fetches so the next launch renders without a
-			# request; snapshot hits below stay session-only (the snapshot
-			# itself already persists).
-			_mods_meta_sidecar_store(mod_id)
-	else:
-		# Snapshot hit: memo for the session, exactly as before the sidecar.
-		_mods_mws_meta_by_id[mod_id] = data
-	if data.is_empty():
+		# Cold path: no memo, no snapshot. Queue the network fetch instead of
+		# firing it inline -- N uncached rows used to spawn N parallel requests
+		# in one build loop (see _mods_meta_fetch_enqueue). The queue memoizes,
+		# persists to the sidecar, and paints on completion; snapshot hits
+		# below stay session-only (the snapshot itself already persists).
+		_mods_meta_fetch_enqueue(mod_id)
 		return
+	# Snapshot hit: memo for the session, exactly as before the sidecar.
+	_mods_mws_meta_by_id[mod_id] = data
 	_mods_apply_mws_meta(mod_id, data)
 
 # Click handler for a Mods-row ModWorkshop name link. Opens the same detail
@@ -4348,12 +4487,29 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			_show_info_toast(msg)
 	)
 
+	# Debounce the filter rebuild: text_changed fires per keystroke, and every
+	# _rebuild_mods_tab is a full tear-down with synchronous disk work (config
+	# loads, modpack zip parse, thumbnail decodes) -- typing a word used to
+	# cost one full rebuild per letter. Same pattern as the Browse search box:
+	# keystrokes only store the text and restart the timer; the timeout does
+	# the one rebuild. The timer lives in the tab, so a rebuild from another
+	# surface frees it mid-wait -- harmless, since that rebuild already renders
+	# the stored _mods_filter_text.
+	var filter_debounce := Timer.new()
+	filter_debounce.one_shot = true
+	filter_debounce.wait_time = 0.25
+	filter_bar.add_child(filter_debounce)
+	filter_debounce.timeout.connect(func():
+		# Restore focus after the rebuild so the user can keep typing.
+		# Flag is consumed on the next build below.
+		_mods_filter_focus_pending = true
+		if is_instance_valid(tabs):
+			_rebuild_mods_tab(tabs)
+	)
 	filter_edit.text_changed.connect(func(t: String):
 		_mods_filter_text = t
-		# Each text_changed rebuilds the tab; restore focus afterward so the
-		# user can keep typing. Flag is consumed on the next build below.
-		_mods_filter_focus_pending = true
-		_rebuild_mods_tab(tabs)
+		filter_debounce.stop()
+		filter_debounce.start()
 	)
 	all_btn.pressed.connect(func():
 		for entry in _ui_mod_entries:
@@ -4449,13 +4605,16 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 
 	# Rebuilds the right-side order list from current entry state.
 	var refresh_order := func():
-		_refresh_dependency_status()
+		# _refresh_dependency_status already ran the full resolution pipeline
+		# (priority sort + topological order + blocked-set fixpoint) and hands
+		# back the same pick the loader itself uses -- the panel shows the
+		# EFFECTIVE order, so what you see is what mounts. Reusing it matters
+		# here: this closure fires per step while a load-order spin arrow is
+		# held, and a second _loadable_enabled_entries call per tick doubled
+		# the whole pipeline.
+		var pick: Dictionary = _refresh_dependency_status()
 		for child in order_list.get_children():
 			child.queue_free()
-		# Same pick the loader itself uses -- the panel shows the EFFECTIVE
-		# order (priority sort + dependency hoist), so what you see is what
-		# mounts.
-		var pick := _loadable_enabled_entries()
 		var loadable: Array = pick["loadable"]
 		var enabled_count := int(pick["enabled_count"])
 		if enabled_count == 0:
@@ -4831,6 +4990,11 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	# Track whether any row passed the filter so we can show a hint when a
 	# search or hide-disabled toggle narrows the list to zero rows.
 	var rendered_any := false
+	# Hoisted once per build for _dependency_display_for_id: its fallback
+	# rebuilds this whole map per call, and the row loop below calls it per
+	# dependency for both the visible "needs:" line and the tooltip --
+	# O(rows x deps x mods) rebuilds per keystroke without the hoist.
+	var dep_names_by_id := _entries_by_mod_id(_ui_mod_entries)
 	for entry in _ui_mod_entries:
 		if not _mods_entry_visible(entry):
 			continue
@@ -4948,7 +5112,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		if required_deps.size() > 0 or optional_deps.size() > 0:
 			var named := PackedStringArray()
 			for d in required_deps:
-				named.append(_dependency_display_for_id(str(d)))
+				named.append(_dependency_display_for_id(str(d), dep_names_by_id))
 			var dep_line := ""
 			if named.size() > 0:
 				dep_line = "needs: " + ", ".join(named)
@@ -4959,9 +5123,9 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 					dep_line = "%d optional integration(s)" % optional_deps.size()
 			var tip := PackedStringArray()
 			for d in required_deps:
-				tip.append("requires %s (%s)" % [_dependency_display_for_id(str(d)), str(d)])
+				tip.append("requires %s (%s)" % [_dependency_display_for_id(str(d), dep_names_by_id), str(d)])
 			for d in optional_deps:
-				tip.append("optional: %s (%s)" % [_dependency_display_for_id(str(d)), str(d)])
+				tip.append("optional: %s (%s)" % [_dependency_display_for_id(str(d), dep_names_by_id), str(d)])
 			name_col.add_child(_make_sub_label(dep_line, COL_TEXT_DIM, "\n".join(tip)))
 		for warn_text: String in entry.get("warnings", []):
 			name_col.add_child(_make_sub_label(warn_text, COL_AMBER, warn_text))
@@ -5138,7 +5302,12 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			_after_dep_action(tabs)
 		)
 		spin.value_changed.connect(func(val: float):
-			e["priority"] = int(val)
+			# Write through the LIVE entry like the checkbox handler above: a
+			# mid-drag rescan (e.g. a background download finishing) replaces
+			# _ui_mod_entries with fresh dicts, orphaning the captured `e` --
+			# later ticks written into it would never be saved.
+			var live_spin := _live_entry_for_profile_key(str(e.get("profile_key", "")), e)
+			live_spin["priority"] = int(val)
 			# No rebuild here: value_changed fires per step while the arrows
 			# are held, and rebuilding would destroy the SpinBox under the
 			# cursor. refresh_order recomputes dependency status for the
@@ -5224,6 +5393,18 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		# download_queue: Array of {mod_data, get_btn} dicts awaiting their
 		# turn. on_get drains this FIFO once the current download completes.
 		"download_queue": [],
+		# queue_failures / queue_done_total: per-batch failure report. A failed
+		# item's status line is synchronously overwritten while the queue
+		# drains (next item's "Downloading...", then the success re-fetch), so
+		# failures accumulate here and are summarized once the queue empties.
+		"queue_failures": [],
+		"queue_done_total": 0,
+		# categories_loaded / categories_loading: the category dropdown is
+		# populated by a one-shot fetch at tab build. These gate the retry
+		# paths (banner Retry, next successful list fetch) so the dropdown can
+		# recover from a failed first fetch without ever double-populating.
+		"categories_loaded": false,
+		"categories_loading": false,
 	}
 
 	# -- Toolbar: search + sort + category --
@@ -5308,6 +5489,28 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		status_lbl.text = text
 		status_lbl.add_theme_color_override("font_color", color)
 
+	# Mirror of set_status for downloads started from the detail dialog. The
+	# dialog is exclusive and covers the tab's status label, so failures and
+	# already-downloading/queued notices were invisible behind it -- the
+	# dialog's button just flipped back to "Download" with no explanation.
+	# _show_browse_mod_detail_dialog tags its Download button with an
+	# in-dialog status Label (meta "browse_dialog_status"); when the button
+	# that initiated the download carries that tag, render the message there
+	# too. No-op for list-row buttons and freed dialogs.
+	var set_dl_status := func(get_btn: Variant, text: String, color: Color):
+		if not is_instance_valid(get_btn):
+			return
+		var btn := get_btn as Button
+		if btn == null or not btn.has_meta("browse_dialog_status"):
+			return
+		var lbl_v: Variant = btn.get_meta("browse_dialog_status")
+		if is_instance_valid(lbl_v) and lbl_v is Label:
+			var lbl := lbl_v as Label
+			lbl.visible = true
+			lbl.text = text
+			lbl.tooltip_text = text
+			lbl.add_theme_color_override("font_color", color)
+
 	# Failure reason for the offline banner. The 429 cooldown owns the copy
 	# while it is armed (rate-limited is actionable-by-waiting, unreachable
 	# is not); otherwise the generic unreachable line.
@@ -5352,6 +5555,10 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		retry_btn.text = "Retry"
 		banner_row.add_child(retry_btn)
 		retry_btn.pressed.connect(func():
+			# The category dropdown's one-shot fetch may have failed in the
+			# same outage that raised this banner; Retry is the tab's recovery
+			# affordance, so repopulate it too (guarded no-op once loaded).
+			(state["fn_populate_categories"] as Callable).call()
 			if str(state["mode"]) == "discover":
 				(state["fn_discover_fetch"] as Callable).call()
 			else:
@@ -5457,6 +5664,26 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		var queue: Array = state["download_queue"]
 		var qsuffix := (" (" + str(queue.size()) + " queued)") if not queue.is_empty() else ""
 		set_status.call("Downloading " + str(mod_data.get("name", "?")) + qsuffix + "...", COL_AMBER)
+		set_dl_status.call(get_btn, "Downloading " + str(mod_data.get("name", "?")) + "...", COL_AMBER)
+
+		# Rate-limit pause, same as the modpack apply loop: once a 429 arms
+		# the cooldown, every remaining queued item's metadata lookup would
+		# fail fast in milliseconds and the whole batch would mass-fail.
+		# Wait it out with a visible countdown instead; the Browse tab stays
+		# interactive (no modal here). Bail if the launcher closes mid-wait.
+		var rate_waited := false
+		while mws_rate_cooldown_seconds() > 0:
+			rate_waited = true
+			if not is_instance_valid(status_lbl) or get_tree() == null:
+				state["downloading_id"] = -1
+				return
+			var wait_s := mws_rate_cooldown_seconds()
+			set_status.call("Rate limited by ModWorkshop -- resuming in %ds" % wait_s, COL_AMBER)
+			set_dl_status.call(get_btn, "Rate limited by ModWorkshop -- resuming in %ds" % wait_s, COL_AMBER)
+			await get_tree().create_timer(1.0).timeout
+		if rate_waited and is_instance_valid(status_lbl):
+			set_status.call("Downloading " + str(mod_data.get("name", "?")) + "...", COL_AMBER)
+			set_dl_status.call(get_btn, "Downloading " + str(mod_data.get("name", "?")) + "...", COL_AMBER)
 
 		var result: Dictionary = await download_new_mod(mws_id)
 		state["downloading_id"] = -1
@@ -5468,18 +5695,22 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		if not is_instance_valid(status_lbl):
 			return
 
+		# Count every completed item (success or failure) so the drain summary
+		# below can say "N of M downloads failed".
+		state["queue_done_total"] = int(state.get("queue_done_total", 0)) + 1
+
 		if bool(result.get("ok", false)):
-			# Remember that this queued batch installed at least one mod, so
-			# the drain below can still sync duplicate rows when a LATER item
-			# in the batch fails (the re-fetch is gated on the last result).
+			# Remember that this batch installed at least one mod; the drain
+			# below keys the one-shot rescan and row sync on it. The full
+			# mods-dir rescan + Mods-tab rebuild happen at drain, NOT here:
+			# per-item they re-opened every installed archive and rebuilt the
+			# hidden Mods tab once per queued download.
 			state["queue_any_success"] = true
-			_reload_entries_for_active_profile()
-			if is_instance_valid(tabs):
-				_rebuild_mods_tab(tabs)
 			if is_instance_valid(get_btn):
 				get_btn.text = "Installed"
 				get_btn.disabled = true
 			set_status.call("Installed " + str(result.get("file_name", "")), COL_OK)
+			set_dl_status.call(get_btn, "Installed " + str(result.get("file_name", "")), COL_OK)
 		else:
 			if is_instance_valid(get_btn):
 				get_btn.disabled = false
@@ -5490,15 +5721,22 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 			var err_detail := str(result.get("error", "")).strip_edges()
 			if err_detail.is_empty():
 				err_detail = "Check your connection and try again."
-			set_status.call("Could not download " + str(mod_data.get("name", "mod")) + ". " + err_detail, COL_ERR)
+			var fail_line := "Could not download " + str(mod_data.get("name", "mod")) + ". " + err_detail
+			set_status.call(fail_line, COL_ERR)
+			set_dl_status.call(get_btn, fail_line, COL_ERR)
+			# Remember the failure: while a queued batch drains, the status
+			# line above is synchronously overwritten by the next item's
+			# "Downloading...", so the drain summary below is the only report
+			# of mid-batch casualties that survives.
+			(state["queue_failures"] as Array).append(str(mod_data.get("name", "mod")) + " (" + err_detail + ")")
 
-		# Drain queue or re-render. Re-rendering frees button refs in the
-		# queue, so we only re-render once the queue is empty -- otherwise
+		# Drain queue or settle the batch. Re-rendering frees button refs in
+		# the queue, so we only re-render once the queue is empty -- otherwise
 		# subsequent items lose their "Queued" button state mid-flight.
 		#
 		# Call through `state`, NOT the captured locals. GDScript lambdas
 		# capture locals BY VALUE at creation time; this lambda was created
-		# (line ~4015) before perform_download_for_item / do_discover_fetch /
+		# before perform_download_for_item / do_discover_fetch /
 		# do_filter_fetch were assigned, so the captured copies are empty
 		# Callables. `state` is a Dictionary (reference type), so the bindings
 		# stored on it at the end of build_browse_tab are visible here.
@@ -5506,33 +5744,58 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		if not remaining.is_empty():
 			var next_item: Dictionary = remaining.pop_front()
 			(state["fn_perform_download"] as Callable).call(next_item)
-		elif bool(result.get("ok", false)):
-			# Re-render only after a SUCCESS. The re-fetch exists to flip
-			# duplicate Get buttons to Installed; on failure it would
-			# synchronously overwrite the "Download failed: ..." status with
-			# "Loading..." before it ever rendered a frame, and nothing
-			# changed on disk anyway -- so keep the failure visible instead.
-			#
-			# Carry the scroll position across the re-render: the full
-			# re-render resets the ScrollContainer to the top. The fetch
-			# lambdas consume restore_scroll and re-apply it one frame after
-			# rendering.
-			state["queue_any_success"] = false
-			if is_instance_valid(scroll):
-				state["restore_scroll"] = int(scroll.scroll_vertical)
-			if str(state["mode"]) == "discover":
-				(state["fn_discover_fetch"] as Callable).call()
-			else:
-				(state["fn_filter_fetch"] as Callable).call(false)
-		elif bool(state.get("queue_any_success", false)):
-			# Mixed batch: earlier queued downloads installed but the FINAL
-			# one failed, so the success-only re-fetch above is skipped and
-			# duplicate rows (same mod in popular AND latest) of the installed
-			# mods would keep a live Download button. Sync those rows in place
-			# -- no re-fetch, so the failure status text stays visible.
-			state["queue_any_success"] = false
-			if is_instance_valid(scroll):
-				_refresh_browse_installed_rows(scroll)
+			return
+
+		# Queue drained -- settle the whole batch at once.
+		var any_success := bool(state.get("queue_any_success", false))
+		var failures: Array = state["queue_failures"]
+		var batch_total := int(state.get("queue_done_total", 0))
+		state["queue_any_success"] = false
+		state["queue_failures"] = []
+		state["queue_done_total"] = 0
+
+		# ONE mods-dir rescan + hidden Mods-tab rebuild for the whole batch
+		# (previously per successful item -- a main-thread stall proportional
+		# to installed-mod count, multiplied by the queue length).
+		if any_success:
+			_reload_entries_for_active_profile()
+			if is_instance_valid(tabs):
+				_rebuild_mods_tab(tabs)
+
+		if failures.is_empty():
+			if any_success:
+				# Re-render only after an all-success batch. The re-fetch
+				# exists to flip duplicate Get buttons to Installed; after a
+				# failure it would synchronously overwrite the failure report
+				# with "Loading..." before it ever rendered a frame.
+				#
+				# Carry the scroll position across the re-render: the full
+				# re-render resets the ScrollContainer to the top. The fetch
+				# lambdas consume restore_scroll and re-apply it one frame
+				# after rendering.
+				if is_instance_valid(scroll):
+					state["restore_scroll"] = int(scroll.scroll_vertical)
+				if str(state["mode"]) == "discover":
+					(state["fn_discover_fetch"] as Callable).call()
+				else:
+					(state["fn_filter_fetch"] as Callable).call(false)
+			return
+
+		# At least one item failed. Skip the re-fetch (its completion would
+		# wipe the failure report with "N popular, M latest"); sync duplicate
+		# rows of installed mods in place instead -- same mod can appear in
+		# popular AND latest -- so the failure text stays visible.
+		if any_success and is_instance_valid(scroll):
+			_refresh_browse_installed_rows(scroll)
+		# Persistent batch summary: for a lone download the full error set
+		# above is already on screen and stays; for a real batch it names
+		# every failed mod, since only the LAST item's outcome survived the
+		# drain before.
+		if batch_total > 1:
+			var fail_strs := PackedStringArray()
+			for f_v in failures:
+				fail_strs.append(str(f_v))
+			set_status.call("%d of %d downloads failed: %s" % [failures.size(), batch_total, ", ".join(fail_strs)], COL_ERR)
 
 	var on_get: Callable
 	on_get = func(mod_data: Dictionary, get_btn: Button):
@@ -5542,17 +5805,21 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 			# same mod already in-flight or already queued -- silent dedup).
 			if int(state["downloading_id"]) == mws_id:
 				set_status.call("Already downloading this mod", COL_TEXT_DIM)
+				set_dl_status.call(get_btn, "Already downloading this mod", COL_TEXT_DIM)
 				return
 			var queue: Array = state["download_queue"]
 			for q_v in queue:
 				if int((q_v as Dictionary).get("mod_data", {}).get("id", 0)) == mws_id:
 					set_status.call("Already queued", COL_TEXT_DIM)
+					set_dl_status.call(get_btn, "Already queued", COL_TEXT_DIM)
 					return
 			queue.append({"mod_data": mod_data, "get_btn": get_btn})
 			if is_instance_valid(get_btn):
 				get_btn.disabled = true
 				get_btn.text = "Queued"
-			set_status.call("Queued " + str(mod_data.get("name", "?")) + " (" + str(queue.size()) + " in queue)", COL_TEXT_DIM)
+			var queued_line := "Queued " + str(mod_data.get("name", "?")) + " (" + str(queue.size()) + " in queue)"
+			set_status.call(queued_line, COL_TEXT_DIM)
+			set_dl_status.call(get_btn, queued_line, COL_TEXT_DIM)
 			return
 		perform_download_for_item.call({"mod_data": mod_data, "get_btn": get_btn})
 
@@ -5659,6 +5926,12 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 			show_browse_banner.call("Showing cached results. " + str(browse_fail_reason.call()), cached_at, COL_AMBER)
 		else:
 			clear_browse_banner.call()
+			# A live fetch landing proves connectivity is back: recover a
+			# category dropdown whose one-shot populate failed earlier
+			# (guarded no-op once loaded). Snapshot fallback proves nothing,
+			# hence the live-only branch. Through `state`: this lambda was
+			# created before populate_categories was assigned.
+			(state["fn_populate_categories"] as Callable).call()
 		set_status.call("%d popular, %d latest" % [popular.size(), latest.size()], COL_TEXT_DIM)
 		# Restore the pre-refetch scroll position one frame later: the fresh
 		# rows have no layout yet on this frame, so setting scroll_vertical
@@ -5760,6 +6033,9 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		state["next_page"] = current_page + 1
 		state["has_more"] = current_page < last_page
 		clear_browse_banner.call()
+		# Successful live fetch: recover the category dropdown if its one-shot
+		# populate failed earlier (guarded no-op once loaded).
+		(state["fn_populate_categories"] as Callable).call()
 		# Full re-render of the accumulated set. On Load more this replaces
 		# the old per-page append -- required for the global re-sort above to
 		# actually show -- so carry the current scroll position across the
@@ -5854,10 +6130,25 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	# dropdown is already a stretch UX-wise, so we surface only top-level
 	# (parent_id == null) and rely on search to find sub-category mods.
 	var populate_categories := func():
+		# Retry-able, not one-shot: the banner Retry and every successful list
+		# fetch re-invoke this until it lands, so a failed first fetch
+		# (offline launch, rate-limit cooldown) no longer leaves an
+		# "All categories"-only dropdown for the whole session. The two flags
+		# make re-invocation safe: loaded = success is permanent for the
+		# session, loading = don't stack a second in-flight fetch (which
+		# would double-populate the items on a race).
+		if bool(state.get("categories_loaded", false)) or bool(state.get("categories_loading", false)):
+			return
+		state["categories_loading"] = true
 		var data: Variant = await mws_get_categories()
+		# Bookkeeping BEFORE the validity guard so a freed dropdown can't
+		# leave the loading flag stuck true forever.
+		state["categories_loading"] = false
 		if not is_instance_valid(category_dropdown):
 			return
 		if not (data is Dictionary):
+			# Leave categories_loaded false so the next Retry / successful
+			# list fetch attempts again.
 			return
 		var rows: Array = _mws_data_rows(data)
 		for cat in rows:
@@ -5874,6 +6165,7 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 			category_dropdown.add_item(cat_name)
 			var idx := category_dropdown.item_count - 1
 			category_dropdown.set_item_metadata(idx, cat_id)
+		state["categories_loaded"] = true
 	populate_categories.call()
 
 	# Bind the forward-referenced lambdas onto `state` so the
@@ -5883,6 +6175,7 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	state["fn_perform_download"] = perform_download_for_item
 	state["fn_discover_fetch"] = do_discover_fetch
 	state["fn_filter_fetch"] = do_filter_fetch
+	state["fn_populate_categories"] = populate_categories
 
 	# Initial fetch is the curated landing page.
 	do_discover_fetch.call()
@@ -5950,6 +6243,16 @@ func _refresh_browse_installed_rows(root: Node) -> void:
 				btn.disabled = true
 
 
+# Guarded int() for API JSON fields. Dictionary.get()'s default only covers
+# an ABSENT key -- a present-but-null value flows through and int(null) is a
+# runtime error (the search sort comparator and the snapshot loader already
+# guard this way). JSON numbers parse as float, so accept int/float and
+# coerce anything else (null, string junk) to the fallback.
+func _json_int(d: Dictionary, key: String, fallback: int = 0) -> int:
+	var v: Variant = d.get(key)
+	return int(v) if (v is int or v is float) else fallback
+
+
 # Render one row in the Browse tab list. Pulls from a ModSummary dict (live
 # response shape from /games/{id}/mods or /games/{id}/popular-and-latest).
 # Thumbnail loads asynchronously via _browse_load_thumbnail_async; the row
@@ -5988,13 +6291,19 @@ func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get
 	info_col.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	row.add_child(info_col)
 
-	# Mod name doubles as the click target for the detail modal. LinkButton
-	# matches the bottom-bar self-update affordance: text by default, underlines
-	# on hover. Discoverable without crowding the row with a separate "Details"
-	# button next to Get.
-	var name_lnk := LinkButton.new()
+	# Mod name doubles as the click target for the detail modal. Flat Button,
+	# not LinkButton: LinkButton has no clip_text/overrun support, so its min
+	# width equals the full text width and one long ModWorkshop name inflated
+	# the row past the list, forcing a horizontal scrollbar and pushing the
+	# Download/Enabled control out of view. Same recipe as the Mods-tab name
+	# link (hover color is the click cue in place of underline).
+	var name_lnk := Button.new()
+	name_lnk.flat = true
 	name_lnk.text = str(mod_data.get("name", "?"))
-	name_lnk.underline = LinkButton.UNDERLINE_MODE_ON_HOVER
+	name_lnk.clip_text = true
+	name_lnk.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	name_lnk.alignment = HORIZONTAL_ALIGNMENT_LEFT
+	name_lnk.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	name_lnk.add_theme_font_size_override("font_size", FS_EMPH)
 	name_lnk.add_theme_color_override("font_color", COL_TEXT)
 	name_lnk.add_theme_color_override("font_hover_color", COL_TEXT_HI)
@@ -6009,8 +6318,8 @@ func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get
 	var category_dict: Dictionary = mod_data.get("category", {}) if mod_data.get("category") is Dictionary else {}
 	var author: String = str(user_dict.get("name", ""))
 	var version: String = str(mod_data.get("version", "")).strip_edges()
-	var downloads: int = int(mod_data.get("downloads", 0))
-	var likes: int = int(mod_data.get("likes", 0))
+	var downloads: int = _json_int(mod_data, "downloads")
+	var likes: int = _json_int(mod_data, "likes")
 	var category: String = str(category_dict.get("name", ""))
 	var bumped_raw: String = str(mod_data.get("bumped_at", ""))
 	var bumped_short: String = _format_iso_datetime(bumped_raw)
@@ -6105,6 +6414,21 @@ func _set_thumb_failed(rect: TextureRect, failed: bool) -> void:
 	wrap.add_child(lbl)
 
 
+# Session memo of decoded thumbnail textures keyed by storage filename.
+# Without it every Mods-tab rebuild (per filter keystroke) and every Browse
+# re-render re-read the disk cache and re-decoded the image into a fresh
+# ImageTexture per row -- a visible hitch that grew with each "Load more"
+# page. FIFO-bounded so a long Browse session can't hold hundreds of
+# 640px textures forever (Dictionary preserves insertion order).
+var _thumb_texture_cache: Dictionary = {}
+const _THUMB_TEXTURE_CACHE_MAX := 256
+
+func _thumb_texture_cache_store(fn: String, tex: Texture2D) -> void:
+	while _thumb_texture_cache.size() >= _THUMB_TEXTURE_CACHE_MAX:
+		_thumb_texture_cache.erase(_thumb_texture_cache.keys()[0])
+	_thumb_texture_cache[fn] = tex
+
+
 # Async thumbnail loader. Cache layout: user://mws_cache/thumbs/<storage_filename>.
 # Filenames from MWS are opaque/immutable per upload, so the storage filename
 # IS the cache key -- a thumbnail replaced by the author gets a different file
@@ -6125,6 +6449,13 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 		_set_thumb_failed(rect, false)
 		return
 
+	# Memory hit: already decoded this session -- no disk read, no decode.
+	var memo_tex_v: Variant = _thumb_texture_cache.get(fn)
+	if memo_tex_v is Texture2D:
+		if is_instance_valid(rect):
+			rect.texture = memo_tex_v as Texture2D
+		return
+
 	var cache_dir := "user://mws_cache/thumbs"
 	DirAccess.make_dir_recursive_absolute(cache_dir)
 	var cache_path := cache_dir.path_join(fn)
@@ -6142,8 +6473,10 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 				if img.load_webp_from_buffer(bytes) == OK \
 						or img.load_jpg_from_buffer(bytes) == OK \
 						or img.load_png_from_buffer(bytes) == OK:
+					var disk_tex := ImageTexture.create_from_image(img)
+					_thumb_texture_cache_store(fn, disk_tex)
 					if is_instance_valid(rect):
-						rect.texture = ImageTexture.create_from_image(img)
+						rect.texture = disk_tex
 					return
 
 	# Cache miss: fetch from CDN. The /mods/images/thumbs/ path returns 404
@@ -6220,8 +6553,10 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 		if not wrote:
 			DirAccess.remove_absolute(cache_path)
 
+	var net_tex := ImageTexture.create_from_image(img)
+	_thumb_texture_cache_store(fn, net_tex)
 	if is_instance_valid(rect):
-		rect.texture = ImageTexture.create_from_image(img)
+		rect.texture = net_tex
 
 
 # Format a byte count as a compact human-readable string. Used by the mod
@@ -6359,13 +6694,41 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 	var d := AcceptDialog.new()
 	d.title = str(mod_data.get("name", "?"))
 	d.ok_button_text = "Close"
-	d.min_size = Vector2i(660, 540)
+	# Clamped to the launcher: the fixed 660x540 exceeded the launcher's
+	# 640x420 minimum in BOTH axes and got clipped by the embedder.
+	d.min_size = _dialog_fit_size(Vector2i(660, 540))
+
+	# Single content child for the AcceptDialog (it stacks added children over
+	# the same rect): scroll on top, a download-status line pinned below it so
+	# feedback stays visible regardless of scroll position.
+	var outer := VBoxContainer.new()
+	outer.add_theme_constant_override("separation", SP_S)
+	d.add_child(outer)
 
 	var scroll := ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(640, 480)
+	# Track the (possibly clamped) dialog size, keeping the original
+	# 20x60 chrome allowance (660x540 dialog held a 640x480 scroll).
+	scroll.custom_minimum_size = Vector2(d.min_size - Vector2i(20, 60))
 	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	d.add_child(scroll)
+	outer.add_child(scroll)
+
+	# In-dialog download status. This modal is exclusive and covers the Browse
+	# tab's status label, so a download started HERE used to fail (or dedupe)
+	# with no visible feedback -- the button just flipped back to "Download".
+	# The Download button below carries this Label in its
+	# "browse_dialog_status" meta; build_browse_tab's set_dl_status mirror
+	# fills it. Hidden until the first message so it costs no height. clip
+	# + ellipsis, never autowrap: a long error must not inflate the dialog's
+	# min width (the tooltip carries the full text, set by the mirror).
+	var dl_status := Label.new()
+	dl_status.visible = false
+	dl_status.add_theme_font_size_override("font_size", FS_BODY)
+	dl_status.add_theme_color_override("font_color", COL_TEXT_DIM)
+	dl_status.clip_text = true
+	dl_status.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	dl_status.mouse_filter = Control.MOUSE_FILTER_PASS
+	outer.add_child(dl_status)
 
 	# Right-margin wrap so content doesn't sit under the scrollbar -- same
 	# trick the Browse tab's main list uses.
@@ -6414,8 +6777,8 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 	var version := str(mod_data.get("version", "")).strip_edges()
 	if version != "":
 		parts.append("v" + version)
-	parts.append(str(int(mod_data.get("downloads", 0))) + " downloads")
-	parts.append(str(int(mod_data.get("likes", 0))) + " likes")
+	parts.append(str(_json_int(mod_data, "downloads")) + " downloads")
+	parts.append(str(_json_int(mod_data, "likes")) + " likes")
 	if category_dict.has("name"):
 		parts.append(str(category_dict["name"]))
 	var bumped := _format_iso_datetime(str(mod_data.get("bumped_at", "")))
@@ -6505,12 +6868,15 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 		# The dialog's one primary action (spec section 6). List rows keep
 		# bare-theme Download buttons -- primary is at most one per surface.
 		style_primary_button(get_btn)
+		# Tag the button with the in-dialog status label so the Browse tab's
+		# download paths (set_dl_status) render feedback inside this dialog.
+		get_btn.set_meta("browse_dialog_status", dl_status)
 		var captured_data := mod_data
 		get_btn.pressed.connect(func():
 			on_get.call(captured_data, get_btn)
 		)
 
-	var primary_file_id := int(mod_data.get("download_id", 0))
+	var primary_file_id := _json_int(mod_data, "download_id")
 	var load_files := func():
 		var files_resp: Variant = await mws_list_files(mod_id)
 		if not is_instance_valid(files_status):
@@ -6534,14 +6900,14 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 
 			var v_lbl := Label.new()
 			var v_str: String = "v" + str(fd.get("version", ""))
-			if int(fd.get("id", 0)) == primary_file_id and primary_file_id > 0:
+			if _json_int(fd, "id") == primary_file_id and primary_file_id > 0:
 				v_str += " (primary)"
 			v_lbl.text = v_str
 			v_lbl.custom_minimum_size.x = 140
 			f_row.add_child(v_lbl)
 
 			var size_lbl := Label.new()
-			size_lbl.text = _format_size(int(fd.get("size", 0)))
+			size_lbl.text = _format_size(_json_int(fd, "size"))
 			size_lbl.custom_minimum_size.x = 80
 			size_lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
 			f_row.add_child(size_lbl)
@@ -6559,6 +6925,185 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 	_wire_accept_dismiss(d)
 	d.popup_centered()
 
+
+# -- Updates-tab session state -------------------------------------------------
+# The Updates tab is torn down and rebuilt on every show (tab_changed ->
+# _rebuild_updates_tab), which used to wipe a completed check's per-row
+# statuses, the Activity log, and the scroll position -- forcing the user to
+# re-run the check (spending rate budget) just to see results again. This
+# state survives rebuilds at module scope, same as _mod_updates_state does for
+# the Mods-tab badges.
+#   _updates_tab_status: profile_key -> {text, tooltip, color} snapshot of a
+#     row's TERMINAL Status text ("Up to date", "Check failed", "Updated --
+#     restart to apply", "Download failed"). Rows with an update AVAILABLE are
+#     not stored here -- they re-arm from _mod_updates_state so a mod updated
+#     from the Mods tab never shows a stale "Update: vX" here.
+#   _updates_tab_log: already-timestamped Activity lines, re-rendered on build.
+#   _updates_tab_dl_in_flight: count of this tab's row downloads currently
+#     awaiting; "Check for updates" only re-enables when it reaches zero (a
+#     single completion used to re-enable it while a second download was still
+#     running, letting a fresh check reset the downloading row).
+var _updates_tab_status: Dictionary = {}
+var _updates_tab_log: Array[String] = []
+var _updates_tab_dl_in_flight: int = 0
+# Live references to the current build's list scroller / check button so the
+# rebuild can carry scroll position and download completions can re-enable the
+# CURRENT check button even after the one they captured was freed. Cleared on
+# launcher close with the other _ui_* node refs.
+var _ui_updates_scroll: ScrollContainer = null
+var _ui_updates_check_btn: Button = null
+
+# Arm an Updates-tab row for an available update: amber status, visible
+# Download button, wired download handler. Shared by check_updates_for_ui (a
+# fresh check result) and build_updates_tab (re-arming from _mod_updates_state
+# after the on-show rebuild). State writes happen unconditionally; UI touches
+# are guarded per node because the row may have been freed by a mid-check
+# rebuild.
+func _updates_arm_row_update(info: Dictionary, latest_v: String, add_log: Callable) -> void:
+	var pre_entry: Dictionary = info.get("entry", {})
+	var pk: String = str(pre_entry.get("profile_key", "")) if not pre_entry.is_empty() else ""
+	# Surface state via _mod_updates_state so the Mods tab can show the
+	# per-row badge without re-querying, and so the on-show rebuild of this
+	# tab re-arms the row instead of wiping the result.
+	if pk != "":
+		_mod_updates_state[pk] = {
+			"latest_version": latest_v,
+			"current_version": str(info["version"]),
+			"mw_id": int(info["mw_id"]),
+			"full_path": str(info["full_path"]),
+			"mod_name": str(info["mod_name"]),
+		}
+		# An available update supersedes any stored terminal status.
+		_updates_tab_status.erase(pk)
+	var lbl: Label = info["label"]
+	var dl_btn: Button = info["dl_btn"]
+	if is_instance_valid(lbl):
+		# Amber = the update signal. Tooltip mirrors the text: long prerelease
+		# strings ellipsize in the 160px column (label is MOUSE_FILTER_PASS at
+		# creation).
+		lbl.text = "Update: v" + latest_v
+		lbl.tooltip_text = lbl.text
+		lbl.add_theme_color_override("font_color", COL_AMBER)
+	if not is_instance_valid(dl_btn):
+		return
+	dl_btn.modulate.a = 1.0
+	dl_btn.disabled = false
+	dl_btn.mouse_filter = Control.MOUSE_FILTER_STOP
+	var full_path: String = str(info["full_path"])
+	var mw_id: int = int(info["mw_id"])
+	var mod_name: String = str(info["mod_name"])
+	var new_ver: String = latest_v
+	# Guard key for _mod_update_in_flight -- the SAME dictionary the Mods-tab
+	# badge path uses, because both surfaces target the same mod file (and the
+	# same .download temp / .bak rollback paths). Path fallback only for the
+	# unexpected entry-less row.
+	var guard_key: String = pk if pk != "" else full_path
+	# Disconnect previous connections so repeated checks don't stack callbacks.
+	for c in dl_btn.pressed.get_connections():
+		dl_btn.pressed.disconnect(c["callable"])
+	dl_btn.pressed.connect(func():
+		# Refuse a second concurrent download of the same mod: the Mods-tab
+		# badge, or this same row on a pre-rebuild Updates tab, may already be
+		# running one -- two concurrent runs delete each other's temp/backup
+		# files mid-flight and corrupt the rollback.
+		if _mod_update_in_flight.has(guard_key):
+			return
+		_mod_update_in_flight[guard_key] = true
+		_updates_tab_dl_in_flight += 1
+		dl_btn.disabled = true
+		dl_btn.text = "Downloading..."
+		if is_instance_valid(lbl):
+			lbl.text = "Downloading..."
+			lbl.tooltip_text = lbl.text
+			lbl.add_theme_color_override("font_color", COL_AMBER)
+		if is_instance_valid(_ui_updates_check_btn):
+			_ui_updates_check_btn.disabled = true
+		# Re-resolve live: the Mods-tab badge may have updated/renamed this
+		# file since the Updates tab was built, orphaning the captured path.
+		var live_path: String = _live_full_path(pk, full_path)
+		var result: Dictionary = await download_and_replace_mod(live_path, mw_id)
+		# -- State bookkeeping FIRST, unconditionally. The on-show rebuild can
+		# free every node this closure captured while the download is in
+		# flight; an early return on node validity here used to silently drop
+		# ALL of it, leaving the tab offering an update that was already
+		# installed (whose retry then hits the file-collision error until a
+		# rescan). UI touches are guarded individually below instead.
+		_mod_update_in_flight.erase(guard_key)
+		_updates_tab_dl_in_flight = maxi(0, _updates_tab_dl_in_flight - 1)
+		# Only re-enable the (current) check button when NO downloads remain --
+		# the first of two completions used to re-enable it mid-download.
+		if _updates_tab_dl_in_flight == 0 and is_instance_valid(_ui_updates_check_btn):
+			_ui_updates_check_btn.disabled = false
+		if result.get("ok", false):
+			# Update cached version so next Check won't re-flag this mod.
+			info["version"] = new_ver
+			# Reflect the on-disk rename in the in-memory entry so the next
+			# discovery pass (and any subsequent UI rebuild before relaunch)
+			# point at the right archive instead of the old filename that no
+			# longer exists. Write through the LIVE entry dict: a rescan may
+			# have replaced _ui_mod_entries since this row was built.
+			var new_path: String = str(result.get("new_path", full_path))
+			var new_fn: String = str(result.get("new_file_name", full_path.get_file()))
+			info["full_path"] = new_path
+			var entry_ref: Dictionary = _live_entry_for_profile_key(pk, pre_entry)
+			if not entry_ref.is_empty():
+				entry_ref["full_path"] = new_path
+				entry_ref["file_name"] = new_fn
+			if pk != "":
+				# Drop the shared badge state so the Mods tab stops offering an
+				# update that was just installed, and persist the terminal
+				# status so a rebuilt tab shows the outcome.
+				_mod_updates_state.erase(pk)
+				_updates_tab_status[pk] = {
+					"text": "Updated -- restart to apply",
+					"tooltip": "Updated -- restart to apply",
+					"color": COL_OK,
+				}
+			# The badge state changed while the Mods tab may be off-screen.
+			_mods_badges_dirty = true
+			var rename_note: String = (" (renamed to " + new_fn + ")") if new_fn != full_path.get_file() else ""
+			add_log.call(mod_name + " -- updated to v" + new_ver + rename_note + ". Restart game to apply.")
+			if is_instance_valid(lbl):
+				lbl.text = "Updated -- restart to apply"
+				lbl.tooltip_text = lbl.text
+				lbl.add_theme_color_override("font_color", COL_OK)
+			if is_instance_valid(dl_btn):
+				dl_btn.modulate.a = 0.0
+				dl_btn.disabled = true
+				dl_btn.mouse_filter = Control.MOUSE_FILTER_IGNORE
+				dl_btn.text = "Update"
+			var ver_lbl_v: Variant = info.get("ver_lbl")
+			if ver_lbl_v is Label and is_instance_valid(ver_lbl_v):
+				(ver_lbl_v as Label).text = "v" + new_ver
+				(ver_lbl_v as Label).tooltip_text = "v" + new_ver
+		else:
+			# Surface the REAL failure cause ("A different file named X is
+			# already in the mods folder", "file may be locked", rate-limit
+			# copy) instead of always blaming the connection -- retrying a
+			# non-network problem forever is the trap the old copy set.
+			var err_detail := str(result.get("error", ""))
+			var log_line := "Could not download " + mod_name + ". Check your connection and try again."
+			if err_detail != "" and err_detail != "unknown":
+				log_line = "Could not download " + mod_name + " -- " + err_detail
+			if pk != "":
+				_updates_tab_status[pk] = {"text": "Download failed", "tooltip": log_line, "color": COL_ERR}
+			add_log.call(log_line)
+			if is_instance_valid(lbl):
+				lbl.text = "Download failed"
+				lbl.tooltip_text = log_line
+				lbl.add_theme_color_override("font_color", COL_ERR)
+			if is_instance_valid(dl_btn):
+				dl_btn.disabled = false
+				dl_btn.text = "Retry"
+	)
+
+# Scroll the restored Activity log to its newest line one frame later -- the
+# fresh labels have no layout on the build frame, so an immediate
+# scroll_vertical set clamps against a zero content height.
+func _updates_scroll_log_to_bottom(sc: ScrollContainer) -> void:
+	await get_tree().process_frame
+	if is_instance_valid(sc):
+		sc.scroll_vertical = 999999
 
 func build_updates_tab() -> Control:
 	var margin := _make_tab_margin()
@@ -6579,7 +7124,13 @@ func build_updates_tab() -> Control:
 	var check_btn := Button.new()
 	check_btn.text = "Check for updates"
 	style_primary_button(check_btn)
+	# A tab rebuilt mid-download must not offer a check that would reset the
+	# downloading row; the last completing download re-enables this via the
+	# _ui_updates_check_btn member.
+	if _updates_tab_dl_in_flight > 0:
+		check_btn.disabled = true
 	toolbar.add_child(check_btn)
+	_ui_updates_check_btn = check_btn
 
 	container.add_child(HSeparator.new())
 
@@ -6620,6 +7171,7 @@ func build_updates_tab() -> Control:
 	var scroll := ScrollContainer.new()
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	container.add_child(scroll)
+	_ui_updates_scroll = scroll
 
 	var list := VBoxContainer.new()
 	list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -6693,8 +7245,13 @@ func build_updates_tab() -> Control:
 			# there is no Download button instead of offering one that misfires.
 			status_lbl.text = "Dev folder"
 			status_lbl.tooltip_text = "Dev folders load straight from your mods folder, so there is nothing to download. Update downloads only apply to mods installed as archives."
+		elif mw_id == 0 or version == "":
+			# Explain WHY this row cannot be checked (the adjacent Dev-folder
+			# state already explains itself; this one used to sit unexplained).
+			status_lbl.text = "No update info"
+			status_lbl.tooltip_text = "This mod's mod.txt has no ModWorkshop update info ([updates] modworkshop= plus [mod] version=), so it cannot be checked. Add both fields to enable update checks."
 		else:
-			status_lbl.text = "No update info" if mw_id == 0 or version == "" else "--"
+			status_lbl.text = "--"
 		row.add_child(status_lbl)
 
 		# Always add dl_btn to preserve column width. Use modulate.a to
@@ -6756,15 +7313,70 @@ func build_updates_tab() -> Control:
 	log_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	log_scroll.add_child(log_list)
 
-	var add_log := func(msg: String):
-		var t := Time.get_time_string_from_system()
+	var log_label := func(line: String) -> Label:
 		var lbl := Label.new()
-		lbl.text = "[" + t + "] " + msg
+		lbl.text = line
 		lbl.add_theme_font_size_override("font_size", FS_BODY)
 		lbl.add_theme_color_override("font_color", COL_TEXT)
 		lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		log_list.add_child(lbl)
+		return lbl
+
+	var add_log := func(msg: String):
+		var t := Time.get_time_string_from_system()
+		var line := "[" + t + "] " + msg
+		# Persist FIRST: a download can finish after this tab was rebuilt
+		# (freeing log_list); the line must survive into the restored log.
+		_updates_tab_log.append(line)
+		if not is_instance_valid(log_list):
+			return
+		log_list.add_child(log_label.call(line))
 		log_scroll.scroll_vertical = 999999
+
+	# Restore Activity lines from earlier checks/downloads this session -- the
+	# tab is rebuilt on every show and used to wipe the log. Scroll to the
+	# newest line one frame later: the restored labels have no layout yet, so
+	# an immediate set would clamp to 0.
+	for line in _updates_tab_log:
+		log_list.add_child(log_label.call(line))
+	if not _updates_tab_log.is_empty():
+		_updates_scroll_log_to_bottom(log_scroll)
+
+	# Restore per-row results from earlier checks this session (the rebuild
+	# used to reset every row to "--", forcing a re-check -- and a re-spend of
+	# rate budget -- just to re-see results). Precedence: a download in flight
+	# renders the row inert (a fresh live Update button here would allow a
+	# second concurrent download of the same file); then an available update
+	# re-arms from _mod_updates_state; then any stored terminal status.
+	for fn in status_info:
+		var info: Dictionary = status_info[fn]
+		var entry_d: Dictionary = info.get("entry", {})
+		var pk := str(entry_d.get("profile_key", ""))
+		if pk == "":
+			continue
+		var row_lbl: Label = info["label"]
+		if _mod_update_in_flight.has(pk):
+			row_lbl.text = "Downloading..."
+			row_lbl.tooltip_text = row_lbl.text
+			row_lbl.add_theme_color_override("font_color", COL_AMBER)
+			var b: Button = info["dl_btn"]
+			b.modulate.a = 1.0
+			b.disabled = true
+			b.text = "Downloading..."
+			continue
+		if _mod_updates_state.has(pk):
+			var upd: Dictionary = _mod_updates_state[pk]
+			var latest_known := str(upd.get("latest_version", ""))
+			# Re-verify against the row's CURRENT version -- the file may have
+			# been updated through another surface since the check ran.
+			if latest_known != "" and compare_versions(str(info["version"]), latest_known) < 0:
+				_updates_arm_row_update(info, latest_known, add_log)
+				continue
+		if _updates_tab_status.has(pk):
+			var st: Dictionary = _updates_tab_status[pk]
+			row_lbl.text = str(st.get("text", ""))
+			row_lbl.tooltip_text = str(st.get("tooltip", row_lbl.text))
+			var col_v: Variant = st.get("color")
+			row_lbl.add_theme_color_override("font_color", col_v if col_v is Color else COL_TEXT_DIM)
 
 	check_btn.pressed.connect(func():
 		check_btn.disabled = true
@@ -6860,17 +7472,18 @@ func _run_updates_check_for_mods() -> Dictionary:
 	return summary
 
 
-func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn: Button) -> void:
+func check_updates_for_ui(status_info: Dictionary, add_log: Callable, _check_btn: Button) -> void:
 	var ids: Array[int] = []
 	for fn in status_info:
 		ids.append(status_info[fn]["mw_id"])
 	if ids.is_empty():
+		# With only dev-folder or id-less mods installed the button used to
+		# flash "Checking for updates..." and revert with zero feedback; say
+		# why nothing happened (same copy as the Mods-tab toast).
+		add_log.call("No installed mods have ModWorkshop update info, so there is nothing to check.")
 		return
 
 	var latest := await fetch_latest_modworkshop_versions(ids)
-
-	if not is_instance_valid(check_btn):
-		return
 
 	# A check just ran, so _mod_updates_state may have gained or lost entries.
 	# This function runs from the Updates tab, where the Mods tab isn't visible
@@ -6878,112 +7491,47 @@ func check_updates_for_ui(status_info: Dictionary, add_log: Callable, check_btn:
 	# rebuilds and shows the promised per-row update badges.
 	_mods_badges_dirty = true
 
+	# State bookkeeping below must survive a mid-check tab rebuild (switching
+	# away and back frees every node captured in status_info): persisted state
+	# is written unconditionally, UI touches are guarded per node. The old
+	# whole-function bail on a freed button silently dropped the completed
+	# check's results; the rebuilt tab now re-renders them from
+	# _mod_updates_state / _updates_tab_status.
 	for fn: String in status_info:
 		var info: Dictionary = status_info[fn]
 		var lbl: Label = info["label"]
-		var dl_btn: Button = info["dl_btn"]
+		var pre_entry: Dictionary = info.get("entry", {})
+		var pk: String = str(pre_entry.get("profile_key", "")) if not pre_entry.is_empty() else ""
 		var latest_v = latest.get(str(info["mw_id"]), null)
 		if latest_v == null:
-			lbl.text = "Check failed"
 			# Rate-limit hint (spec section 7: what happened + what to do)
 			# lives in the tooltip -- the full sentence would ellipsize in
 			# this narrow column. Falls back to the plain text when no MWS
 			# cooldown is armed.
-			lbl.tooltip_text = mws_error_status(lbl.text)
-			lbl.add_theme_color_override("font_color", COL_ERR)
+			var fail_tip := mws_error_status("Check failed")
+			if pk != "":
+				_updates_tab_status[pk] = {"text": "Check failed", "tooltip": fail_tip, "color": COL_ERR}
+			if is_instance_valid(lbl):
+				lbl.text = "Check failed"
+				lbl.tooltip_text = fail_tip
+				lbl.add_theme_color_override("font_color", COL_ERR)
 			continue
 
-		# Also surface state via _mod_updates_state so the Mods tab can show
-		# the per-row badge without re-querying.
-		var pre_entry: Dictionary = info.get("entry", {})
-		var pk: String = str(pre_entry.get("profile_key", "")) if not pre_entry.is_empty() else ""
 		var cmp := compare_versions(info["version"], str(latest_v))
 		if cmp >= 0:
 			# Local is same version or newer than what's on the server.
-			lbl.text = "Up to date"
-			lbl.tooltip_text = lbl.text
-			lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
 			if pk != "":
 				_mod_updates_state.erase(pk)
-		else:
-			# Server has a newer version. Amber = the update signal. Tooltip
-			# mirrors the text: long prerelease strings ellipsize in the
-			# 160px column (label is MOUSE_FILTER_PASS at creation).
-			lbl.text = "Update: v" + str(latest_v)
-			lbl.tooltip_text = lbl.text
-			lbl.add_theme_color_override("font_color", COL_AMBER)
-			dl_btn.modulate.a = 1.0
-			dl_btn.disabled = false
-			dl_btn.mouse_filter = Control.MOUSE_FILTER_STOP
-			if pk != "":
-				_mod_updates_state[pk] = {
-					"latest_version": str(latest_v),
-					"current_version": str(info["version"]),
-					"mw_id": int(info["mw_id"]),
-					"full_path": str(info["full_path"]),
-					"mod_name": str(info["mod_name"]),
-				}
-			var full_path: String = info["full_path"]
-			var mw_id: int = info["mw_id"]
-			var mod_name: String = info["mod_name"]
-			var new_ver: String = str(latest_v)
-			# Disconnect previous connections so repeated checks don't stack callbacks.
-			for c in dl_btn.pressed.get_connections():
-				dl_btn.pressed.disconnect(c["callable"])
-			dl_btn.pressed.connect(func():
-				dl_btn.disabled = true
-				dl_btn.text = "Downloading..."
-				lbl.text = "Downloading..."
+				_updates_tab_status[pk] = {"text": "Up to date", "tooltip": "Up to date", "color": COL_TEXT_DIM}
+			if is_instance_valid(lbl):
+				lbl.text = "Up to date"
 				lbl.tooltip_text = lbl.text
-				lbl.add_theme_color_override("font_color", COL_AMBER)
-				check_btn.disabled = true
-				# Re-resolve live: the Mods-tab badge may have updated/renamed this
-				# file since the Updates tab was built, orphaning the captured path.
-				var live_path: String = _live_full_path(pk, full_path)
-				var result: Dictionary = await download_and_replace_mod(live_path, mw_id)
-				if not is_instance_valid(check_btn):
-					return
-				if not is_instance_valid(dl_btn):
-					return
-				check_btn.disabled = false
-				if result.get("ok", false):
-					lbl.text = "Updated -- restart to apply"
-					lbl.tooltip_text = lbl.text
-					lbl.add_theme_color_override("font_color", COL_OK)
-					dl_btn.modulate.a = 0.0
-					dl_btn.disabled = true
-					dl_btn.mouse_filter = Control.MOUSE_FILTER_IGNORE
-					dl_btn.text = "Update"
-					# Update cached version so next Check won't re-flag this mod.
-					info["version"] = new_ver
-					(info["ver_lbl"] as Label).text = "v" + new_ver
-					(info["ver_lbl"] as Label).tooltip_text = "v" + new_ver
-					# Drop the shared badge state so the Mods tab stops
-					# offering an update that was just installed (mirrors the
-					# badge-path erase after a successful download).
-					if pk != "":
-						_mod_updates_state.erase(pk)
-					# Reflect the on-disk rename in the in-memory entry so the
-					# next discovery pass (and any subsequent UI rebuild before
-					# relaunch) point at the right archive instead of the old
-					# filename that no longer exists.
-					var new_path: String = result.get("new_path", full_path)
-					var new_fn: String = result.get("new_file_name", full_path.get_file())
-					info["full_path"] = new_path
-					var entry_ref: Dictionary = info.get("entry", {})
-					if not entry_ref.is_empty():
-						entry_ref["full_path"] = new_path
-						entry_ref["file_name"] = new_fn
-					var rename_note: String = (" (renamed to " + new_fn + ")") if new_fn != full_path.get_file() else ""
-					add_log.call(mod_name + " -- updated to v" + new_ver + rename_note + ". Restart game to apply.")
-				else:
-					lbl.text = "Download failed"
-					lbl.tooltip_text = lbl.text
-					lbl.add_theme_color_override("font_color", COL_ERR)
-					dl_btn.disabled = false
-					dl_btn.text = "Retry"
-					add_log.call("Could not download " + mod_name + ". Check your connection and try again.")
-			)
+				lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
+		else:
+			# Server has a newer version -- paint the row and wire its Download
+			# button through the shared helper (also used by the on-show
+			# rebuild to re-arm rows from _mod_updates_state).
+			_updates_arm_row_update(info, str(latest_v), add_log)
 
 # ----- modloader self-update check ----------------------------------------
 

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -1414,6 +1414,10 @@ func _launch_vanilla_once(win: Window) -> void:
 		f.close()
 	else:
 		_log_warning("[LaunchVanilla] Could not write sentinel at %s -- aborting" % sentinel)
+		# Without this the button just looks dead: the window stays open and
+		# nothing else changes.
+		_show_error_dialog("Could not launch vanilla",
+			"Could not write " + sentinel + "\n\nCheck the game folder's permissions and try again.")
 		return
 	var log_lines := PackedStringArray()
 	_static_force_vanilla_state("UI Launch Vanilla button", log_lines)
@@ -2415,6 +2419,14 @@ func _modpacks_render_row(entry: Dictionary, active_modpack: String, tabs: TabCo
 	name_lbl.text = str(entry.get("raw_name", "?"))
 	name_lbl.add_theme_font_size_override("font_size", FS_HEAD)
 	name_lbl.add_theme_color_override("font_color", COL_TEXT_HI)
+	# raw_name comes straight from the modpack zip, so it can be arbitrarily
+	# long. Clip it instead of letting it inflate the row's min width and push
+	# the Details/Apply/Unload buttons out of the scroll viewport.
+	name_lbl.clip_text = true
+	name_lbl.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	name_lbl.tooltip_text = name_lbl.text
+	name_lbl.mouse_filter = Control.MOUSE_FILTER_PASS
+	name_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	name_row.add_child(name_lbl)
 
 	var author: String = str(entry.get("author", "")).strip_edges()
@@ -4720,6 +4732,12 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			u_ver.add_theme_color_override("font_color", COL_TEXT)
 			u_ver.add_theme_font_size_override("font_size", FS_BODY)
 			u_ver.custom_minimum_size.x = 160
+			# A long prerelease string must not widen the column and push the
+			# Update button out of alignment.
+			u_ver.clip_text = true
+			u_ver.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+			u_ver.tooltip_text = u_ver.text
+			u_ver.mouse_filter = Control.MOUSE_FILTER_PASS
 			upd_row.add_child(u_ver)
 
 			var u_btn := Button.new()
@@ -5417,6 +5435,9 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	search_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	search_input.custom_minimum_size.x = 200
 	search_input.custom_minimum_size.y = CTRL_H
+	# The API 422s on a query over 150 chars, which our non-2xx handling would
+	# report as a connection problem no retry could fix. Stop it at the input.
+	search_input.max_length = MWS_QUERY_MAX_LEN
 	toolbar.add_child(search_input)
 
 	var sort_dropdown := OptionButton.new()
@@ -6904,6 +6925,10 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 				v_str += " (primary)"
 			v_lbl.text = v_str
 			v_lbl.custom_minimum_size.x = 140
+			v_lbl.clip_text = true
+			v_lbl.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+			v_lbl.tooltip_text = v_lbl.text
+			v_lbl.mouse_filter = Control.MOUSE_FILTER_PASS
 			f_row.add_child(v_lbl)
 
 			var size_lbl := Label.new()
@@ -6945,6 +6970,8 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 #     running, letting a fresh check reset the downloading row).
 var _updates_tab_status: Dictionary = {}
 var _updates_tab_log: Array[String] = []
+# Oldest lines drop off past this many; see add_log in build_updates_tab.
+const _UPDATES_LOG_MAX := 200
 var _updates_tab_dl_in_flight: int = 0
 # Live references to the current build's list scroller / check button so the
 # rebuild can carry scroll position and download completions can re-enable the
@@ -7326,11 +7353,19 @@ func build_updates_tab() -> Control:
 		var line := "[" + t + "] " + msg
 		# Persist FIRST: a download can finish after this tab was rebuilt
 		# (freeing log_list); the line must survive into the restored log.
+		# Capped: the log now survives every rebuild, and each rebuild
+		# re-renders one Label per stored line, so an unbounded array would
+		# make repeated checks/downloads cost more on every tab switch.
 		_updates_tab_log.append(line)
+		while _updates_tab_log.size() > _UPDATES_LOG_MAX:
+			_updates_tab_log.remove_at(0)
 		if not is_instance_valid(log_list):
 			return
 		log_list.add_child(log_label.call(line))
-		log_scroll.scroll_vertical = 999999
+		# Defer by a frame: the label just added has no layout yet, so an
+		# immediate set clamps against the pre-append content height and the
+		# view lags one message behind.
+		_updates_scroll_log_to_bottom(log_scroll)
 
 	# Restore Activity lines from earlier checks/downloads this session -- the
 	# tab is rebuilt on every show and used to wipe the log. Scroll to the

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -42,10 +42,10 @@ const COL_ERR        := Color(0.91, 0.44, 0.38)  # errors, blocked, danger
 const COL_ERR_DIM    := Color(0.45, 0.22, 0.19)
 
 # Type scale (five sizes, no exceptions)
-const FS_META  := 10   # timestamps, counts, fine print
-const FS_BODY  := 11   # default body, buttons, rows
-const FS_EMPH  := 12   # emphasized row titles, dialog body
-const FS_HEAD  := 13   # section headings, dialog titles
+const FS_META  := 11   # timestamps, counts, fine print
+const FS_BODY  := 12   # default body, buttons, rows
+const FS_EMPH  := 13   # emphasized row titles, dialog body
+const FS_HEAD  := 14   # section headings, dialog titles
 const FS_TITLE := 16   # the window header plate only
 
 # Spacing scale
@@ -54,6 +54,9 @@ const SP_S  := 4   # intra-row gaps
 const SP_M  := 8   # between controls in a group
 const SP_L  := 12  # between groups; container padding
 const SP_XL := 16  # dialog outer padding, tab content padding
+
+# Control sizing
+const CTRL_H := 26  # uniform min height for single-line inputs (LineEdit, SpinBox)
 
 func _load_developer_mode_setting() -> void:
 	var cfg := ConfigFile.new()
@@ -920,6 +923,7 @@ func _show_save_modpack_dialog(profile_to_save: String, orphans: Array, tabs: Ta
 	var name_input := LineEdit.new()
 	name_input.placeholder_text = "Name for this modpack"
 	name_input.text = profile_to_save
+	name_input.custom_minimum_size.y = CTRL_H
 	name_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	box.add_child(name_input)
 
@@ -938,6 +942,7 @@ func _show_save_modpack_dialog(profile_to_save: String, orphans: Array, tabs: Ta
 	var author_input := LineEdit.new()
 	author_input.placeholder_text = "Your modder name or handle"
 	author_input.text = _load_preferred_author()
+	author_input.custom_minimum_size.y = CTRL_H
 	author_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	box.add_child(author_input)
 
@@ -1997,6 +2002,7 @@ func _show_new_profile_dialog(tabs: TabContainer) -> void:
 
 	var name_edit := LineEdit.new()
 	name_edit.custom_minimum_size.x = 280
+	name_edit.custom_minimum_size.y = CTRL_H
 	form.add_child(name_edit)
 
 	var state_lbl := Label.new()
@@ -2079,6 +2085,7 @@ func _show_rename_profile_dialog(tabs: TabContainer) -> void:
 
 	var name_edit := LineEdit.new()
 	name_edit.custom_minimum_size.x = 280
+	name_edit.custom_minimum_size.y = CTRL_H
 	name_edit.text = current
 	form.add_child(name_edit)
 
@@ -2114,9 +2121,8 @@ func _show_rename_profile_dialog(tabs: TabContainer) -> void:
 # shows up here. Apply runs the modpack's profile + MCM and backs up the
 # user's previous state; Unload restores the backup. Edits while a modpack
 # is active save into the modpack's profile slot and persist across applies.
-# The standard 8/8/6/6 outer margin shared by the top-level tab builders
-# (Profile, Browse, Updates). Divergent margins (e.g. the Mods tab's 10/10/8/10)
-# stay inline on purpose.
+# The standard 8/8/6/6 outer margin shared by ALL top-level tab builders
+# (Mods, Modpacks, Browse, Updates).
 func _make_tab_margin() -> MarginContainer:
 	var m := MarginContainer.new()
 	m.add_theme_constant_override("margin_left", 8)
@@ -2982,8 +2988,32 @@ func show_mod_ui() -> void:
 	# hacks. Embedded, they render on top of the launcher content and can't fall
 	# behind it, fixing every tooltip at once.
 	win.gui_embed_subwindows = true
-	win.size = Vector2i(960, 640)
-	win.min_size = Vector2i(640, 420)
+	# High-DPI scaling. The game runs DPI-aware, so Windows does NOT upscale it,
+	# and this launcher is its own OS Window OUTSIDE the game's scaled viewport
+	# -- with no explicit scale everything renders physically tiny on high-DPI
+	# displays. content_scale_factor scales fonts, styleboxes and scrollbars
+	# uniformly, so no per-widget changes are needed. screen_get_dpi can be
+	# unreliable on some platforms (0 or garbage), so fall back to 96 and clamp:
+	# never shrink below 1x, cap at 3x.
+	var dpi := DisplayServer.screen_get_dpi(win.current_screen)
+	if dpi <= 0:
+		dpi = 96
+	var ui_scale := clampf(float(dpi) / 96.0, 1.0, 3.0)
+	win.content_scale_factor = ui_scale
+	var want := Vector2i(roundi(960.0 * ui_scale), roundi(640.0 * ui_scale))
+	var want_min := Vector2i(roundi(640.0 * ui_scale), roundi(420.0 * ui_scale))
+	# A scaled window must still FIT the display. A 1920x1080 laptop at 200% OS
+	# scaling reports 192 dpi -> 2x -> a 1920x1280 window on a 1080-tall screen.
+	# Clamp to the usable area (minus room for taskbar/chrome), and keep
+	# min_size <= size or Godot rejects the pair.
+	var usable := DisplayServer.screen_get_usable_rect(win.current_screen).size
+	if usable.x > 0 and usable.y > 0:
+		want.x = mini(want.x, maxi(320, usable.x - 40))
+		want.y = mini(want.y, maxi(240, usable.y - 40))
+	want_min.x = mini(want_min.x, want.x)
+	want_min.y = mini(want_min.y, want.y)
+	win.size = want
+	win.min_size = want_min
 	win.wrap_controls = false
 	win.always_on_top = true
 	win.transparent = true
@@ -3277,6 +3307,9 @@ func show_mod_ui() -> void:
 	# In-flight HTTPRequests (list + thumbnail fetches) are parented to self
 	# and self-queue_free on completion, so no node-leak cleanup is needed.
 	_mws_cache.clear()
+	# Mods-tab row nodes die with the window; drop the mapping so a meta fetch
+	# resolving after close paints nothing (it still memoizes + persists).
+	_mods_meta_nodes.clear()
 	win.queue_free()
 
 # Launch button label reflects whether anything will load. Both this and
@@ -3508,18 +3541,22 @@ func make_dark_theme() -> Theme:
 	t.set_stylebox("panel", "ScrollContainer", StyleBoxEmpty.new())
 
 	# -- ScrollBars (slim dark track; stock ones glare) -------------------------
-	# Width is driven by stylebox minimum sizes: track margins (1+1) +
-	# grabber margins (3+3) = 8px nominal.
+	# Width is driven by stylebox minimum sizes: track margins (2+2) +
+	# grabber margins (6+6) = 16px nominal -- wide enough to actually hit.
+	# The along-axis grabber margins (12+12) give the grabber a minimum
+	# LENGTH so it stays grabbable on very long lists.
 	var track_v := StyleBoxFlat.new()
 	track_v.bg_color = COL_BG
 	track_v.border_color = COL_BORDER_DIM
 	track_v.border_width_left = 1
-	track_v.content_margin_left = 1
-	track_v.content_margin_right = 1
+	track_v.content_margin_left = 2
+	track_v.content_margin_right = 2
 	var grab_v := StyleBoxFlat.new()
 	grab_v.bg_color = COL_BORDER
-	grab_v.content_margin_left = 3
-	grab_v.content_margin_right = 3
+	grab_v.content_margin_left = 6
+	grab_v.content_margin_right = 6
+	grab_v.content_margin_top = 12
+	grab_v.content_margin_bottom = 12
 	var grab_v_hi: StyleBoxFlat = grab_v.duplicate()
 	grab_v_hi.bg_color = COL_TEXT_DIM
 	t.set_stylebox("scroll",            "VScrollBar", track_v)
@@ -3530,12 +3567,14 @@ func make_dark_theme() -> Theme:
 	track_h.bg_color = COL_BG
 	track_h.border_color = COL_BORDER_DIM
 	track_h.border_width_top = 1
-	track_h.content_margin_top = 1
-	track_h.content_margin_bottom = 1
+	track_h.content_margin_top = 2
+	track_h.content_margin_bottom = 2
 	var grab_h := StyleBoxFlat.new()
 	grab_h.bg_color = COL_BORDER
-	grab_h.content_margin_top = 3
-	grab_h.content_margin_bottom = 3
+	grab_h.content_margin_top = 6
+	grab_h.content_margin_bottom = 6
+	grab_h.content_margin_left = 12
+	grab_h.content_margin_right = 12
 	var grab_h_hi: StyleBoxFlat = grab_h.duplicate()
 	grab_h_hi.bg_color = COL_TEXT_DIM
 	t.set_stylebox("scroll",            "HScrollBar", track_h)
@@ -3616,10 +3655,12 @@ func make_dark_theme() -> Theme:
 	dlg_panel.bg_color = COL_SURFACE
 	dlg_panel.border_color = COL_BORDER
 	_sb_border(dlg_panel)
-	dlg_panel.content_margin_left = 10
-	dlg_panel.content_margin_right = 10
-	dlg_panel.content_margin_top = 8
-	dlg_panel.content_margin_bottom = 8
+	# Same padding tokens as _make_dialog_panel_stylebox so "dialog padding"
+	# has a single definition whether a dialog is themed or hand-styled.
+	dlg_panel.content_margin_left = SP_XL
+	dlg_panel.content_margin_right = SP_XL
+	dlg_panel.content_margin_top = SP_L
+	dlg_panel.content_margin_bottom = SP_L
 	t.set_stylebox("panel", "AcceptDialog", dlg_panel)
 	t.set_stylebox("panel", "ConfirmationDialog", dlg_panel.duplicate())
 	t.set_stylebox("embedded_border",           "Window", dlg_panel.duplicate())
@@ -3831,46 +3872,193 @@ func _mods_cached_summary_by_id(mod_id: int) -> Dictionary:
 				return row_v
 	return {}
 
+# Persisted per-mod meta sidecar. Without it, every relaunch re-fetched
+# /mods/{id} for each installed MWS mod (the memo is session-only, and the
+# thumbnail disk cache is keyed by storage filename with no mod_id mapping to
+# reach it). One JSON file, {"<mod_id>": {"mod": <mod object>, "saved_at":
+# unix}}, storing the full fetched mod object so the detail dialog stays as
+# rich offline as it was in the session that fetched it. Lives under
+# user://mws_cache/ next to the thumbnail cache (already on modpacks.gd's
+# override deny list, so packs can't poison it). Entries older than
+# _MODS_META_REFRESH_SEC soft-refresh in the background so replaced
+# thumbnails / renamed authors converge within a day.
+const _MODS_META_SIDECAR_PATH := "user://mws_cache/mods_meta.json"
+const _MODS_META_REFRESH_SEC := 86400
+
+# Lazy one-time seed of the meta memo from the sidecar. Runs BEFORE the
+# snapshot/network path consults the memo, so cached rows paint immediately
+# and offline. Every field is shape-checked: a hand-edited or truncated file
+# (wrong root type, non-dict entry, null/absent "mod", null/absent
+# "saved_at") degrades to skipping that entry, never a crash -- .get()'s
+# default only covers ABSENT keys, so present-but-null needs the `is` guards.
+func _mods_meta_sidecar_load() -> void:
+	if _mods_meta_sidecar_loaded:
+		return
+	_mods_meta_sidecar_loaded = true
+	if not FileAccess.file_exists(_MODS_META_SIDECAR_PATH):
+		return
+	var f := FileAccess.open(_MODS_META_SIDECAR_PATH, FileAccess.READ)
+	if f == null:
+		return
+	var parsed: Variant = JSON.parse_string(f.get_as_text())
+	f.close()
+	if not (parsed is Dictionary):
+		return
+	for key_v in (parsed as Dictionary):
+		var mod_id := str(key_v).to_int()
+		if mod_id <= 0:
+			continue
+		var entry_v: Variant = (parsed as Dictionary)[key_v]
+		if not (entry_v is Dictionary):
+			continue
+		var mod_v: Variant = (entry_v as Dictionary).get("mod")
+		if not (mod_v is Dictionary) or (mod_v as Dictionary).is_empty():
+			continue
+		# saved_at arrives as a float after the JSON round-trip; int() it.
+		var saved_v: Variant = (entry_v as Dictionary).get("saved_at", 0)
+		if not (saved_v is int or saved_v is float) or int(saved_v) <= 0:
+			continue
+		# Never clobber fresher data a fetch already memoized this session.
+		if not _mods_mws_meta_by_id.has(mod_id):
+			_mods_mws_meta_by_id[mod_id] = mod_v
+			_mods_mws_meta_saved_at[mod_id] = int(saved_v)
+
+# Stamp mod_id as freshly fetched and rewrite the sidecar from the memo.
+# Only ids with a saved_at stamp are persisted -- i.e. only entries that came
+# from a real /mods/{id} fetch (this session or a prior one); snapshot-sourced
+# memo entries stay session-only as before. Best-effort: a failed write just
+# means a refetch next launch, never an error the user sees.
+func _mods_meta_sidecar_store(mod_id: int) -> void:
+	_mods_mws_meta_saved_at[mod_id] = int(Time.get_unix_time_from_system())
+	var out := {}
+	for id_v in _mods_mws_meta_saved_at:
+		var d: Variant = _mods_mws_meta_by_id.get(id_v, {})
+		if d is Dictionary and not (d as Dictionary).is_empty():
+			out[str(id_v)] = {
+				"mod": d,
+				"saved_at": int(_mods_mws_meta_saved_at[id_v]),
+			}
+	DirAccess.make_dir_recursive_absolute(_MODS_META_SIDECAR_PATH.get_base_dir())
+	var f := FileAccess.open(_MODS_META_SIDECAR_PATH, FileAccess.WRITE)
+	if f == null:
+		return
+	f.store_string(JSON.stringify(out))
+	f.close()
+
+# Paint ModWorkshop meta onto the CURRENT Mods-tab row for mod_id, looked up
+# via _mods_meta_nodes at paint time -- NOT via nodes captured when the fetch
+# started, which a rebuild may have freed. No entry (row filtered out, tab
+# rebuilt without it, launcher closed) means the data is memoized for the next
+# build and nothing is painted. Idempotent per row: the author line is added
+# once (node-name guard), and a repeat thumbnail load just re-resolves the
+# same cache entry.
+func _mods_apply_mws_meta(mod_id: int, data: Dictionary) -> void:
+	# One workshop id can back several rows (e.g. a .vmz copy plus a dev-folder
+	# copy of the same mod), so the mapping holds a LIST of row-node dicts.
+	var rows_v: Variant = _mods_meta_nodes.get(mod_id)
+	if not (rows_v is Array):
+		return
+	for nodes_v in (rows_v as Array):
+		if not (nodes_v is Dictionary):
+			continue
+		var nodes: Dictionary = nodes_v
+		var holder_v: Variant = nodes.get("holder")
+		if holder_v is Dictionary:
+			(holder_v as Dictionary)["data"] = data
+		var thumb_v: Variant = nodes.get("thumb")
+		if is_instance_valid(thumb_v) and thumb_v is TextureRect:
+			var thumb_rect: TextureRect = thumb_v
+			var thumb_record: Variant = data.get("thumbnail")
+			if thumb_record is Dictionary:
+				# A soft-refresh repaint can land after a "no image" overlay
+				# went up (stale sidecar said no thumbnail, refreshed data has
+				# one); drop the overlay so the fresh texture isn't captioned
+				# missing.
+				var wrap := thumb_rect.get_parent() as Control
+				if wrap != null and is_instance_valid(wrap) and wrap.has_node("ThumbStateLabel"):
+					var stale_lbl := wrap.get_node("ThumbStateLabel")
+					wrap.remove_child(stale_lbl)
+					stale_lbl.queue_free()
+				_browse_load_thumbnail_async(thumb_rect, thumb_record)
+			else:
+				# Mod exists on MWS but has no thumbnail record -- say so
+				# instead of leaving the cell an ambiguous forever-gray panel.
+				_set_thumb_failed(thumb_rect, false)
+		var col_v: Variant = nodes.get("name_col")
+		if is_instance_valid(col_v) and col_v is VBoxContainer:
+			var name_col: VBoxContainer = col_v
+			if not name_col.has_node("MwsAuthorLabel"):
+				var user_dict: Dictionary = data.get("user", {}) if data.get("user") is Dictionary else {}
+				var author := str(user_dict.get("name", ""))
+				if author != "":
+					var author_lbl := _make_sub_label("by " + author, COL_TEXT_DIM, "")
+					author_lbl.name = "MwsAuthorLabel"
+					name_col.add_child(author_lbl)
+					name_col.move_child(author_lbl, 1)  # right under the name
+
 # Populate an installed mod row's ModWorkshop thumbnail + author, and stash the
 # mod object so the name link can open the Browse detail dialog (description +
-# file history). Cache-first (Browse snapshot), then a by-id fetch only for mods
-# the snapshot doesn't cover. All async and best-effort: offline or a failed
+# file history). Memo-first (seeded from the on-disk sidecar, so relaunches and
+# offline render instantly), then the Browse snapshot, then a by-id fetch only
+# for mods neither covers. All async and best-effort: offline or a failed
 # fetch just leaves the gray placeholder and the name link shows a gentle
-# notice -- no error, no log spam. The holder Dictionary is captured by the name
-# link's lambda, so filling it here wires the click up once data arrives (never
-# capture the mod object by value into the lambda -- it isn't known at build).
-func _mods_load_mws_meta(mod_id: int, thumb_rect: TextureRect, name_col: VBoxContainer, holder: Dictionary) -> void:
+# notice -- no error, no log spam. Painting goes through _mods_apply_mws_meta,
+# which resolves the row's CURRENT nodes from _mods_meta_nodes at paint time,
+# so a fetch that outlives a tab rebuild still lands on screen.
+func _mods_load_mws_meta(mod_id: int) -> void:
+	_mods_meta_sidecar_load()
 	var data: Dictionary = _mods_mws_meta_by_id.get(mod_id, {})
-	if data.is_empty():
-		# Skip if a recent attempt failed or is still in flight. The retry window
-		# is armed BEFORE the await, so quick racing rebuilds don't each fire a
-		# request; successes are memoed for the session below.
+	if not data.is_empty():
+		# Memoized (this session, or seeded from the sidecar): paint the row
+		# synchronously -- even when an earlier fetch for this id is still in
+		# flight, the freshly built row must not sit gray waiting on it.
+		_mods_apply_mws_meta(mod_id, data)
+		# Soft refresh: a sidecar entry older than a day re-fetches in the
+		# background so changed thumbnails/authors converge. Values in
+		# _mods_mws_meta_saved_at are ints we wrote ourselves; 0 means the
+		# entry is session-sourced (snapshot) and never soft-refreshes.
+		var saved_at := int(_mods_mws_meta_saved_at.get(mod_id, 0))
+		if saved_at <= 0 \
+				or int(Time.get_unix_time_from_system()) - saved_at < _MODS_META_REFRESH_SEC:
+			return
+		# Same retry window as the cold path, so racing rebuilds share one
+		# refresh request per mod per minute.
 		if Time.get_ticks_msec() < int(_mods_mws_meta_retry_at.get(mod_id, 0)):
 			return
 		_mods_mws_meta_retry_at[mod_id] = Time.get_ticks_msec() + 60000
-		data = _mods_cached_summary_by_id(mod_id)
-		if data.is_empty():
-			var fetched: Variant = await mws_get_mod(mod_id)
-			if fetched is Dictionary:
-				var obj: Variant = (fetched as Dictionary).get("data", fetched)
-				if obj is Dictionary:
-					data = obj
+		var refreshed: Variant = await mws_get_mod(mod_id)
+		if refreshed is Dictionary:
+			var obj_v: Variant = (refreshed as Dictionary).get("data", refreshed)
+			if obj_v is Dictionary and not (obj_v as Dictionary).is_empty():
+				_mods_mws_meta_by_id[mod_id] = obj_v
+				_mods_meta_sidecar_store(mod_id)
+				_mods_apply_mws_meta(mod_id, obj_v)
+		return
+	# Skip if a recent attempt failed or is still in flight. The retry window
+	# is armed BEFORE the await, so quick racing rebuilds don't each fire a
+	# request; successes are memoed for the session below.
+	if Time.get_ticks_msec() < int(_mods_mws_meta_retry_at.get(mod_id, 0)):
+		return
+	_mods_mws_meta_retry_at[mod_id] = Time.get_ticks_msec() + 60000
+	data = _mods_cached_summary_by_id(mod_id)
+	if data.is_empty():
+		var fetched: Variant = await mws_get_mod(mod_id)
+		if fetched is Dictionary:
+			var obj: Variant = (fetched as Dictionary).get("data", fetched)
+			if obj is Dictionary:
+				data = obj
 		if not data.is_empty():
 			_mods_mws_meta_by_id[mod_id] = data
+			# Persist real fetches so the next launch renders without a
+			# request; snapshot hits below stay session-only (the snapshot
+			# itself already persists).
+			_mods_meta_sidecar_store(mod_id)
+	else:
+		# Snapshot hit: memo for the session, exactly as before the sidecar.
+		_mods_mws_meta_by_id[mod_id] = data
 	if data.is_empty():
 		return
-	holder["data"] = data
-	if is_instance_valid(thumb_rect):
-		var thumb_record: Variant = data.get("thumbnail")
-		if thumb_record is Dictionary:
-			_browse_load_thumbnail_async(thumb_rect, thumb_record)
-	if is_instance_valid(name_col):
-		var user_dict: Dictionary = data.get("user", {}) if data.get("user") is Dictionary else {}
-		var author := str(user_dict.get("name", ""))
-		if author != "":
-			var author_lbl := _make_sub_label("by " + author, COL_TEXT_DIM, "")
-			name_col.add_child(author_lbl)
-			name_col.move_child(author_lbl, 1)  # right under the name
+	_mods_apply_mws_meta(mod_id, data)
 
 # Click handler for a Mods-row ModWorkshop name link. Opens the same detail
 # dialog the Browse tab uses (banner/thumbnail + author + description + file
@@ -3887,6 +4075,11 @@ func _open_mods_mws_detail(holder: Dictionary) -> void:
 
 func build_mods_tab(tabs: TabContainer) -> Control:
 	_refresh_dependency_status()
+	# Drop last build's row-node mapping; the row loop below re-registers each
+	# visible MWS row. An async meta fetch still in flight from the previous
+	# build then paints the row built HERE (or, for a now-filtered-out mod,
+	# finds no entry and just memoizes).
+	_mods_meta_nodes.clear()
 	var outer := VBoxContainer.new()
 	outer.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
@@ -4073,6 +4266,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	var filter_edit := LineEdit.new()
 	filter_edit.placeholder_text = "Filter mods..."
 	filter_edit.text = _mods_filter_text
+	filter_edit.custom_minimum_size.y = CTRL_H
 	filter_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	filter_bar.add_child(filter_edit)
 
@@ -4705,7 +4899,19 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			name_lnk.add_theme_color_override("font_hover_color", COL_TEXT_HI)
 			name_col.add_child(name_lnk)
 			name_lnk.pressed.connect(_open_mods_mws_detail.bind(mws_holder))
-			_mods_load_mws_meta(row_mws_id, thumb_ref, name_col, mws_holder)
+			# Register the row's live nodes BEFORE kicking the meta load, so
+			# both the synchronous memo-hit paint and any async completion
+			# (including one from a fetch a PREVIOUS build started) resolve to
+			# these current nodes instead of freed ones. Appended, not
+			# assigned: several rows can share one workshop id.
+			var meta_rows: Array = _mods_meta_nodes.get(row_mws_id, [])
+			meta_rows.append({
+				"thumb": thumb_ref,
+				"name_col": name_col,
+				"holder": mws_holder,
+			})
+			_mods_meta_nodes[row_mws_id] = meta_rows
+			_mods_load_mws_meta(row_mws_id)
 			name_ctrl = name_lnk
 		else:
 			var name_lbl := Label.new()
@@ -4880,6 +5086,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		spin.max_value = PRIORITY_MAX
 		spin.value = entry["priority"]
 		spin.custom_minimum_size.x = 100
+		spin.custom_minimum_size.y = CTRL_H
 		row.add_child(spin)
 
 		# Per-row Remove. Folder mods (dev) skip the file delete because
@@ -4993,6 +5200,11 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		"mode": "discover",
 		"query": "",
 		"sort": "bumped_at",
+		# featured: true while the sort dropdown sits on item 0 ("Featured",
+		# the curated landing). The empty-input handlers key on THIS flag --
+		# not on sort == "bumped_at" -- so "Recently updated" is a real sort
+		# that routes through the filter fetch like every other sort.
+		"featured": true,
 		"category_id": 0,
 		"next_page": 1,
 		"has_more": false,
@@ -5023,17 +5235,24 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	search_input.placeholder_text = "Search mods..."
 	search_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	search_input.custom_minimum_size.x = 200
+	search_input.custom_minimum_size.y = CTRL_H
 	toolbar.add_child(search_input)
 
 	var sort_dropdown := OptionButton.new()
-	# Index -> API sort enum. Search honors this sort (no best_match override) --
-	# default "Recently bumped" keeps most-recently-updated mods on top.
+	# Index -> API sort enum. Item 0 "Featured" is NOT a sort: it represents
+	# the curated Popular+Latest discover landing. It still maps to bumped_at
+	# in sort_keys so a search typed while Featured is selected has a sane
+	# sort. The real sorts follow; search honors the chosen sort (no
+	# best_match override).
+	sort_dropdown.add_item("Featured")
 	sort_dropdown.add_item("Recently updated")
 	sort_dropdown.add_item("Most downloaded")
 	sort_dropdown.add_item("Most liked")
 	sort_dropdown.add_item("Most viewed")
 	sort_dropdown.add_item("Newest")
-	var sort_keys := ["bumped_at", "downloads", "likes", "views", "published_at"]
+	var sort_keys := ["bumped_at", "bumped_at", "downloads", "likes", "views", "published_at"]
+	# Explicit, not incidental: the resting label is the Featured landing.
+	sort_dropdown.select(0)
 	toolbar.add_child(sort_dropdown)
 
 	var category_dropdown := OptionButton.new()
@@ -5365,6 +5584,14 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 			my_restore = int(state["restore_scroll"])
 			state.erase("restore_scroll")
 		state["mode"] = "discover"
+		# Rendering the landing means "Featured" is the truthful dropdown
+		# label; sync state + selection so clearing a search/category (or the
+		# initial fetch) never leaves a sort name over the curated view.
+		# OptionButton.select() does not emit item_selected, so no recursion.
+		state["featured"] = true
+		state["sort"] = "bumped_at"
+		if is_instance_valid(sort_dropdown) and sort_dropdown.selected != 0:
+			sort_dropdown.select(0)
 		state["next_page"] = 1
 		state["has_more"] = false
 		state.erase("loaded_rows")
@@ -5399,7 +5626,9 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		var install_map: Dictionary = compute_install_map.call()
 		if not popular.is_empty():
 			var pop_hdr := Label.new()
-			pop_hdr.text = "Popular"
+			# "this week" because the backing sort is ModWorkshop's
+			# weekly_score -- the label must match the parameter.
+			pop_hdr.text = "Popular this week"
 			pop_hdr.add_theme_font_size_override("font_size", FS_HEAD)
 			pop_hdr.add_theme_color_override("font_color", COL_TEXT)
 			list.add_child(pop_hdr)
@@ -5571,7 +5800,7 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	search_debounce.wait_time = 0.3
 	container.add_child(search_debounce)
 	search_debounce.timeout.connect(func():
-		if str(state["query"]) == "" and int(state["category_id"]) == 0 and str(state["sort"]) == "bumped_at":
+		if str(state["query"]) == "" and int(state["category_id"]) == 0 and bool(state["featured"]):
 			do_discover_fetch.call()
 		else:
 			do_filter_fetch.call(false)
@@ -5584,14 +5813,23 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	)
 	search_input.text_submitted.connect(func(_t: String):
 		search_debounce.stop()
-		do_filter_fetch.call(false)
+		# Same routing as the debounce timeout: Enter in an EMPTY box while
+		# Featured is selected must (re)render the curated landing -- an
+		# unconditional filter fetch here would show a flat sorted list under
+		# a "Featured" dropdown label.
+		if str(state["query"]) == "" and int(state["category_id"]) == 0 and bool(state["featured"]):
+			do_discover_fetch.call()
+		else:
+			do_filter_fetch.call(false)
 	)
 
 	sort_dropdown.item_selected.connect(func(idx: int):
 		state["sort"] = sort_keys[idx] if idx >= 0 and idx < sort_keys.size() else "bumped_at"
-		# A non-default sort means we're in filter mode now even with empty
-		# query; routes through list_mods with the chosen sort.
-		if str(state["query"]) == "" and int(state["category_id"]) == 0 and str(state["sort"]) == "bumped_at":
+		# Item 0 = "Featured" (the curated landing); any real sort -- including
+		# "Recently updated" (bumped_at) -- routes through list_mods with the
+		# chosen sort, even with an empty query.
+		state["featured"] = idx == 0
+		if str(state["query"]) == "" and int(state["category_id"]) == 0 and bool(state["featured"]):
 			do_discover_fetch.call()
 		else:
 			do_filter_fetch.call(false)
@@ -5600,7 +5838,7 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 	category_dropdown.item_selected.connect(func(idx: int):
 		var cid_var = category_dropdown.get_item_metadata(idx)
 		state["category_id"] = int(cid_var) if cid_var != null else 0
-		if str(state["query"]) == "" and int(state["category_id"]) == 0 and str(state["sort"]) == "bumped_at":
+		if str(state["query"]) == "" and int(state["category_id"]) == 0 and bool(state["featured"]):
 			do_discover_fetch.call()
 		else:
 			do_filter_fetch.call(false)
@@ -5842,22 +6080,49 @@ func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get
 	return row
 
 
+# Visible terminal state for a thumbnail cell. Without this, "still loading",
+# "mod has no image" and "fetch/decode failed" all look like the same bare
+# gray panel. Overlays a centered dim label ("load failed" when a fetch or
+# decode broke, "no image" when there is nothing to fetch) into the cell's
+# parent PanelContainer -- no image asset needed, and FS_META + COL_TEXT_DIM
+# keeps it as quiet as the rest of the meta text. Safe to call after awaits
+# (guards the rect and its parent) and idempotent per cell.
+func _set_thumb_failed(rect: TextureRect, failed: bool) -> void:
+	if not is_instance_valid(rect):
+		return
+	var wrap := rect.get_parent() as Control
+	if wrap == null or not is_instance_valid(wrap):
+		return
+	if wrap.has_node("ThumbStateLabel"):
+		return
+	var lbl := Label.new()
+	lbl.name = "ThumbStateLabel"
+	lbl.text = "load failed" if failed else "no image"
+	lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
+	lbl.add_theme_font_size_override("font_size", FS_META)
+	wrap.add_child(lbl)
+
+
 # Async thumbnail loader. Cache layout: user://mws_cache/thumbs/<storage_filename>.
 # Filenames from MWS are opaque/immutable per upload, so the storage filename
 # IS the cache key -- a thumbnail replaced by the author gets a different file
 # name and we naturally fetch fresh. No TTL needed, no manual cache busting.
-# Failures are silent: the row's gray placeholder stays visible. 1MB hard
-# cap (download_body_size_limit below) defends against malformed responses
-# without limiting real thumbnails (typical MWS thumbs are 10-80KB).
+# Failures surface via _set_thumb_failed so the cell doesn't stay an
+# ambiguous gray panel. 1MB hard cap (download_body_size_limit below) defends
+# against malformed responses without limiting real thumbnails.
 func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -> void:
 	var fn: String = str(image_record.get("file", ""))
 	if fn.is_empty():
+		_set_thumb_failed(rect, false)
 		return
 	# Server-provided name: accept only a bare basename so path_join cannot
 	# escape the cache dir (same never-trust-a-server-name posture as the
 	# _is_safe_mod_filename gate on mod download names). get_file() only
 	# splits on "/", so reject backslashes and ".." explicitly too.
 	if fn != fn.get_file() or fn.contains("\\") or fn.contains(".."):
+		_set_thumb_failed(rect, false)
 		return
 
 	var cache_dir := "user://mws_cache/thumbs"
@@ -5888,6 +6153,7 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 	# eat memory.
 	var url := mws_image_url(image_record, false)
 	if url.is_empty():
+		_set_thumb_failed(rect, false)
 		return
 
 	var req := HTTPRequest.new()
@@ -5900,14 +6166,17 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 	var err := req.request(url, headers)
 	if err != OK:
 		req.queue_free()
+		_set_thumb_failed(rect, true)
 		return
 
 	var res: Array = await req.request_completed
 	req.queue_free()
 	if res[0] != HTTPRequest.RESULT_SUCCESS or res[1] < 200 or res[1] >= 300:
+		_set_thumb_failed(rect, true)
 		return
 	var body: PackedByteArray = res[3]
 	if body.is_empty():
+		_set_thumb_failed(rect, true)
 		return
 
 	var img := Image.new()
@@ -5915,14 +6184,41 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 			or img.load_jpg_from_buffer(body) == OK \
 			or img.load_png_from_buffer(body) == OK
 	if not ok:
+		_set_thumb_failed(rect, true)
 		return
 
+	# The CDN serves full-size images (100-300KB+) while the row cells render
+	# at 96x54, so downscale before caching. This ONE cache is also read by
+	# the detail dialog's banner (a ~220px-tall letterboxed band), so rather
+	# than keying a separate small variant -- which risks serving a tiny stale
+	# entry where the banner expects a large one -- cap the longest side at
+	# 640px: still crisp for the banner band, while cutting typical cached
+	# files by roughly an order of magnitude. Re-encoded as lossy WebP; the
+	# cache-hit reader above tries webp/jpg/png regardless of the stored
+	# filename's extension, so the container swap is safe.
+	var thumb_cache_max := 640
+	var cache_bytes := body
+	if maxi(img.get_width(), img.get_height()) > thumb_cache_max:
+		var scale := float(thumb_cache_max) / float(maxi(img.get_width(), img.get_height()))
+		img.resize(
+			maxi(1, int(round(img.get_width() * scale))),
+			maxi(1, int(round(img.get_height() * scale))),
+			Image.INTERPOLATE_LANCZOS
+		)
+		var resized := img.save_webp_to_buffer(true, 0.85)
+		if resized.size() > 0:
+			cache_bytes = resized
+
 	# Stash for next launch. Failure to write is non-fatal -- we still display
-	# the texture this session, just refetch next time.
+	# the texture this session, just refetch next time. store_buffer returns
+	# bool since 4.3; drop a partial file rather than leaving a truncated
+	# cache entry around.
 	var out := FileAccess.open(cache_path, FileAccess.WRITE)
 	if out != null:
-		out.store_buffer(body)
+		var wrote := out.store_buffer(cache_bytes)
 		out.close()
+		if not wrote:
+			DirAccess.remove_absolute(cache_path)
 
 	if is_instance_valid(rect):
 		rect.texture = ImageTexture.create_from_image(img)
@@ -6099,7 +6395,10 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 		box.add_child(banner_wrap)
 		var banner_rect := TextureRect.new()
 		banner_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-		banner_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+		# CENTERED, not COVERED: the whole banner letterboxes inside the
+		# 220px band (the panel's surface colour mattes it) instead of being
+		# cover-cropped. Small grid tiles / row thumbnails keep COVERED.
+		banner_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 		banner_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 		banner_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
 		banner_wrap.add_child(banner_rect)

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -74,6 +74,40 @@ func _load_developer_mode_setting() -> void:
 	if _developer_mode:
 		_log_info("Developer mode: ON")
 
+# User-chosen launcher zoom, as a content_scale_factor. 1.0 = native (the
+# 3.3.0 look). Read straight from the config rather than cached in a var so the
+# reopen path picks up a change made in an earlier session. Clamped because a
+# hand-edited config could otherwise produce a window nobody can click out of.
+func _ui_scale_setting() -> float:
+	var cfg := ConfigFile.new()
+	if cfg.load(UI_CONFIG_PATH) != OK:
+		return 1.0
+	return clampf(float(cfg.get_value("settings", "ui_scale", 1.0)), 1.0, 2.0)
+
+# Apply a launcher zoom to the window: content scale plus a matching window
+# size. Also used when the user changes the setting live, so it must be safe to
+# call on an already-sized window -- min_size is dropped to zero first, since
+# shrinking the scale while the old (larger) minimum is still in force would
+# clamp the new size back up.
+func _apply_ui_scale(win: Window, ui_scale: float) -> void:
+	if not is_instance_valid(win):
+		return
+	win.content_scale_factor = ui_scale
+	var want := Vector2i(roundi(960.0 * ui_scale), roundi(640.0 * ui_scale))
+	var want_min := Vector2i(roundi(640.0 * ui_scale), roundi(420.0 * ui_scale))
+	# A scaled window must still FIT the display: clamp to the usable area
+	# (minus room for taskbar/chrome) so the Launch bar can never land
+	# off-screen, and keep min_size <= size or Godot rejects the pair.
+	var usable := DisplayServer.screen_get_usable_rect(win.current_screen).size
+	if usable.x > 0 and usable.y > 0:
+		want.x = mini(want.x, maxi(320, usable.x - 40))
+		want.y = mini(want.y, maxi(240, usable.y - 40))
+	want_min.x = mini(want_min.x, want.x)
+	want_min.y = mini(want_min.y, want.y)
+	win.min_size = Vector2i.ZERO
+	win.size = want
+	win.min_size = want_min
+
 func _load_ui_config() -> void:
 	_active_profile = "Default"
 	var cfg := ConfigFile.new()
@@ -3082,32 +3116,20 @@ func show_mod_ui() -> void:
 	# hacks. Embedded, they render on top of the launcher content and can't fall
 	# behind it, fixing every tooltip at once.
 	win.gui_embed_subwindows = true
-	# High-DPI scaling. The game runs DPI-aware, so Windows does NOT upscale it,
-	# and this launcher is its own OS Window OUTSIDE the game's scaled viewport
-	# -- with no explicit scale everything renders physically tiny on high-DPI
-	# displays. content_scale_factor scales fonts, styleboxes and scrollbars
-	# uniformly, so no per-widget changes are needed. screen_get_dpi can be
-	# unreliable on some platforms (0 or garbage), so fall back to 96 and clamp:
-	# never shrink below 1x, cap at 3x.
-	var dpi := DisplayServer.screen_get_dpi(win.current_screen)
-	if dpi <= 0:
-		dpi = 96
-	var ui_scale := clampf(float(dpi) / 96.0, 1.0, 3.0)
-	win.content_scale_factor = ui_scale
-	var want := Vector2i(roundi(960.0 * ui_scale), roundi(640.0 * ui_scale))
-	var want_min := Vector2i(roundi(640.0 * ui_scale), roundi(420.0 * ui_scale))
-	# A scaled window must still FIT the display. A 1920x1080 laptop at 200% OS
-	# scaling reports 192 dpi -> 2x -> a 1920x1280 window on a 1080-tall screen.
-	# Clamp to the usable area (minus room for taskbar/chrome), and keep
-	# min_size <= size or Godot rejects the pair.
-	var usable := DisplayServer.screen_get_usable_rect(win.current_screen).size
-	if usable.x > 0 and usable.y > 0:
-		want.x = mini(want.x, maxi(320, usable.x - 40))
-		want.y = mini(want.y, maxi(240, usable.y - 40))
-	want_min.x = mini(want_min.x, want.x)
-	want_min.y = mini(want_min.y, want.y)
-	win.size = want
-	win.min_size = want_min
+	# UI scale. Do NOT derive this from screen DPI. The launcher is a subwindow
+	# of the game's root viewport, and RTV's project.godot sets
+	# stretch/mode="canvas_items" against a 1920x1080 base -- so the root
+	# ALREADY scales everything we draw by (window size / 1920x1080). A
+	# DPI-derived factor multiplies on top of that: a 4K display gave roughly
+	# 2x from the root and another 1.7x from DPI, and the launcher came out
+	# unusably large. Deriving it from DPI also can't be right for both a dense
+	# 1080p laptop and a 4K desktop, because the root scale differs between
+	# them in the opposite direction.
+	#
+	# So: 1.0 by default (identical to 3.3.0 proportions), with an explicit
+	# user setting for anyone who wants it bigger. Readability at 1.0 is the
+	# job of the type scale and the scrollbar metrics, not of a global zoom.
+	_apply_ui_scale(win, _ui_scale_setting())
 	win.wrap_controls = false
 	win.always_on_top = true
 	win.transparent = true
@@ -4360,6 +4382,39 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	toolbar.add_child(spacer)
 
+	# Launcher zoom, user-owned. Auto-detecting it from screen DPI compounded
+	# with the game's own canvas_items stretch and blew the window up on
+	# high-res displays (see _show_mod_ui), and no single formula fits every
+	# monitor -- so this is an explicit choice that applies immediately.
+	var scale_lbl := Label.new()
+	scale_lbl.text = "UI scale"
+	scale_lbl.add_theme_font_size_override("font_size", FS_BODY)
+	scale_lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
+	toolbar.add_child(scale_lbl)
+
+	var scale_values := [1.0, 1.25, 1.5, 1.75, 2.0]
+	var scale_opt := OptionButton.new()
+	for sv: float in scale_values:
+		scale_opt.add_item("%d%%" % int(round(sv * 100.0)))
+	var cur_scale_idx := scale_values.find(_ui_scale_setting())
+	scale_opt.select(cur_scale_idx if cur_scale_idx >= 0 else 0)
+	scale_opt.custom_minimum_size.y = CTRL_H
+	scale_opt.add_theme_font_size_override("font_size", FS_BODY)
+	toolbar.add_child(scale_opt)
+	_wire_hint(scale_opt, "Scale the launcher window. Applies immediately.")
+
+	scale_opt.item_selected.connect(func(idx: int):
+		var sv: float = scale_values[idx] if idx >= 0 and idx < scale_values.size() else 1.0
+		# Written straight through rather than via _save_ui_config: this is a
+		# display preference, and the full save rewrites profile state we have
+		# no reason to touch here.
+		var scfg := ConfigFile.new()
+		scfg.load(UI_CONFIG_PATH)
+		scfg.set_value("settings", "ui_scale", sv)
+		_persist_ui_cfg(scfg)
+		_apply_ui_scale(_ui_window, sv)
+	)
+
 	var dev_check := CheckBox.new()
 	dev_check.text = "Developer mode"
 	dev_check.tooltip_text = "Enables verbose logging, conflict report, and loose folder loading"
@@ -5037,25 +5092,29 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 			row_mws_id = int(str(row_cfg.get_value("updates", "modworkshop", "0")))
 		var mws_holder: Dictionary = {}
 		var thumb_ref: TextureRect = null
+		# EVERY row gets a real thumbnail cell, captioned "no thumbnail" from
+		# the moment it is built. Previously a non-MWS mod got a bare invisible
+		# spacer -- so a modlist of hand-installed mods showed nothing at all
+		# where a thumbnail belongs -- and an MWS row sat as an unlabelled gray
+		# panel until its meta fetch resolved, which is indistinguishable from
+		# still-loading and never resolves at all while offline. A texture that
+		# arrives later clears the caption (_set_thumb_ready).
+		var thumb_wrap := PanelContainer.new()
+		thumb_wrap.custom_minimum_size = Vector2(96, 54)
+		thumb_wrap.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+		var thumb_style := StyleBoxFlat.new()
+		thumb_style.bg_color = COL_SURFACE_2
+		thumb_wrap.add_theme_stylebox_override("panel", thumb_style)
+		row.add_child(thumb_wrap)
+		var thumb_rect := TextureRect.new()
+		thumb_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+		thumb_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+		thumb_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		thumb_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		thumb_wrap.add_child(thumb_rect)
+		_set_thumb_failed(thumb_rect, false)
 		if row_mws_id > 0:
-			var thumb_wrap := PanelContainer.new()
-			thumb_wrap.custom_minimum_size = Vector2(96, 54)
-			thumb_wrap.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-			var thumb_style := StyleBoxFlat.new()
-			thumb_style.bg_color = COL_SURFACE_2
-			thumb_wrap.add_theme_stylebox_override("panel", thumb_style)
-			row.add_child(thumb_wrap)
-			var thumb_rect := TextureRect.new()
-			thumb_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-			thumb_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
-			thumb_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-			thumb_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
-			thumb_wrap.add_child(thumb_rect)
 			thumb_ref = thumb_rect
-		else:
-			var thumb_gap := Control.new()
-			thumb_gap.custom_minimum_size.x = 96
-			row.add_child(thumb_gap)
 
 		var name_col := VBoxContainer.new()
 		name_col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -6471,12 +6530,26 @@ func _set_thumb_failed(rect: TextureRect, failed: bool) -> void:
 		return
 	var lbl := Label.new()
 	lbl.name = "ThumbStateLabel"
-	lbl.text = "load failed" if failed else "no image"
+	lbl.text = "load failed" if failed else "no thumbnail"
 	lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	lbl.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	lbl.add_theme_color_override("font_color", COL_TEXT_DIM)
 	lbl.add_theme_font_size_override("font_size", FS_META)
 	wrap.add_child(lbl)
+
+# Paint a loaded texture into a thumbnail cell, clearing any state caption
+# first. Every texture-setting path goes through here: cells now start
+# captioned "no thumbnail", so a path that assigned .texture directly would
+# leave the caption sitting on top of a perfectly good image.
+func _set_thumb_ready(rect: TextureRect, tex: Texture2D) -> void:
+	if not is_instance_valid(rect):
+		return
+	var wrap := rect.get_parent() as Control
+	if wrap != null and is_instance_valid(wrap) and wrap.has_node("ThumbStateLabel"):
+		var stale := wrap.get_node("ThumbStateLabel")
+		wrap.remove_child(stale)
+		stale.queue_free()
+	rect.texture = tex
 
 
 # Session memo of decoded thumbnail textures keyed by storage filename.
@@ -6517,8 +6590,7 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 	# Memory hit: already decoded this session -- no disk read, no decode.
 	var memo_tex_v: Variant = _thumb_texture_cache.get(fn)
 	if memo_tex_v is Texture2D:
-		if is_instance_valid(rect):
-			rect.texture = memo_tex_v as Texture2D
+		_set_thumb_ready(rect, memo_tex_v as Texture2D)
 		return
 
 	var cache_dir := "user://mws_cache/thumbs"
@@ -6540,8 +6612,7 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 						or img.load_png_from_buffer(bytes) == OK:
 					var disk_tex := ImageTexture.create_from_image(img)
 					_thumb_texture_cache_store(fn, disk_tex)
-					if is_instance_valid(rect):
-						rect.texture = disk_tex
+					_set_thumb_ready(rect, disk_tex)
 					return
 
 	# Cache miss: fetch from CDN. The /mods/images/thumbs/ path returns 404
@@ -6620,8 +6691,7 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 
 	var net_tex := ImageTexture.create_from_image(img)
 	_thumb_texture_cache_store(fn, net_tex)
-	if is_instance_valid(rect):
-		rect.texture = net_tex
+	_set_thumb_ready(rect, net_tex)
 
 
 # Format a byte count as a compact human-readable string. Used by the mod

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -4088,15 +4088,10 @@ func _mods_apply_mws_meta(mod_id: int, data: Dictionary) -> void:
 			var thumb_rect: TextureRect = thumb_v
 			var thumb_record: Variant = data.get("thumbnail")
 			if thumb_record is Dictionary:
-				# A soft-refresh repaint can land after a "no image" overlay
-				# went up (stale sidecar said no thumbnail, refreshed data has
-				# one); drop the overlay so the fresh texture isn't captioned
-				# missing.
-				var wrap := thumb_rect.get_parent() as Control
-				if wrap != null and is_instance_valid(wrap) and wrap.has_node("ThumbStateLabel"):
-					var stale_lbl := wrap.get_node("ThumbStateLabel")
-					wrap.remove_child(stale_lbl)
-					stale_lbl.queue_free()
+				# Leave the caption in place: _set_thumb_ready clears it the
+				# instant a texture actually lands, so the cell reads
+				# "no thumbnail" while the fetch is in flight rather than
+				# reverting to a bare gray panel that means nothing.
 				_browse_load_thumbnail_async(thumb_rect, thumb_record)
 			else:
 				# Mod exists on MWS but has no thumbnail record -- say so
@@ -5099,20 +5094,7 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		# panel until its meta fetch resolved, which is indistinguishable from
 		# still-loading and never resolves at all while offline. A texture that
 		# arrives later clears the caption (_set_thumb_ready).
-		var thumb_wrap := PanelContainer.new()
-		thumb_wrap.custom_minimum_size = Vector2(96, 54)
-		thumb_wrap.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-		var thumb_style := StyleBoxFlat.new()
-		thumb_style.bg_color = COL_SURFACE_2
-		thumb_wrap.add_theme_stylebox_override("panel", thumb_style)
-		row.add_child(thumb_wrap)
-		var thumb_rect := TextureRect.new()
-		thumb_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-		thumb_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
-		thumb_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		thumb_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		thumb_wrap.add_child(thumb_rect)
-		_set_thumb_failed(thumb_rect, false)
+		var thumb_rect := _make_thumb_cell(row, Vector2(96, 54), true, true)
 		if row_mws_id > 0:
 			thumb_ref = thumb_rect
 
@@ -6388,23 +6370,10 @@ func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get
 	var row := HBoxContainer.new()
 	row.add_theme_constant_override("separation", SP_L)
 
-	# Thumbnail wrapper. PanelContainer gives us a solid background so the
-	# placeholder looks intentional rather than "missing image" before the
-	# texture loads. ColorRect would also work but PanelContainer composes
-	# better with the dark theme's stylebox conventions.
-	var thumb_wrap := PanelContainer.new()
-	thumb_wrap.custom_minimum_size = Vector2(96, 54)
-	var thumb_style := StyleBoxFlat.new()
-	thumb_style.bg_color = COL_SURFACE_2
-	thumb_wrap.add_theme_stylebox_override("panel", thumb_style)
-	row.add_child(thumb_wrap)
-
-	var thumb_rect := TextureRect.new()
-	thumb_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	thumb_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
-	thumb_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	thumb_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	thumb_wrap.add_child(thumb_rect)
+	# Same cell the Mods tab builds, so a Browse mod with no image reads
+	# "no thumbnail" exactly like an installed one instead of sitting as a
+	# bare gray panel.
+	var thumb_rect := _make_thumb_cell(row, Vector2(96, 54))
 
 	var thumb_record = mod_data.get("thumbnail")
 	if thumb_record is Dictionary:
@@ -6526,7 +6495,13 @@ func _set_thumb_failed(rect: TextureRect, failed: bool) -> void:
 	var wrap := rect.get_parent() as Control
 	if wrap == null or not is_instance_valid(wrap):
 		return
+	# Cells are captioned "no thumbnail" the moment they are built, so an
+	# existing label is the normal case, not a duplicate to skip: update it, or
+	# a fetch that actually broke would keep reading "no thumbnail".
 	if wrap.has_node("ThumbStateLabel"):
+		var existing := wrap.get_node("ThumbStateLabel") as Label
+		if existing != null:
+			existing.text = "load failed" if failed else "no thumbnail"
 		return
 	var lbl := Label.new()
 	lbl.name = "ThumbStateLabel"
@@ -6550,6 +6525,38 @@ func _set_thumb_ready(rect: TextureRect, tex: Texture2D) -> void:
 		wrap.remove_child(stale)
 		stale.queue_free()
 	rect.texture = tex
+
+# Build an image cell: a surface-coloured PanelContainer holding a TextureRect,
+# captioned "no thumbnail" until an image lands. This is the single source of
+# truth for every image cell in the launcher. The Mods rows, the Browse rows
+# and the detail banner each grew their own copy of this construction, and that
+# is exactly how they drifted -- only one of the three ever got a placeholder.
+#
+# cover=true crops to fill, for small row tiles. cover=false letterboxes inside
+# the band so the whole image stays visible, which is what the detail banner
+# wants. shrink_center keeps the cell at its natural height instead of
+# stretching to the row.
+#
+# Returns the TextureRect to paint into (via _set_thumb_ready).
+func _make_thumb_cell(parent: Control, min_size: Vector2, cover: bool = true,
+		shrink_center: bool = false) -> TextureRect:
+	var wrap := PanelContainer.new()
+	wrap.custom_minimum_size = min_size
+	if shrink_center:
+		wrap.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	var style := StyleBoxFlat.new()
+	style.bg_color = COL_SURFACE_2
+	wrap.add_theme_stylebox_override("panel", style)
+	parent.add_child(wrap)
+	var rect := TextureRect.new()
+	rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED if cover \
+			else TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	wrap.add_child(rect)
+	_set_thumb_failed(rect, false)
+	return rect
 
 
 # Session memo of decoded thumbnail textures keyed by storage filename.
@@ -6884,22 +6891,12 @@ func _show_browse_mod_detail_dialog(mod_data: Dictionary, on_get: Callable) -> v
 	var banner_record = mod_data.get("banner")
 	var thumb_record = mod_data.get("thumbnail")
 	var img_record = banner_record if banner_record is Dictionary else thumb_record
+	# cover=false so the whole banner letterboxes inside the 220px band (the
+	# cell's surface colour mattes it) instead of being cover-cropped; row
+	# tiles keep the crop. Built only when there IS an image: unlike a 96x54
+	# row tile, a 220px band captioned "no thumbnail" is worse than no band.
 	if img_record is Dictionary:
-		var banner_wrap := PanelContainer.new()
-		banner_wrap.custom_minimum_size = Vector2(0, 220)
-		var banner_style := StyleBoxFlat.new()
-		banner_style.bg_color = COL_SURFACE_2
-		banner_wrap.add_theme_stylebox_override("panel", banner_style)
-		box.add_child(banner_wrap)
-		var banner_rect := TextureRect.new()
-		banner_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-		# CENTERED, not COVERED: the whole banner letterboxes inside the
-		# 220px band (the panel's surface colour mattes it) instead of being
-		# cover-cropped. Small grid tiles / row thumbnails keep COVERED.
-		banner_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-		banner_rect.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		banner_rect.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		banner_wrap.add_child(banner_rect)
+		var banner_rect := _make_thumb_cell(box, Vector2(0, 220), false)
 		_browse_load_thumbnail_async(banner_rect, img_record)
 
 	var user_dict: Dictionary = mod_data.get("user", {}) if mod_data.get("user") is Dictionary else {}

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -5848,6 +5848,25 @@ func build_browse_tab(tabs: TabContainer) -> Control:
 		if not append:
 			for child in list.get_children():
 				child.queue_free()
+			# Give this view the same heading treatment the landing's sections
+			# get. Sits above the empty state too, so "no results" still says
+			# what was searched for.
+			var cat_name := ""
+			if is_instance_valid(category_dropdown) and int(state["category_id"]) > 0:
+				cat_name = category_dropdown.get_item_text(category_dropdown.selected)
+			var hdr := Label.new()
+			hdr.text = _browse_results_header_text(
+				str(state["query"]), str(state["sort"]), cat_name)
+			hdr.add_theme_font_size_override("font_size", FS_HEAD)
+			hdr.add_theme_color_override("font_color", COL_TEXT)
+			# A long search string must not widen the list and force a
+			# horizontal scrollbar.
+			hdr.clip_text = true
+			hdr.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+			hdr.tooltip_text = hdr.text
+			hdr.mouse_filter = Control.MOUSE_FILTER_PASS
+			list.add_child(hdr)
+			list.add_child(HSeparator.new())
 		var install_map: Dictionary = compute_install_map.call()
 		for mod_data in mods:
 			if not (mod_data is Dictionary):
@@ -6281,6 +6300,31 @@ func _json_int(d: Dictionary, key: String, fallback: int = 0) -> int:
 # button for a disabled "Installed" indicator -- update detection (delta vs
 # MWS' current version) lives in the Updates tab for now and isn't surfaced
 # here in this iteration.
+# Title for a filtered / searched / category Browse view. The curated landing
+# titles its own two sections ("Popular this week" / "Latest") but every other
+# view rendered a bare row list, so the only heading in the whole tab belonged
+# to Popular -- it read as if that were a permanent title rather than one
+# section among several.
+#
+# Derived from the sort key actually sent to the API, not the dropdown index:
+# picking a category while the dropdown still reads "Featured" sends bumped_at,
+# and the header has to describe the results, not the control.
+func _browse_results_header_text(query: String, sort_key: String, category_name: String) -> String:
+	var sort_labels := {
+		"bumped_at": "Recently updated",
+		"downloads": "Most downloaded",
+		"likes": "Most liked",
+		"views": "Most viewed",
+		"published_at": "Newest",
+	}
+	var q := query.strip_edges()
+	var head: String = ("Results for \"" + q + "\"") if not q.is_empty() \
+			else str(sort_labels.get(sort_key, "Results"))
+	var cat := category_name.strip_edges()
+	if not cat.is_empty():
+		head += " in " + cat
+	return head
+
 func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get: Callable, on_toggle: Callable) -> Control:
 	var row := HBoxContainer.new()
 	row.add_theme_constant_override("separation", SP_L)


### PR DESCRIPTION
Two commits' worth of 3.3.1 fixes: a user bug report (MJRamon) plus a 46-finding internal audit, then an adversarial review pass over the whole diff.

## Correctness / user-facing errors
- **Offline downloads no longer lie.** Both `download_and_replace_mod` paths collapsed transport failures and real HTTP errors into one branch that formatted a status code -- with no response, that code is 0, so an offline download reported `Download failed (HTTP 0)`. The branches are split; transport failures say so.
- **Legacy API routes send our User-Agent.** `api.modworkshop.net` answers a default UA with a bodyless 403. The update-check and update-download routes were the only ones missing it.
- **Search is clamped to 150 chars** at the input and in `mws_list_mods`. The API 422s past that, which surfaced as "check your connection" -- a diagnosis no retry could fix.
- **JSON responses are capped at 8MB.** These were the only two uncapped fetch paths.
- **The discover snapshot is written atomically** (.tmp + checked write + rename), so a crash mid-write no longer truncates the offline grace snapshot in place.
- **"Launch vanilla" reports a failed sentinel write** instead of leaving a dead-looking button.

## Rendering / layout
DPI content-scaling with a screen clamp, base font scale, scrollbar width, unified control height and dialog padding, dialog size clamping. Thumbnails get a no-image/load-failed placeholder, downscale-before-cache, an in-memory texture cache with FIFO eviction, and a freed-node race guard. Modpack row names, the Mods-tab version column, and Browse detail file versions clip with an ellipsis plus a full-text tooltip.

## Flow / state
Updates-tab in-flight guard with bookkeeping ordered before the validity early-return, real error surfacing, and state that survives a tab switch. Browse gets in-dialog download status, batch failure reporting, category retry, null-safe numerics, a "Featured" dropdown with Enter routing. Modpack rate-limit pause with a working Cancel; save-as validates before destroying input. The Updates Activity log autoscrolls correctly and is capped at 200 lines.

## Performance
Debounced Mods filter, hoisted dependency map, serialized meta queue, persisted mod-meta sidecar, security-scan result cache, MWS transport retry, priority-save flush.

## Verification
No Godot on the dev machine -- correctness is by reading, and the build is smoke-tested in-game before merge. The full ~1,400-line diff was reviewed hunk-by-hunk against GDScript 4.6.2 validity, cross-file top-level symbol collisions (build.sh concatenates all of `src/` into one namespace), lambda capture-by-value, typed-array assignment, `Dictionary.get` present-but-null, nodes freed across an `await`, timers firing after their target is freed, and unbounded caches. That pass found and fixed the Activity-log leak; four lower-severity items were logged and deferred as needing restructuring beyond this diff's intent.

`bash build.sh` is clean (24,396 lines, 39 files) and the output is ASCII-clean.
