### PR TITLE
fix: 3.3.1 -- repair the 3.3.0 hook regression, and make it untestable-no-more

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -97,4 +97,18 @@ if [[ -n "$bad_await" ]]; then
     exit 1
 fi
 echo "OK: codegen invariants hold (no unconditional await in wrapper templates)"
+
+# ---------------------------------------------------------------------------
+# Codegen compile harness: run the REAL rewriter over real vanilla scripts,
+# then compile both the rewritten output and a generated caller stub with the
+# real GDScript compiler. The grep invariant above pins the one template line
+# that broke 3.3.0; the harness fails the whole bug class (any wrapper
+# becoming a coroutine, signature drift, transform breakage) at build time.
+# Skips itself (exit 0, with a banner) on machines without the decompiled
+# vanilla source. Self-test: ./check_codegen.sh --prove
+# ---------------------------------------------------------------------------
+if ! ./check_codegen.sh; then
+    echo "FAILED: codegen compile harness (see above)" >&2
+    exit 1
+fi
 exit 0

--- a/check.sh
+++ b/check.sh
@@ -96,7 +96,23 @@ if [[ -n "$bad_await" ]]; then
     echo "$bad_await" >&2
     exit 1
 fi
-echo "OK: codegen invariants hold (no unconditional await in wrapper templates)"
+# INVARIANT: the docs must not re-bless the bug either.
+#
+# The commit that shipped the 3.3.0 await regression ALSO edited Hooks.md to
+# document the broken wrapper as intended behavior -- in two separate places.
+# That is worse than an undocumented bug: it made the fix look like a contract
+# change, and the first pass at correcting the docs missed the second block.
+# Pin both, so a future doc sync cannot quietly describe the bug as a feature.
+bad_doc=$(grep -n 'await _repl\[0\]' docs/wiki/Hooks.md || true)
+bad_doc+=$(grep -in 'replace callback is always awaited' docs/wiki/Hooks.md || true)
+if [[ -n "$bad_doc" ]]; then
+    echo "FAILED: docs/wiki/Hooks.md documents the 3.3.0 unconditional-await bug" >&2
+    echo "        as intended behavior. The wrapper awaits the replace callback" >&2
+    echo "        ONLY when the vanilla method is itself a coroutine." >&2
+    echo "$bad_doc" >&2
+    exit 1
+fi
+echo "OK: codegen invariants hold (no unconditional await in templates or docs)"
 
 # ---------------------------------------------------------------------------
 # Codegen compile harness: run the REAL rewriter over real vanilla scripts,

--- a/check.sh
+++ b/check.sh
@@ -66,5 +66,35 @@ if [[ $status -eq 0 ]]; then
     echo "OK: $OUT parses clean ($(wc -l < "$OUT") lines)"
 else
     echo "FAILED: $OUT has parse/type errors (see above)" >&2
+    exit $status
 fi
-exit $status
+
+# ---------------------------------------------------------------------------
+# Codegen invariants. These assert on the wrapper TEMPLATES in rewriter.gd,
+# not on a running loader: generating a wrapper for real would mean executing
+# modloader.gd, and its static-init runs the whole boot sequence against
+# whatever directory the engine lives in. Static assertions are the safe way
+# to pin a contract the compiler cannot see.
+# ---------------------------------------------------------------------------
+
+# INVARIANT: no emitted line may contain a literal `await`.
+#
+# In GDScript, ANY function whose body contains `await` is a coroutine. A
+# hardcoded await in a wrapper template therefore turns every wrapped vanilla
+# method into a coroutine, and every existing caller breaks at PARSE time
+# ("Function X is a coroutine, so it must be called with await") -- including
+# third-party mods calling vanilla correctly. Shipped in 3.3.0 and broke any
+# mod pairing with a wide enough hook surface.
+#
+# The only legitimate way to emit an await is via the `aw` variable, which is
+# "await " only when the vanilla target is itself a coroutine.
+bad_await=$(grep -n 'out += ' src/rewriter.gd | grep 'await' || true)
+if [[ -n "$bad_await" ]]; then
+    echo "FAILED: rewriter.gd emits a literal 'await' into generated code." >&2
+    echo "        Use the is_coro-gated 'aw' variable instead -- an" >&2
+    echo "        unconditional await makes every wrapped method a coroutine." >&2
+    echo "$bad_await" >&2
+    exit 1
+fi
+echo "OK: codegen invariants hold (no unconditional await in wrapper templates)"
+exit 0

--- a/check.sh
+++ b/check.sh
@@ -127,4 +127,18 @@ if ! ./check_codegen.sh; then
     echo "FAILED: codegen compile harness (see above)" >&2
     exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# Runtime dispatch harness: the layer above the compile harness. Loads the
+# neutered loader in-engine, rewrites a synthetic fixture with the real
+# rewriter, attaches it to real Nodes, registers hooks through the real
+# public API and asserts on actual dispatch behavior (ordering, skip_super,
+# post-result mutation, _caller, re-entrancy, coroutines, defaults).
+# Needs no vanilla corpus, so it never skips; ~1s. Self-test:
+# ./check_dispatch.sh --prove
+# ---------------------------------------------------------------------------
+if ! ./check_dispatch.sh; then
+    echo "FAILED: runtime dispatch harness (see above)" >&2
+    exit 1
+fi
 exit 0

--- a/check_codegen.sh
+++ b/check_codegen.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# check_codegen.sh -- COMPILE the rewriter's generated output with the real
+# GDScript compiler, against real vanilla game source.
+#
+# Why this exists: the loader rewrites vanilla scripts by string manipulation
+# (src/rewriter.gd) and the result was historically never compiled outside a
+# running game. 3.3.0 shipped a one-character-class bug -- an unconditional
+# `await` in a wrapper template -- that made every wrapped vanilla method a
+# coroutine and broke every third-party mod calling them AT PARSE TIME.
+# check.sh's grep invariants pin that exact template line; THIS harness runs
+# the real rewriter over real vanilla scripts and compiles what comes out,
+# so the whole bug class (not just the known instance) fails the build.
+#
+# Pipeline (details in tests/codegen/runner.gd):
+#   1. Assemble a THROWAWAY Godot project under the system temp dir:
+#      decompiled vanilla Scripts/*.gd, the game's own global class cache,
+#      generated stub .tres/.tscn for every preload() target, the game's
+#      three autoload singletons pointed at the copied scripts, the
+#      synthetic tests/codegen/Fixture*.gd, and a NEUTERED copy of the
+#      built modloader.gd (see below).
+#   2. Run runner.gd headless in that project. Per fixture it compiles the
+#      pristine source (baseline), rewrites it with the real
+#      _rtv_rewrite_vanilla_source (wrap-all AND masked), asserts output
+#      properties (no await in non-coroutine wrappers, body preserved under
+#      _rtv_vanilla_<name>, wrapper signature byte-identical, masked set
+#      exact), recompiles the rewritten file at its canonical path, and
+#      compiles a generated CALLER stub that invokes every wrapped method
+#      without `await` -- the call-site check that actually catches a
+#      wrapper silently becoming a coroutine.
+#
+# WHY LOADING THE MODLOADER HERE IS SAFE: merely instantiating modloader.gd
+# executes its boot sequence, because constants.gd declares
+#     var _filescope_mounted: Dictionary = _mount_previous_session()
+# and _mount_previous_session() mounts archives, rewrites override.cfg and
+# wipes hook caches relative to OS.get_executable_path() -- which in a test
+# is the GODOT BINARY's directory. This script therefore builds
+# modloader_neutered.gd: a byte-identical copy with that ONE initializer
+# mechanically replaced by `= {}` (verified to match exactly once, so the
+# harness fails loudly if constants.gd drifts). No boot code can run; the
+# runner double-checks _filescope_mounted is empty after new().
+#
+# HOW TO ADD A FIXTURE:
+#   - Real vanilla script: add {"file": "Name.gd"} to FIXTURES in
+#     tests/codegen/runner.gd. The script must compile PRISTINE in the
+#     harness project (the baseline step tells you if it does not -- usually
+#     a preload of an asset type this script cannot stub, or a missing
+#     autoload). Add a "mask": [...] entry to also exercise the partial
+#     rename path. If the rewriter modifies the method's body on purpose
+#     (prelude injection), list it in BODY_MODIFIED.
+#   - Synthetic script: drop a FixtureName.gd in tests/codegen/ (it is
+#     copied into res://Scripts/), add it to FIXTURES. Use
+#     {"baseline": false} if the pristine source is intentionally invalid
+#     (legacy-autofix fixtures).
+#
+# Usage:
+#   ./check_codegen.sh              # build.sh must have run first
+#   ./check_codegen.sh --prove      # self-test: reintroduce the 3.3.0
+#                                   #   unconditional await in the TEMP copy
+#                                   #   (never src/) and require the harness
+#                                   #   to FAIL; exits 0 only if it did
+#   GODOT=... VANILLA_SRC=... ./check_codegen.sh   # override paths
+#
+# This NEVER opens a window and NEVER touches the game install: --headless
+# only, against the throwaway project. If the decompiled vanilla source is
+# not present on this machine the harness SKIPS (exit 0) with a banner, so
+# check.sh still works for contributors without it.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+PROVE=0
+if [[ "${1:-}" == "--prove" ]]; then
+    PROVE=1
+fi
+
+OUT=modloader.gd
+
+# Same engine resolution as check.sh.
+DEFAULT_GODOT="/c/Users/ametr/Downloads/Godot_v4.6.1-stable_win64.exe/Godot_v4.6.1-stable_win64_console.exe"
+GODOT="${GODOT:-}"
+if [[ -z "$GODOT" ]]; then
+    if command -v godot >/dev/null 2>&1; then
+        GODOT=$(command -v godot)
+    else
+        GODOT="$DEFAULT_GODOT"
+    fi
+fi
+if [[ ! -x "$GODOT" && ! -f "$GODOT" ]]; then
+    echo "ERROR: Godot not found at: $GODOT (set GODOT=/path/to/godot)" >&2
+    exit 127
+fi
+
+if [[ ! -f "$OUT" ]]; then
+    echo "ERROR: $OUT not found -- run ./build.sh first." >&2
+    exit 1
+fi
+
+# Decompiled vanilla game source (plain .gd) -- the input corpus.
+VANILLA_SRC="${VANILLA_SRC:-/c/Users/ametr/Documents/Road to Vostok}"
+if [[ ! -d "$VANILLA_SRC/Scripts" ]]; then
+    echo "SKIPPED: codegen compile harness needs the decompiled vanilla source at:"
+    echo "         $VANILLA_SRC/Scripts  (override with VANILLA_SRC=...)"
+    echo "         Machines without it skip this check; the template grep invariants"
+    echo "         in check.sh still apply."
+    exit 0
+fi
+if [[ ! -f "$VANILLA_SRC/.godot/global_script_class_cache.cfg" ]]; then
+    echo "ERROR: $VANILLA_SRC/.godot/global_script_class_cache.cfg missing -- the" >&2
+    echo "       harness reuses the game's own class_name cache verbatim." >&2
+    exit 1
+fi
+
+start_s=$SECONDS
+
+# Throwaway project outside the repo. Rebuilt every run so a stale copy can
+# never be what gets checked.
+WORK="${TMPDIR:-/tmp}/modloader-codegen-check"
+rm -rf "$WORK"
+mkdir -p "$WORK/Scripts" "$WORK/.godot" "$WORK/callers"
+
+cp "$VANILLA_SRC"/Scripts/*.gd "$WORK/Scripts/"
+cp "$VANILLA_SRC/.godot/global_script_class_cache.cfg" "$WORK/.godot/"
+cp tests/codegen/Fixture*.gd "$WORK/Scripts/"
+cp tests/codegen/runner.gd "$WORK/runner.gd"
+
+# Mirror the game's real autoload singletons (project.godot [autoload] in the
+# decompile lists Loader/Database/Simulation as scenes; the scripts are what
+# the analyzer needs, and headless --script runs instantiate them, which is
+# harmless -- a few missing-node lines of startup noise, filtered below).
+cat > "$WORK/project.godot" <<'EOF'
+config_version=5
+
+[application]
+
+config/name="modloader-codegen-check"
+
+[autoload]
+
+Loader="*res://Scripts/Loader.gd"
+Database="*res://Scripts/Database.gd"
+Simulation="*res://Scripts/Simulation.gd"
+EOF
+
+# Stub every preload() target so pristine vanilla compiles. The corpus only
+# preloads .tres and .tscn (both representable as text); anything else is a
+# hard error so a future corpus change cannot silently weaken the baseline.
+preload_list="$WORK/preload_paths.txt"
+grep -hoE 'preload\("res://[^"]+"' "$WORK"/Scripts/*.gd | sed 's/^preload("//; s/"$//' | sort -u > "$preload_list"
+# Create all needed directories in one call, then the stub files.
+sed "s|^res://|$WORK/|" "$preload_list" | xargs -r -d '\n' -n 64 dirname | sort -u | tr '\n' '\0' | xargs -0 -r mkdir -p
+while IFS= read -r p; do
+    rel="${p#res://}"
+    tgt="$WORK/$rel"
+    [[ -f "$tgt" ]] && continue
+    case "$p" in
+        *.tres) printf '[gd_resource type="Resource" format=3]\n\n[resource]\n' > "$tgt" ;;
+        *.tscn) printf '[gd_scene format=3]\n\n[node name="Root" type="Node"]\n' > "$tgt" ;;
+        *)
+            echo "ERROR: unstubbable preload target in vanilla corpus: $p" >&2
+            echo "       Extend the stub generator in check_codegen.sh." >&2
+            exit 1
+            ;;
+    esac
+done < "$preload_list"
+
+# Neuter the modloader's static-init boot line (see the header). Exact-line
+# match, required to appear exactly once -- fails loudly on drift.
+INIT_LINE='var _filescope_mounted: Dictionary = _mount_previous_session()'
+n=$(grep -cxF "$INIT_LINE" "$OUT" || true)
+if [[ "$n" -ne 1 ]]; then
+    echo "ERROR: expected exactly 1 occurrence of the static-init initializer line" >&2
+    echo "       in $OUT, found $n. constants.gd changed -- update INIT_LINE in" >&2
+    echo "       check_codegen.sh so the harness keeps neutering the right thing." >&2
+    exit 1
+fi
+sed 's|^var _filescope_mounted: Dictionary = _mount_previous_session()$|var _filescope_mounted: Dictionary = {}  # codegen-check: boot static-init neutralized (test copy only)|' \
+    "$OUT" > "$WORK/modloader_neutered.gd"
+if [[ $(grep -cxF "$INIT_LINE" "$WORK/modloader_neutered.gd" || true) -ne 0 ]]; then
+    echo "ERROR: neutering failed -- initializer line still present in the test copy." >&2
+    exit 1
+fi
+
+# --prove: reintroduce the exact 3.3.0 regression (unconditional await in the
+# wrapper template) in the TEMP copy only, and demand the harness FAIL.
+if [[ $PROVE -eq 1 ]]; then
+    AW_LINE=$'\tvar aw: String = "await " if is_coro else ""'
+    if [[ $(grep -cxF "$AW_LINE" "$WORK/modloader_neutered.gd" || true) -ne 1 ]]; then
+        echo "ERROR: --prove could not find the aw template line to mutate." >&2
+        exit 1
+    fi
+    perl -i -pe 's/^\tvar aw: String = "await " if is_coro else ""$/\tvar aw: String = "await "  # --prove: 3.3.0 unconditional-await regression reintroduced (temp copy only)/' \
+        "$WORK/modloader_neutered.gd"
+    echo "--prove: reintroduced the unconditional await in the TEMP modloader copy"
+fi
+
+"$GODOT" --headless --path "$WORK" --script res://runner.gd > "$WORK/run.log" 2>&1
+status=$?
+
+# Show the log from the harness marker onward (drops the expected startup
+# noise from instantiating the game's autoloads headless: missing child
+# nodes, audio bus lookups). The complete log stays at $WORK/run.log.
+awk '/\[codegen\] harness start/{on=1} on' "$WORK/run.log" | grep -v '^Godot Engine v' | grep -v '^$'
+elapsed=$((SECONDS - start_s))
+
+if [[ $PROVE -eq 1 ]]; then
+    if [[ $status -ne 0 ]]; then
+        echo "PROVE-OK: harness FAILED as required with the regression present (${elapsed}s). Full log: $WORK/run.log"
+        exit 0
+    fi
+    echo "PROVE FAILED: the harness PASSED with the unconditional await present." >&2
+    echo "              The harness is a rubber stamp -- do not trust it." >&2
+    exit 1
+fi
+
+if [[ $status -eq 0 ]]; then
+    echo "OK: codegen harness passed in ${elapsed}s (full log: $WORK/run.log)"
+else
+    echo "FAILED: codegen harness (exit $status, ${elapsed}s). Full log: $WORK/run.log" >&2
+fi
+exit $status

--- a/check_dispatch.sh
+++ b/check_dispatch.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# check_dispatch.sh -- prove the generated hook wrappers DISPATCH correctly
+# at runtime, with the real engine.
+#
+# Why this exists: check.sh proves the built loader parses; check_codegen.sh
+# proves the rewriter's output COMPILES. Neither proves it BEHAVES. A wrapper
+# can compile perfectly and still call the wrong callback, in the wrong
+# order, with the wrong arguments, drop a post hook's result mutation, or
+# ignore skip_super() -- the loader's entire value proposition (mods hooking
+# vanilla methods) with no automated check on it. This harness closes that
+# gap: it instantiates the (neutered) loader, runs the REAL rewriter over a
+# synthetic fixture, attaches the rewritten script to real Nodes, registers
+# hooks through the REAL public API (Engine.get_meta("RTVModLib").hook(...)),
+# CALLS the wrapped methods, and asserts on the recorded execution order.
+#
+# Behaviors covered (contract: docs/wiki/Hooks.md + src/hooks_api.gd; test
+# ids T1..T12 in tests/codegen/dispatch_runner.gd):
+#   T1  -pre fires before vanilla, with the vanilla arguments
+#   T2  replace: before vanilla; vanilla's return wins unless skip_super(),
+#       which suppresses vanilla and promotes the callback's return
+#   T3  -post: trailing _result, non-null replaces / null passes through,
+#       legacy 2-arg observer form, ascending-priority chaining
+#   T4  -callback fires deferred, after the method returned
+#   T5  pre -> replace-or-vanilla -> post -> deferred; ascending priority
+#   T6  replace slot single-owner (second registration -1, first still runs)
+#   T7  unhook(id) stops that callback, leaves others intact
+#   T8  _lib._caller correct + restored around nested wrapped calls
+#   T9  re-entrancy: no recursive dispatch, and the guard key is RELEASED
+#       (a leaked key would permanently disable the hook for that instance)
+#   T10 two instances of one wrapped script dispatch independently
+#   T11 coroutine vanilla methods still await and return their value
+#   T12 defaulted parameters flow through when omitted
+#
+# Unlike check_codegen.sh this needs NO decompiled vanilla source -- the
+# fixture is synthetic -- so it runs on every machine with a Godot binary
+# and never skips.
+#
+# NEUTERING: identical recipe to check_codegen.sh (see its header for the
+# full rationale). modloader.gd's single static-init boot line
+#     var _filescope_mounted: Dictionary = _mount_previous_session()
+# is replaced by `= {}` in a TEMP copy, asserted to occur exactly once so
+# drift in constants.gd fails loudly; the runner double-checks no boot code
+# ran. This NEVER opens a window and NEVER touches the game install:
+# --headless only, against a throwaway project under the system temp dir.
+#
+# Usage:
+#   ./check_dispatch.sh             # build.sh must have run first
+#   ./check_dispatch.sh --prove     # self-test: three separate mutations of
+#                                   #   the TEMP loader copy (never src/),
+#                                   #   each must make the harness FAIL on
+#                                   #   the specific behavior it breaks:
+#                                   #   A. skip_super ignored        -> T2b
+#                                   #   B. post result mutation lost -> T3a
+#                                   #   C. re-entrancy guard leaks   -> T9
+#   GODOT=/path/to/godot ./check_dispatch.sh
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+PROVE=0
+if [[ "${1:-}" == "--prove" ]]; then
+    PROVE=1
+fi
+
+OUT=modloader.gd
+
+# Same engine resolution as check.sh.
+DEFAULT_GODOT="/c/Users/ametr/Downloads/Godot_v4.6.1-stable_win64.exe/Godot_v4.6.1-stable_win64_console.exe"
+GODOT="${GODOT:-}"
+if [[ -z "$GODOT" ]]; then
+    if command -v godot >/dev/null 2>&1; then
+        GODOT=$(command -v godot)
+    else
+        GODOT="$DEFAULT_GODOT"
+    fi
+fi
+if [[ ! -x "$GODOT" && ! -f "$GODOT" ]]; then
+    echo "ERROR: Godot not found at: $GODOT (set GODOT=/path/to/godot)" >&2
+    exit 127
+fi
+
+if [[ ! -f "$OUT" ]]; then
+    echo "ERROR: $OUT not found -- run ./build.sh first." >&2
+    exit 1
+fi
+
+start_s=$SECONDS
+WORK="${TMPDIR:-/tmp}/modloader-dispatch-check"
+
+# Assemble the throwaway project. Rebuilt from scratch on every call so a
+# stale copy (or a previous run's mutation) can never be what gets checked.
+prepare_work() {
+    rm -rf "$WORK"
+    mkdir -p "$WORK/Scripts"
+    cp tests/codegen/FixtureDispatch.gd "$WORK/Scripts/"
+    cp tests/codegen/dispatch_runner.gd "$WORK/runner.gd"
+    printf 'config_version=5\n\n[application]\n\nconfig/name="modloader-dispatch-check"\n' > "$WORK/project.godot"
+
+    # Neuter the modloader's static-init boot line (see the header). Exact-line
+    # match, required to appear exactly once -- fails loudly on drift.
+    local INIT_LINE='var _filescope_mounted: Dictionary = _mount_previous_session()'
+    local n
+    n=$(grep -cxF "$INIT_LINE" "$OUT" || true)
+    if [[ "$n" -ne 1 ]]; then
+        echo "ERROR: expected exactly 1 occurrence of the static-init initializer line" >&2
+        echo "       in $OUT, found $n. constants.gd changed -- update INIT_LINE in" >&2
+        echo "       check_dispatch.sh so the harness keeps neutering the right thing." >&2
+        exit 1
+    fi
+    sed 's|^var _filescope_mounted: Dictionary = _mount_previous_session()$|var _filescope_mounted: Dictionary = {}  # dispatch-check: boot static-init neutralized (test copy only)|' \
+        "$OUT" > "$WORK/modloader_neutered.gd"
+    if [[ $(grep -cxF "$INIT_LINE" "$WORK/modloader_neutered.gd" || true) -ne 0 ]]; then
+        echo "ERROR: neutering failed -- initializer line still present in the test copy." >&2
+        exit 1
+    fi
+}
+
+# Mutate the TEMP loader copy. $1 = perl -pe expression, $2 = substring the
+# expression targets, $3 = how many times that substring must exist BEFORE
+# mutation (so template drift in rewriter.gd fails loudly instead of the
+# mutation silently matching nothing and the prove run rubber-stamping).
+mutate() {
+    local expr="$1" needle="$2" want="$3"
+    local have
+    have=$(grep -cF "$needle" "$WORK/modloader_neutered.gd" || true)
+    if [[ "$have" -ne "$want" ]]; then
+        echo "ERROR: --prove expected $want occurrence(s) of '$needle' in the loader," >&2
+        echo "       found $have. The wrapper template drifted -- update check_dispatch.sh." >&2
+        exit 1
+    fi
+    perl -i -pe "$expr" "$WORK/modloader_neutered.gd"
+    if [[ $(grep -cF "$needle" "$WORK/modloader_neutered.gd" || true) -ne 0 ]]; then
+        echo "ERROR: --prove mutation did not apply ('$needle' still present)." >&2
+        exit 1
+    fi
+}
+
+run_harness() {
+    "$GODOT" --headless --path "$WORK" --script res://runner.gd > "$WORK/run.log" 2>&1
+    return $?
+}
+
+show_log() {
+    awk '/\[dispatch\] harness start/{on=1} on' "$WORK/run.log" | grep -v '^Godot Engine v' | grep -v '^$'
+}
+
+if [[ $PROVE -eq 0 ]]; then
+    prepare_work
+    run_harness
+    status=$?
+    show_log
+    elapsed=$((SECONDS - start_s))
+    if [[ $status -eq 0 ]]; then
+        echo "OK: dispatch harness passed in ${elapsed}s (full log: $WORK/run.log)"
+    else
+        echo "FAILED: dispatch harness (exit $status, ${elapsed}s). Full log: $WORK/run.log" >&2
+    fi
+    exit $status
+fi
+
+# ---------------------------------------------------------------------------
+# --prove: three separate runs, each with ONE behavior broken in the TEMP
+# loader copy. Every run must FAIL, and the log must name the test that
+# guards that exact behavior -- otherwise the harness is a rubber stamp.
+# ---------------------------------------------------------------------------
+prove_failed=0
+
+# Each entry: label | perl mutation | pre-mutation needle | needle count |
+# test marker that must appear in the failing log.
+run_prove() {
+    local label="$1" expr="$2" needle="$3" want="$4" marker="$5"
+    prepare_work
+    mutate "$expr" "$needle" "$want"
+    echo "--prove [$label]: mutated the TEMP loader copy"
+    run_harness
+    local status=$?
+    if [[ $status -eq 0 ]]; then
+        echo "PROVE FAILED [$label]: the harness PASSED with the behavior broken." >&2
+        echo "                       That assertion is a rubber stamp -- do not trust it." >&2
+        prove_failed=1
+        return
+    fi
+    if ! grep -qF "FAIL $marker" "$WORK/run.log"; then
+        echo "PROVE FAILED [$label]: the harness failed, but NOT on $marker (the test" >&2
+        echo "                       guarding this behavior). See $WORK/run.log" >&2
+        prove_failed=1
+        return
+    fi
+    echo "PROVE-OK [$label]: harness FAILED on $marker as required:"
+    grep -F "FAIL $marker" "$WORK/run.log" | head -2 | sed 's/^/    /'
+}
+
+# A. skip_super ignored: the wrapper template's _did_skip capture is forced
+#    false, so vanilla always runs and the replace return is discarded.
+run_prove "skip_super ignored" \
+    's/var _did_skip = _lib\._skip_super/var _did_skip = false/g' \
+    'var _did_skip = _lib._skip_super' 2 \
+    'T2b'
+
+# B. post-hook result mutation dropped: the template still CALLS
+#    _dispatch_post (observers fire) but discards its return.
+run_prove "post result mutation dropped" \
+    's/_result = _lib\._dispatch_post/var _rtv_mut_ignored = _lib._dispatch_post/' \
+    '_result = _lib._dispatch_post' 1 \
+    'T3a'
+
+# C. re-entrancy guard leaks its key: the erase at the end of the wrapper
+#    becomes a read, so the first dispatch permanently disables hooks for
+#    that (instance, method) pair.
+run_prove "re-entrancy guard leaks" \
+    's/_lib\._wrapper_active\.erase\(_rtv_wa_key\)/_lib._wrapper_active.get(_rtv_wa_key)/g' \
+    '_lib._wrapper_active.erase(_rtv_wa_key)' 2 \
+    'T9'
+
+elapsed=$((SECONDS - start_s))
+if [[ $prove_failed -eq 0 ]]; then
+    echo "PROVE-OK: all 3 mutations caught by their guarding tests (${elapsed}s total)"
+    exit 0
+fi
+echo "PROVE FAILED: see above (${elapsed}s total)" >&2
+exit 1

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -158,7 +158,9 @@ func _custom_loot():
 
 ### `await` inside a replace hook
 
-Only suspend (`await` something that actually waits) inside a replace callback when the vanilla method you replaced is itself a coroutine. The wrapper always `await`s your replace callback -- free for synchronous callbacks -- but if vanilla is synchronous and your callback suspends, the wrapper suspends too, and the vanilla call site (which does not `await`) receives a coroutine state object instead of the declared type. Any typed call site (`var n: int = obj.Method()`) then throws a runtime error in vanilla code you cannot fix from a mod. For async work behind a synchronous hook, use `call_deferred` or a `-callback` hook and return a plain value.
+Only suspend (`await` something that actually waits) inside a replace callback when the vanilla method you replaced is itself a coroutine. The wrapper `await`s your replace callback only when vanilla is a coroutine; if vanilla is synchronous and your callback suspends, the method's result is a coroutine state object instead of the declared type. Any typed call site (`var n: int = obj.Method()`) then throws a runtime error in vanilla code you cannot fix from a mod. For async work behind a synchronous hook, use `call_deferred` or a `-callback` hook and return a plain value.
+
+> **Fixed in 3.3.1.** 3.3.0 emitted that `await` unconditionally. In GDScript *any* function whose body contains `await` is a coroutine, so the wrapper for a synchronous vanilla method became a coroutine itself, and every existing caller failed at parse time with `Function "X()" is a coroutine, so it must be called with "await"`. This broke unrelated mods calling vanilla correctly, scaling with the wrap surface. The rule above is unchanged -- suspending in a replace callback for a synchronous method was never supported -- only the wrapper's behavior was wrong.
 
 ## Post hooks and result mutation
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -262,6 +262,17 @@ Mods written against [godot-mod-loader](https://github.com/GodotModding/godot-mo
 - `_caller` is only meaningful during a dispatch.
 - A whole-script replacement at the same path -- a mod shipping its own file at the wrapped `res://Scripts/` path, or `take_over_path` from a script that does not extend it -- displaces the rewrite; hooks will not fire for nodes using that script. Chain-by-`extends` via `[script_extend]` (or its parse-identical legacy alias `[script_overrides]`) composes through `super()` (see below). Either way, the loader warns at boot when a wrapped path also carries an override claim.
 - A mod override that skips `super()` suppresses hook dispatch for that method.
+- **Overlapping calls to the same coroutine method on the same node skip hooks.** If a wrapped `await`-ing method is called again on the same instance while the first call is still suspended, the second call runs vanilla directly -- no pre, replace, post or callback. See below.
+
+### Overlapping coroutine calls
+
+Every wrapper holds a re-entrancy guard for the duration of its dispatch, keyed per instance and per hook. The guard exists to stop a `[script_extend]` subclass calling `super()` from re-entering the same wrapper and dispatching your hooks twice.
+
+For a synchronous method the guard is held for microseconds and you will never observe it. For a **coroutine** method it is held across the `await`, so a second call arriving on the same node while the first is suspended sees the guard and takes the vanilla path with no dispatch at all. Verified behavior, not a leak -- the guard is released on every completed path, and the next call after the first finishes dispatches normally.
+
+This is a known limitation rather than a bug we can fix cheaply: with a per-instance key the wrapper cannot distinguish "overlapping call" from "the extends-chain re-entry this guard exists to suppress", and threading a per-logical-call token through rewritten vanilla signatures is not possible without changing those signatures.
+
+Practical impact is small -- it needs a coroutine vanilla method re-entered on the *same node* mid-suspension. If you are hooking one and need every call observed, hook a synchronous method it calls instead, or use a `-callback` hook on the caller.
 
 ## Worked examples
 

--- a/docs/wiki/Hooks.md
+++ b/docs/wiki/Hooks.md
@@ -392,7 +392,7 @@ func <name>(args):
     if _repl.size() > 0:
         var _prev_skip = _lib._skip_super
         _lib._skip_super = false
-        var _replret = await _repl[0].callv([args])
+        var _replret = _repl[0].callv([args])  # `await`-prefixed only when vanilla is a coroutine
         var _did_skip = _lib._skip_super
         _lib._skip_super = _prev_skip
         if _did_skip:
@@ -418,7 +418,7 @@ func <name>(args):
 Notes:
 
 - **Void methods** use a structurally similar template but fire `_dispatch("<hook_base>-post", ...)` (return ignored) instead of `_dispatch_post`.
-- **Coroutines**: `await` is prepended to the vanilla call only when the vanilla body itself contains `await`. The replace callback is always awaited.
+- **Coroutines**: `await` is prepended to the vanilla call AND the replace-callback call only when the vanilla body itself contains `await`. An unconditional `await` on the replace call was the 3.3.0 regression: it marked every wrapped method a coroutine and broke every non-awaited call site at parse time (fixed in 3.3.1; regression-locked by `check_codegen.sh`).
 - The dispatch helpers (`_dispatch`, `_dispatch_post`, `_dispatch_deferred` in `src/hooks_api.gd`) iterate a `.duplicate()` snapshot of the entry array -- that is what makes mid-dispatch `hook()`/`unhook()` safe.
 - `_skip_super` is saved/restored around the replace call, so nested wrapped calls are safe.
 - The legacy-post deprecation warning is one-shot per (hook name, callback object, callback method), so hot-path methods do not spam the log.

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -161,7 +161,12 @@ static func _static_write_cfg_atomic(cfg_path: String, content: String) -> bool:
 	if dir.rename(tmp.get_file(), cfg_path.get_file()) != OK:
 		DirAccess.remove_absolute(tmp)
 		if FileAccess.file_exists(bak):
-			dir.rename(bak.get_file(), cfg_path.get_file())
+			# If the rename back fails too (same lock that broke the promote),
+			# fall back to a byte copy so a live cfg always exists -- mirrors
+			# _write_override_cfg's restore path. Losing override.cfg entirely
+			# means the ModLoader autoload never loads again (no self-heal).
+			if dir.rename(bak.get_file(), cfg_path.get_file()) != OK:
+				DirAccess.copy_absolute(bak, cfg_path)
 		return false
 	if FileAccess.file_exists(bak):
 		DirAccess.remove_absolute(bak)
@@ -585,8 +590,16 @@ func _ensure_early_autoload_on_disk(res_path: String, mod_name: String) -> Strin
 	if f == null:
 		_log_critical("Cannot write early autoload to disk: " + target + " [" + mod_name + "]")
 		return res_path
-	f.store_string(script.source_code)
+	var wrote_ok := f.store_string(script.source_code)
+	var werr := f.get_error()
 	f.close()
+	if not wrote_ok or werr != OK:
+		# Disk full / IO error: a truncated script here would be handed to
+		# Godot via [autoload_prepend] and compiled next boot. Drop the partial
+		# file and fall back to the archive path instead.
+		DirAccess.remove_absolute(target)
+		_log_critical("Failed writing early autoload to disk: " + target + " [" + mod_name + "]")
+		return res_path
 
 	# Return as user:// path so Godot finds it without archive mounting.
 	var user_path := EARLY_AUTOLOAD_DIR.path_join(rel)
@@ -688,9 +701,13 @@ func _persist_hook_pack_state(pack_path: String, wrapped_paths: PackedStringArra
 	cfg.load(PASS_STATE_PATH)  # OK if missing; we populate below
 	cfg.set_value("state", "hook_pack_path", pack_path)
 	cfg.set_value("state", "hook_pack_wrapped_paths", wrapped_paths)
-	# Store exe mtime alongside so _mount_previous_session's existing
-	# exe-mtime check also invalidates the hook pack on game updates.
-	cfg.set_value("state", "hook_pack_exe_mtime", FileAccess.get_modified_time(OS.get_executable_path()))
+	# The game-update check in _mount_previous_session reads state/exe_mtime
+	# (a "hook_pack_exe_mtime" key written by earlier versions was never read
+	# anywhere). Seed exe_mtime only when missing -- Pass 1 persists the hook
+	# pack BEFORE _write_pass_state runs, and when _write_pass_state did run
+	# its value is authoritative.
+	if int(cfg.get_value("state", "exe_mtime", 0)) == 0:
+		cfg.set_value("state", "exe_mtime", FileAccess.get_modified_time(OS.get_executable_path()))
 	if cfg.get_value("state", "modloader_version", "") == "":
 		cfg.set_value("state", "modloader_version", MODLOADER_VERSION)
 	if cfg.save(PASS_STATE_PATH) == OK:

--- a/src/boot.gd
+++ b/src/boot.gd
@@ -906,5 +906,10 @@ func _restore_clean_override_cfg() -> void:
 func _clear_restart_counter() -> void:
 	var cfg := ConfigFile.new()
 	if cfg.load(PASS_STATE_PATH) == OK:
+		# Skip the save when already 0 -- this runs on the hash-match fast
+		# path every launch, and an unconditional save would add a disk write
+		# to a path that otherwise does no writes.
+		if int(cfg.get_value("state", "restart_count", 0)) == 0:
+			return
 		cfg.set_value("state", "restart_count", 0)
 		cfg.save(PASS_STATE_PATH)

--- a/src/conflict_report.gd
+++ b/src/conflict_report.gd
@@ -42,7 +42,18 @@ func _verify_script_overrides() -> void:
 		if targets.is_empty():
 			continue
 		if not printed_header:
-			_log_info("[OverrideVerify] === Post-autoload cache check ===")
+			# Debug, not info: this block is an operator diagnostic ("did
+			# take_over_path land?"), and a player can do nothing with it. The
+			# FAIL branch below stays a warning -- that one means a mod's
+			# override did not apply, which is worth surfacing to anyone.
+			#
+			# NOTE: only the LOGGING is gated. The load() below is left running
+			# unconditionally on purpose -- it may be load-bearing for the
+			# override mechanism (it populates the ResourceCache at the moment
+			# mod autoloads have just finished), and proving otherwise needs a
+			# runtime test. If it turns out to be purely diagnostic, the whole
+			# function should be skipped when not in developer mode.
+			_log_debug("[OverrideVerify] === Post-autoload cache check ===")
 			printed_header = true
 		for vanilla_path in targets:
 			var vp: String = String(vanilla_path)
@@ -52,7 +63,7 @@ func _verify_script_overrides() -> void:
 				continue
 			var src: String = scr.source_code
 			var src_head: String = src.substr(0, 60).replace("\n", " | ").replace("\t", " ")
-			_log_info("[OverrideVerify] %s | %s | resource_path=%s src_head=[%s]" \
+			_log_debug("[OverrideVerify] %s | %s | resource_path=%s src_head=[%s]" \
 					% [mod_name, vp, scr.resource_path, src_head])
 
 # Conflict summary + report output (developer mode; called from every

--- a/src/fs_archive.gd
+++ b/src/fs_archive.gd
@@ -464,7 +464,10 @@ func zip_folder_to_temp(folder_path: String) -> String:
 func _zip_folder_recursive(zp: ZIPPacker, disk_path: String, archive_prefix: String) -> bool:
 	var dir := DirAccess.open(disk_path)
 	if dir == null:
-		return true
+		# An unreadable (sub)folder means content is missing from the zip.
+		# Returning true here used to let the caller stamp a partial archive
+		# as complete -- every later launch would then trust half a mod.
+		return false
 	var ok := true
 	dir.list_dir_begin()
 	while true:

--- a/src/gdsc_detokenizer.gd
+++ b/src/gdsc_detokenizer.gd
@@ -414,8 +414,16 @@ func _gdsc_variant_to_source(value: Variant) -> String:
 		TYPE_INT:
 			return str(value)
 		TYPE_FLOAT:
+			# str() renders these as bare "inf"/"-inf"/"nan", which are not
+			# valid GDScript identifiers -- emit the builtin constants instead.
+			# (A literal inf/nan constant is rare -- e.g. an overflowing float
+			# literal folded by the tokenizer -- but must still compile.)
+			if is_inf(value):
+				return "INF" if value > 0.0 else "-INF"
+			if is_nan(value):
+				return "NAN"
 			var s := str(value)
-			if "." not in s and "e" not in s and "inf" not in s.to_lower() and "nan" not in s.to_lower():
+			if "." not in s and "e" not in s:
 				s += ".0"
 			return s
 		TYPE_STRING:
@@ -484,7 +492,12 @@ func _save_vanilla_source(script_path: String, source: String) -> void:
 	var cache_file := VANILLA_CACHE_DIR.path_join(script_path.trim_prefix("res://"))
 	DirAccess.make_dir_recursive_absolute(
 		ProjectSettings.globalize_path(cache_file.get_base_dir()))
-	var f := FileAccess.open(cache_file, FileAccess.WRITE)
+	# Write to a .tmp sibling and rename into place. FileAccess.WRITE creates
+	# the target file immediately, so writing the final path directly means a
+	# crash mid-write leaves a truncated file there -- and _read_vanilla_source
+	# trusts any non-empty cache hit as pristine vanilla forever.
+	var tmp_file := cache_file + ".tmp"
+	var f := FileAccess.open(tmp_file, FileAccess.WRITE)
 	if f == null:
 		return
 	# store_string returns bool since Godot 4.3; a truncated cache file would
@@ -494,7 +507,16 @@ func _save_vanilla_source(script_path: String, source: String) -> void:
 	f.close()
 	if not ok or err != OK:
 		_log_warning("[Detokenize] Vanilla cache write failed for %s (err %d) -- removing partial file" % [cache_file, err])
-		DirAccess.remove_absolute(ProjectSettings.globalize_path(cache_file))
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(tmp_file))
+		return
+	# rename_absolute replaces an existing target (DirAccess removes it first
+	# on Windows), so a stale empty file at the final path can't block the swap.
+	var rename_err := DirAccess.rename_absolute(
+		ProjectSettings.globalize_path(tmp_file),
+		ProjectSettings.globalize_path(cache_file))
+	if rename_err != OK:
+		_log_warning("[Detokenize] Vanilla cache rename failed for %s (err %d) -- cache skipped this session" % [cache_file, rename_err])
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(tmp_file))
 
 # ANCHOR: probe_paths below assume vanilla RTV ships Camera/Controller/Audio/AI
 # under res://Scripts/. If a game update renames ALL FOUR, this returns -1,

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -29,6 +29,29 @@ const REGISTRY_TARGETS: Array[String] = [
 func _is_registry_target(filename: String) -> bool:
 	return filename in REGISTRY_TARGETS
 
+# Post-rewrite verification markers for registry targets. Each substring is
+# emitted ONLY when the corresponding transform / prelude injection actually
+# landed in the rewritten source (the always-appended registry appendices
+# deliberately do NOT contain these strings -- verified against rewriter.gd).
+# The rewriter's transforms are anchored to vanilla source patterns and
+# silently no-op when a game update moves the pattern (see the ANCHOR
+# comments in rewriter.gd); checking the marker at generation time turns
+# that silent no-op into one loud, attributable warning. Keep in sync with:
+#   Database.gd  -> _rtv_rewrite_database_constants dict block
+#   Loader.gd    -> _rtv_loader_loadscene_prelude comment line
+#   AISpawner.gd -> _rtv_rewrite_aispawner_agent_assignments call sites
+#   AI.gd        -> _rtv_ai_selectweapon_prelude comment line
+#   FishPool.gd  -> _rtv_fishpool_ready_prelude comment line
+#   Compiler.gd  -> _rtv_compiler_spawn_prelude comment line
+const REGISTRY_EXPECTED_MARKERS: Dictionary = {
+	"Database.gd": "var _rtv_vanilla_scenes",
+	"Loader.gd": "scene_paths registry prelude",
+	"AISpawner.gd": "agent = _rtv_resolve_ai_type(",
+	"AI.gd": "ai_loadouts registry prelude",
+	"FishPool.gd": "fish_species registry prelude",
+	"Compiler.gd": "shelters/maps registry prelude",
+}
+
 # Convert the list of wrapped full res:// paths into the PackedStringArray
 # persisted in pass_state. boot.gd's next-session _mount_previous_session
 # uses these to preempt ONLY scripts this session wrapped, instead of a
@@ -96,6 +119,12 @@ func _source_has_indented_func_body(source: String) -> bool:
 # breaks for scripts loaded from user://, which shows up as broken super()
 # dispatch on class_name-wrapped scripts.
 func _generate_hook_pack(defer_activation: bool = false) -> String:
+	# Fresh per-generation state. _scripts_with_scene_preloads is repopulated
+	# below for exactly the scripts THIS generation rewrites; it is never
+	# cleared anywhere else, so a stale entry from an earlier generation in
+	# the same process would skew the eager/deferred accounting in
+	# _activate_rewritten_scripts and defer scripts we no longer wrap.
+	_scripts_with_scene_preloads.clear()
 	# Wipe prior-run artifacts even when deferring. Cheap + keeps mode-switches
 	# clean.
 	var hook_dir := ProjectSettings.globalize_path(HOOK_PACK_DIR)
@@ -211,18 +240,41 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# Empty inner dict = all methods (fallback used only for REGISTRY_TARGETS
 	# where the wrap contract is whole-script, not per-method).
 	var hook_mask: Dictionary = {}
+	# Reconciliation ledger: one entry per DECLARED wrap target, so the end of
+	# generation can answer "did every declared hook target end up in the
+	# pack?" in one place instead of leaving the reader to reconcile counts.
+	# Every branch below that drops a declared target records WHY here; any
+	# entry still "pending" after the rewrite loop is a target the loop never
+	# even visited. Shape per entry:
+	#   {declared, methods: Array (empty = wildcard), status: "pending" ->
+	#    "wrapped"|"lost", detail, missing_methods: Array}
+	# Consumed by _log_hook_reconciliation, which only runs when the pack
+	# survives (a discarded/failed pack already logs its own critical).
+	var reconcile: Dictionary = {}
 	for path: String in _hooked_methods:
+		var rec: Dictionary = {
+			"declared": "[hooks]/.hook()",
+			"methods": (_hooked_methods[path] as Dictionary).keys(),
+			"status": "pending",
+			"detail": "",
+			"missing_methods": [],
+		}
+		reconcile[path] = rec
 		# Normalize + validate the declared path. Reject anything outside
 		# res://Scripts/ -- hooks are only meaningful on vanilla game scripts.
 		# A bad path here is a silent failure mode for mod authors; surface it.
 		if not path.begins_with("res://Scripts/"):
-			_log_warning("[RTVCodegen] [hooks] declared for non-vanilla path '%s' -- only res://Scripts/*.gd is hookable; entry ignored" % path)
+			rec["status"] = "lost"
+			rec["detail"] = "non-vanilla path -- only res://Scripts/*.gd is hookable"
+			_log_debug("[RTVCodegen] [hooks] declared for non-vanilla path '%s' -- entry ignored (reported by reconciliation)" % path)
 			continue
 		if not vanilla_path_set.has(path):
-			_log_warning("[RTVCodegen] [hooks] declared path '%s' doesn't match any vanilla script -- check for typos or stale paths; entry will no-op" % path)
-			# Still enroll it so the path_mask iteration below logs per-method
-			# "declared method not found" diagnostics against the empty set --
-			# no wrapper will be generated but the logging chain stays consistent.
+			rec["status"] = "lost"
+			rec["detail"] = "no vanilla script at this path (typo, or the game renamed/removed it)"
+			_log_debug("[RTVCodegen] [hooks] declared path '%s' doesn't match any vanilla script (reported by reconciliation)" % path)
+			# Still enroll it (harmless: the rewrite loop iterates the
+			# ENUMERATED vanilla list, so an unknown path is never visited);
+			# the ledger entry above is what actually reports the loss.
 		needed_paths[path] = true
 		hook_mask[path] = (_hooked_methods[path] as Dictionary).duplicate()
 	# Gate Database.gd on explicit [registry] opt-in. REGISTRY_TARGETS are
@@ -234,15 +286,32 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			var rt_path := "res://Scripts/" + rt_filename
 			needed_paths[rt_path] = true
 			hook_mask.erase(rt_path)  # whole-script wrap, no mask
+			if reconcile.has(rt_path):
+				# Also declared via [hooks]; the registry opt-in widens it to
+				# a whole-script wrap, so track it as a wildcard from here on.
+				(reconcile[rt_path] as Dictionary)["declared"] = "[hooks]+[registry]"
+				(reconcile[rt_path] as Dictionary)["methods"] = []
+				(reconcile[rt_path] as Dictionary)["status"] = "pending"
+				(reconcile[rt_path] as Dictionary)["detail"] = ""
+			else:
+				reconcile[rt_path] = {
+					"declared": "[registry]",
+					"methods": [],
+					"status": "pending",
+					"detail": "",
+					"missing_methods": [],
+				}
+			if not vanilla_path_set.has(rt_path):
+				(reconcile[rt_path] as Dictionary)["status"] = "lost"
+				(reconcile[rt_path] as Dictionary)["detail"] = "registry target not found among enumerated vanilla scripts"
 	_log_info("[RTVCodegen] Wrap surface: %d vanilla script(s) declared (%d via [hooks]/.hook(), %d via [registry])" % [
 		needed_paths.size(),
 		_hooked_methods.size(),
 		REGISTRY_TARGETS.size() if _any_mod_declared_registry else 0,
 	])
 	# Skip-list breakdown -- gives the README an evidence trail for "we wrap N
-	# scripts, skip M". The actual rewritten count is logged below by the
-	# "Generated N rewritten" line; this just records the static skip-list sizes.
-	_log_info("[RTVCodegen] Skip lists: %d runtime-sensitive, %d data, %d serialized (total %d skipped from rewrite)" % [
+	# scripts, skip M". Static table sizes, pure developer detail -- dev-only.
+	_log_debug("[RTVCodegen] Skip lists: %d runtime-sensitive, %d data, %d serialized (total %d skipped from rewrite)" % [
 		RTV_SKIP_LIST.size(),
 		RTV_RESOURCE_DATA_SKIP.size(),
 		RTV_RESOURCE_SERIALIZED_SKIP.size(),
@@ -357,17 +426,39 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	var surface_skipped: int = 0
 	for script_path: String in script_paths:
 		var filename := script_path.get_file()
+		# Ledger entry for this path when a mod declared it -- every drop
+		# branch below records its reason so the end-of-generation
+		# reconciliation can name it. Empty dict for undeclared paths
+		# (mutations on the temp default are guarded by is_empty()).
+		var rec_v: Dictionary = reconcile.get(script_path, {}) as Dictionary
 
+		# Skip lists win over declarations by design (wrapping these scripts
+		# is KNOWN to break them -- see constants.gd). But a mod that declared
+		# a hook on one must not find out by silence: warn NOW, in a normal
+		# (non-dev) log, and record the loss for the reconciliation.
 		if filename in RTV_SKIP_LIST:
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "on the runtime-sensitive skip list (wrapping is known to break this script; hooks here are not supported)"
+				_log_warning("[RTVCodegen] %s declares hooks on %s, but that script is excluded from rewriting (runtime-sensitive skip list) -- those hooks can never fire" \
+						% [_hook_declarers_label(script_path), filename])
 			_log_debug("[RTVCodegen] Skipped %s (runtime-sensitive)" % filename)
 			continue
 		if filename in RTV_RESOURCE_SERIALIZED_SKIP or filename in RTV_RESOURCE_DATA_SKIP:
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "a save-data/resource-data class (skip-listed; hook the call sites instead)"
+				_log_warning("[RTVCodegen] %s declares hooks on %s, but data/save resource classes are excluded from rewriting -- those hooks can never fire (hook the call sites instead)" \
+						% [_hook_declarers_label(script_path), filename])
 			continue
 		# Skip zero-byte PCK entries (base game ships empty .gd files for
 		# some scripts; CasettePlayer.gd in RTV 4.6.1). Detokenize cannot
 		# read content that doesn't exist. Not a modloader failure.
 		if _pck_zero_byte_paths.has(script_path):
 			zero_byte_skipped += 1
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "the game ships this script as a zero-byte file -- nothing to hook"
 			continue
 		# Wrap-surface filter: no mod extends, take_over_paths, or hooks
 		# this script, and it's not a pinned-at-boot class_name. Skipping
@@ -396,7 +487,10 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 
 		var source := _read_vanilla_source(script_path)
 		if source.is_empty():
-			_log_warning("[RTVCodegen] Empty detokenized source for %s -- skipped" % script_path)
+			_log_debug("[RTVCodegen] Empty detokenized source for %s -- skipped (reported by reconciliation)" % script_path)
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "detokenizer produced no source for this script (game build mismatch?)"
 			continue
 
 		var parsed := _rtv_parse_script(filename, source)
@@ -405,7 +499,11 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		# see the whole script). A path WITH a mask wraps ONLY declared methods.
 		var path_mask: Dictionary = hook_mask.get(script_path, {}) as Dictionary
 		var apply_mask: bool = not path_mask.is_empty()
-		var hookable_count := 0
+		# Track WHICH declared methods matched a parsed vanilla method, not
+		# just how many: a mask of 3 methods where only 1 exists used to wrap
+		# that 1 and stay silent about the other 2 (silent per-method loss).
+		var matched_names: Array[String] = []
+		var matched_mask_keys: Dictionary = {}
 		for fe in parsed["functions"]:
 			if fe["is_static"]:
 				continue
@@ -413,14 +511,28 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			# name (see add_hook() in hooks_api.gd). Vanilla fn["name"]
 			# preserves source casing (e.g. UpdateToolTip). Compare case-
 			# insensitively so mods writing "updatetooltip" match.
-			if apply_mask and not path_mask.has(fe["name"].to_lower()):
-				continue
-			hookable_count += 1
-		if hookable_count == 0:
 			if apply_mask:
-				_log_warning("[RTVCodegen] %s: declared [hooks] methods %s not found in vanilla -- skipping" \
-						% [filename, str(path_mask.keys())])
+				var mask_key: String = str(fe["name"]).to_lower()
+				if not path_mask.has(mask_key):
+					continue
+				matched_mask_keys[mask_key] = true
+			matched_names.append(str(fe["name"]))
+		var hookable_count := matched_names.size()
+		if hookable_count == 0:
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = ("declared method(s) %s not found in the vanilla script (check spelling/casing)" % str(path_mask.keys())) \
+						if apply_mask else "no hookable (non-static, parseable) method found in the vanilla script"
+			_log_debug("[RTVCodegen] %s: nothing hookable under the current mask -- skipping (reported by reconciliation)" % filename)
 			continue
+		# Partial-miss accounting: some declared methods matched, some didn't.
+		if apply_mask:
+			var missing_partial: Array = []
+			for mk: String in path_mask:
+				if not matched_mask_keys.has(mk):
+					missing_partial.append(mk)
+			if not rec_v.is_empty() and missing_partial.size() > 0:
+				rec_v["missing_methods"] = missing_partial
 
 		# Record scripts whose module-scope preload() pulls in a PackedScene.
 		# _activate_rewritten_scripts skips eager load+reload for these paths
@@ -440,6 +552,46 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			_scripts_with_scene_preloads[script_path] = scene_preloads
 
 		var rewritten := _rtv_rewrite_vanilla_source(source, parsed, path_mask)
+		# GEN-VERIFY: prove the rename actually landed for every matched
+		# method. The parser and the rewriter's rename pass are two separate
+		# implementations of "find this method" (regex parse vs line-prefix
+		# scan); any divergence (odd spacing, autofix side effects, future
+		# edits) silently produces a wrapper-less rewrite. Cheap check: every
+		# matched method must now exist as `func _rtv_vanilla_<Name>`.
+		var renamed_set: Dictionary = {}
+		for rl: String in rewritten.split("\n"):
+			if not rl.begins_with("func _rtv_vanilla_"):
+				continue
+			var name_tail := rl.substr(18)  # len("func _rtv_vanilla_") == 18
+			var name_len := 0
+			while name_len < name_tail.length() and _rtv_is_ident_char(name_tail[name_len]):
+				name_len += 1
+			if name_len > 0:
+				renamed_set[name_tail.substr(0, name_len)] = true
+		var rename_lost: Array = []
+		for mn: String in matched_names:
+			if not renamed_set.has(mn):
+				rename_lost.append(mn)
+		if rename_lost.size() > 0 and not rec_v.is_empty():
+			var mm: Array = rec_v.get("missing_methods", []) as Array
+			for rn in rename_lost:
+				mm.append(str(rn) + " (parsed but rename did not land)")
+			rec_v["missing_methods"] = mm
+		# REGISTRY-VERIFY: the per-target transforms/preludes are anchored to
+		# vanilla source patterns and no-op silently when the game changes
+		# (this is how the AI.gd SelectWeapon prelude went missing with only
+		# an INFO-question in the log). Marker check turns that into a
+		# recorded loss the reconciliation reports.
+		if _any_mod_declared_registry and _is_registry_target(filename):
+			var marker := str(REGISTRY_EXPECTED_MARKERS.get(filename, ""))
+			if marker != "" and not (marker in rewritten):
+				if not rec_v.is_empty():
+					var mm2: Array = rec_v.get("missing_methods", []) as Array
+					mm2.append("registry transform (marker '%s' absent -- registry features on this script will not work)" % marker)
+					rec_v["missing_methods"] = mm2
+				else:
+					# Registry targets are always in the ledger; belt+braces.
+					_log_warning("[RTVCodegen] %s: registry transform marker '%s' missing from rewrite -- registry features on this script will not work (game update changed the vanilla pattern?)" % [filename, marker])
 		# Ship at the ORIGINAL vanilla path so class_name registration in the
 		# PCK's global_script_class_cache.cfg matches our file. Declaring
 		# class_name at a non-registered path triggers "Class X hides a
@@ -450,21 +602,31 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		if zp.start_file(gd_entry) != OK:
 			_log_warning("[RTVCodegen] Failed to start zip entry %s" % gd_entry)
 			pack_write_failed = true
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "zip write failed (disk full / I/O error?)"
 			continue
 		if zp.write_file(rewritten.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			# An unflushed entry is a structurally-valid-but-truncated pack;
+			# treat like any other write failure so the pack gets discarded.
+			pack_write_failed = true
 		# Self-referencing .gd.remap overrides the PCK's .gd.remap -> .gdc
 		# redirect. Godot's _path_remap reads this BEFORE GDScript loader.
 		var remap_entry := gd_entry + ".remap"
 		if zp.start_file(remap_entry) != OK:
 			_log_warning("[RTVCodegen] Failed to start zip entry %s" % remap_entry)
 			pack_write_failed = true
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "zip write failed (disk full / I/O error?)"
 			continue
 		var remap_body := "[remap]\npath=\"%s\"\n" % script_path
 		if zp.write_file(remap_body.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 		# Empty .gdc to shadow the PCK's bytecode. Godot's GDScript loader
 		# prefers a sibling .gdc when present at the same base path -- even
 		# after our self-referencing remap redirects to .gd. A zero-byte
@@ -475,14 +637,22 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		if zp.start_file(gdc_entry) != OK:
 			_log_warning("[RTVCodegen] Failed to start zip entry %s" % gdc_entry)
 			pack_write_failed = true
+			if not rec_v.is_empty() and rec_v["status"] == "pending":
+				rec_v["status"] = "lost"
+				rec_v["detail"] = "zip write failed (disk full / I/O error?)"
 			continue
 		if zp.write_file(PackedByteArray()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 
 		script_count += 1
 		hook_count += hookable_count * 4  # pre/post/callback/replace per method
 		packed_paths.append(script_path)
+		if not rec_v.is_empty() and rec_v["status"] == "pending":
+			rec_v["status"] = "wrapped"
+			rec_v["detail"] = "%d method(s) wrapped" % hookable_count
+			rec_v["wrapped_count"] = hookable_count
 		_log_debug("[RTVCodegen] Rewrote %s (%d hooks)" % [script_path, hookable_count * 4])
 
 	# Step C (mod-subclass rewrite) removed in v3.0.1. Mods that extend
@@ -514,14 +684,15 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 		if zp.write_file(fixed_src.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 		if changed:
 			sibling_fixed += 1
 			sibling_total_bodyless += int(af["bodyless"])
 			sibling_total_reload_stripped += reload_stripped
 			if reload_stripped > 0:
-				_log_info("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
-			_log_info("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
+				_log_debug("[Autofix] Stripped %d redundant .reload() call(s) from %s -- prevents Cannot-reload-while-instances-exist spam" % [reload_stripped, p])
+			_log_debug("[Autofix] Patched sibling %s: bodyless=%d tool=%d onready=%d export=%d" \
 					% [p, af["bodyless"], af["tool"], af["onready"], af["export"]])
 		else:
 			sibling_carried += 1
@@ -541,7 +712,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	if zp.start_file("__modloader_canary__.txt") == OK:
 		if zp.write_file(canary_content.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 	else:
 		pack_write_failed = true
 
@@ -559,11 +731,26 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	# design depends on our Scripts/*.gd + .gd.remap entries winning over the
 	# PCK's same-path entries in Godot's VFS layering.
 	if zero_byte_skipped > 0:
-		_log_info("[RTVCodegen] Skipped %d zero-byte PCK entry(ies) (base game ships empty .gd files -- not hookable, not a modloader failure): %s" \
+		_log_debug("[RTVCodegen] Skipped %d zero-byte PCK entry(ies) (base game ships empty .gd files -- not hookable, not a modloader failure): %s" \
 				% [zero_byte_skipped, ", ".join(_pck_zero_byte_paths.keys())])
 	if surface_skipped > 0:
-		_log_info("[RTVCodegen] Surface-skipped %d vanilla script(s) with no mod interaction -- they run native (no dispatch overhead)" \
+		_log_debug("[RTVCodegen] Surface-skipped %d vanilla script(s) with no mod interaction -- they run native (no dispatch overhead)" \
 				% surface_skipped)
+	# Any ledger entry still "pending" was never even visited by the rewrite
+	# loop -- the loop iterates the ENUMERATED vanilla list, so a declared
+	# path missing from that list falls through every branch above without
+	# a trace. Catch-all so nothing can leave this function unaccounted.
+	for rp: String in reconcile:
+		var pending_rec: Dictionary = reconcile[rp]
+		if pending_rec.get("status", "") == "pending":
+			pending_rec["status"] = "lost"
+			if str(pending_rec.get("detail", "")) == "":
+				pending_rec["detail"] = "never reached the rewrite loop (not in the enumerated vanilla script list)"
+	# THE reconciliation: declared vs packed, in one place. Quiet when
+	# nothing was lost; one actionable line per loss otherwise. Pack-level
+	# failures (pack_write_failed / mount / canary) have their own criticals
+	# and discard the whole pack, so this only runs for a surviving pack.
+	_log_hook_reconciliation(reconcile)
 	if script_count > 0:
 		if defer_activation:
 			# Pass 1 pre-restart: write the zip + persist pass_state so Pass 2's
@@ -602,6 +789,87 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		_log_info("[RTVCodegen] No scripts rewritten -- no pack mounted")
 	return pack_zip_rel
 
+# "ModA, ModB" for the mods that declared hooks on a path, with sensible
+# fallbacks for core-seeded and runtime-registered (add_hook) entries.
+# Attribution comes from _hook_declared_by (mod_loading.gd), which is
+# diagnostic-only and may legitimately be empty for add_hook() callers.
+func _hook_declarers_label(path: String) -> String:
+	var by: Dictionary = _hook_declared_by.get(path, {}) as Dictionary
+	if not by.is_empty():
+		var names := PackedStringArray()
+		for n in by:
+			names.append(str(n))
+		return ", ".join(names)
+	if path == _MENU_SCRIPT_PATH:
+		return "the mod loader itself (core hook)"
+	return "a mod (declared at runtime via add_hook)"
+
+# End-of-generation reconciliation: declared vs actually-in-the-pack, one
+# authoritative answer instead of counts the reader must cross-check by hand.
+# Output contract (per the log-noise policy):
+#   - success: ONE info line ("N/N declared script target(s) wrapped").
+#   - loss: one critical header + one actionable line per lost target,
+#     naming the declaring mod, the methods, and the reason.
+#   - partial: one warning line per script that wrapped but is missing
+#     declared methods (typo'd method, rename that didn't land, registry
+#     transform whose vanilla anchor moved).
+#   - full per-entry table at _log_debug (dev mode only).
+# Deliberately runs only when the pack survived generation -- a discarded
+# pack already logs its own critical ("hooks disabled this session").
+# Pure string/dictionary work over data built during generation: no I/O,
+# no load(), no tree access, every read defaulted -- it cannot itself
+# break a boot.
+func _log_hook_reconciliation(reconcile: Dictionary) -> void:
+	if reconcile.is_empty():
+		return
+	var wrapped_scripts := 0
+	var wrapped_methods := 0
+	var declared_scripts := reconcile.size()
+	var lost_lines: PackedStringArray = []
+	var partial_lines: PackedStringArray = []
+	for path: String in reconcile:
+		var rec: Dictionary = reconcile[path] as Dictionary
+		var status := str(rec.get("status", "?"))
+		var detail := str(rec.get("detail", ""))
+		var methods: Array = rec.get("methods", []) as Array
+		var methods_label := "* (all methods)"
+		if not methods.is_empty():
+			var psa := PackedStringArray()
+			for m in methods:
+				psa.append(str(m))
+			methods_label = ", ".join(psa)
+		_log_debug("[RTVCodegen] reconcile %s :: %s [%s] -> %s%s" \
+				% [path, methods_label, str(rec.get("declared", "?")), status,
+					(" (" + detail + ")") if detail != "" else ""])
+		if status == "wrapped":
+			wrapped_scripts += 1
+			wrapped_methods += int(rec.get("wrapped_count", 0))
+			var mm: Array = rec.get("missing_methods", []) as Array
+			if mm.size() > 0:
+				var mpsa := PackedStringArray()
+				for m2 in mm:
+					mpsa.append(str(m2))
+				partial_lines.append("%s (declared by %s): wrapped, but missing: %s" \
+						% [path.get_file(), _hook_declarers_label(path), ", ".join(mpsa)])
+		else:
+			lost_lines.append("%s :: %s (declared by %s via %s) -- %s" \
+					% [path.get_file(), methods_label, _hook_declarers_label(path),
+						str(rec.get("declared", "?")), detail if detail != "" else "unknown reason"])
+	if lost_lines.is_empty() and partial_lines.is_empty():
+		_log_info("[RTVCodegen] Hook reconciliation OK: %d/%d declared script target(s) wrapped (%d method wrapper(s)) -- nothing lost between declaration and pack" \
+				% [wrapped_scripts, declared_scripts, wrapped_methods])
+		return
+	if lost_lines.size() > 0:
+		_log_critical("[RTVCodegen] Hook reconciliation: %d of %d declared hook target(s) did NOT make it into the hook pack -- these hooks will never fire:" \
+				% [lost_lines.size(), declared_scripts])
+		for ll in lost_lines:
+			_log_critical("[RTVCodegen]   LOST %s" % ll)
+	for pl in partial_lines:
+		_log_warning("[RTVCodegen]   PARTIAL %s" % pl)
+	if wrapped_scripts > 0:
+		_log_info("[RTVCodegen] Hook reconciliation: the other %d declared script target(s) wrapped OK (%d method wrapper(s))" \
+				% [wrapped_scripts, wrapped_methods])
+
 # Force the game's ResourceCache entry for each rewritten vanilla path to use
 # our source. Necessary because:
 #   - pre-mount load()s (engine class_name pre-compile for scripts in the main
@@ -635,6 +903,50 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 	if deferred.size() > 0:
 		_log_info("[RTVCodegen] DEFER %d script(s) with module-scope scene preload -- will lazy-compile via VFS after mod overrides: %s" \
 				% [deferred.size(), ", ".join(Array(deferred))])
+		# DEFER-VERIFY watchdog: "will lazy-compile" was a promise nobody
+		# checked -- if VFS precedence regresses, a deferred script compiles
+		# from PCK bytecode WITHOUT our rewrite and its hooks die silently.
+		# One shot at 60s: inspect ONLY scripts game code already loaded
+		# (has_cached guard -- never force a compile, that would re-create
+		# the exact preload-ordering bug the deferral exists to avoid).
+		# Three outcomes: rewrite live (fine), not yet loaded (normal until
+		# its scenes are used), or compiled WITHOUT rewrite (the silent-loss
+		# case -- one loud critical). Walks the base-script chain so a mod
+		# override sitting on top of our rewrite doesn't false-alarm.
+		var deferred_watch := deferred.duplicate()
+		get_tree().create_timer(60.0).timeout.connect(func():
+			var live_cnt := 0
+			var wrong: PackedStringArray = []
+			var untouched: PackedStringArray = []
+			for dp in deferred_watch:
+				var dps := String(dp)
+				if not ResourceLoader.has_cached(dps):
+					untouched.append(dps.get_file())
+					continue
+				var ds := load(dps) as GDScript
+				var ok := false
+				var chain := ds
+				var depth := 0
+				while chain != null and depth < 8 and not ok:
+					for m in chain.get_script_method_list():
+						if str(m.get("name", "")).begins_with("_rtv_vanilla_"):
+							ok = true
+							break
+					chain = chain.get_base_script() as GDScript
+					depth += 1
+				if ok:
+					live_cnt += 1
+				else:
+					wrong.append(dps.get_file())
+			if wrong.size() > 0:
+				_log_critical("[STABILITY] DEFER-VERIFY (60s): %d deferred script(s) lazy-compiled WITHOUT the rewrite -- VFS did not serve the hook pack for: %s. Hooks on these will not fire this session." \
+						% [wrong.size(), ", ".join(wrong)])
+			elif untouched.size() > 0:
+				_log_debug("[RTVCodegen] DEFER-VERIFY (60s): %d/%d deferred rewrite(s) live; %d not yet loaded by game code (normal until their scenes are used): %s" \
+						% [live_cnt, deferred_watch.size(), untouched.size(), ", ".join(untouched)])
+			else:
+				_log_debug("[RTVCodegen] DEFER-VERIFY (60s): all %d deferred rewrite(s) lazy-compiled with hooks live" % live_cnt)
+		)
 
 	# PRE-ACTIVATE pass: classify each cached script as
 	#  (a) already has _rtv_vanilla_* from static-init preload (pinned OK)
@@ -642,42 +954,46 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 	#  (c) source_code is empty (tokenized bytecode from PCK, no Static init preload)
 	#  (d) something else
 	# Summary counts printed at the end so we don't have to count by hand.
-	var pre_a := 0
-	var pre_b := 0
-	var pre_c := 0
-	var pre_d := 0
-	var pre_b_names: PackedStringArray = []
-	var pre_c_names: PackedStringArray = []
-	for fname: String in filenames:
-		if _scripts_with_scene_preloads.has(fname):
-			continue
-		var vp := fname
-		var c := load(vp) as GDScript
-		if c == null:
-			pre_d += 1
-			continue
-		var pre_rename := false
-		for m in c.get_script_method_list():
-			if str(m["name"]).begins_with("_rtv_vanilla_"):
-				pre_rename = true
-				break
-		var srclen: int = c.source_code.length()
-		if pre_rename:
-			pre_a += 1
-		elif srclen > 0:
-			pre_b += 1
-			pre_b_names.append(fname)
-		else:
-			pre_c += 1
-			pre_c_names.append(fname)
-	_log_info("[RTVCodegen] PRE-ACTIVATE summary: inline-live=%d, pinned-with-source=%d, pinned-tokenized=%d, other=%d / total=%d" \
-			% [pre_a, pre_b, pre_c, pre_d, filenames.size()])
-	if pre_b > 0:
-		_log_info("[RTVCodegen]   pinned-with-source (GDScriptCache has our text but compiled methods are vanilla): %s" \
-				% ", ".join(Array(pre_b_names).slice(0, 25)))
-	if pre_c > 0:
-		_log_info("[RTVCodegen]   pinned-tokenized (PCK .gdc, our static-init preload missed): %s" \
-				% ", ".join(Array(pre_c_names).slice(0, 25)))
+	# Dev-mode only: this pass exists purely for the summary log below (the
+	# activation loop re-derives everything it needs itself), and it costs a
+	# load() + method-list scan per wrapped script on EVERY launch.
+	if _developer_mode:
+		var pre_a := 0
+		var pre_b := 0
+		var pre_c := 0
+		var pre_d := 0
+		var pre_b_names: PackedStringArray = []
+		var pre_c_names: PackedStringArray = []
+		for fname: String in filenames:
+			if _scripts_with_scene_preloads.has(fname):
+				continue
+			var vp := fname
+			var c := load(vp) as GDScript
+			if c == null:
+				pre_d += 1
+				continue
+			var pre_rename := false
+			for m in c.get_script_method_list():
+				if str(m["name"]).begins_with("_rtv_vanilla_"):
+					pre_rename = true
+					break
+			var srclen: int = c.source_code.length()
+			if pre_rename:
+				pre_a += 1
+			elif srclen > 0:
+				pre_b += 1
+				pre_b_names.append(fname)
+			else:
+				pre_c += 1
+				pre_c_names.append(fname)
+		_log_debug("[RTVCodegen] PRE-ACTIVATE summary: inline-live=%d, pinned-with-source=%d, pinned-tokenized=%d, other=%d / total=%d" \
+				% [pre_a, pre_b, pre_c, pre_d, filenames.size()])
+		if pre_b > 0:
+			_log_debug("[RTVCodegen]   pinned-with-source (GDScriptCache has our text but compiled methods are vanilla): %s" \
+					% ", ".join(Array(pre_b_names).slice(0, 25)))
+		if pre_c > 0:
+			_log_debug("[RTVCodegen]   pinned-tokenized (PCK .gdc, our static-init preload missed): %s" \
+					% ", ".join(Array(pre_c_names).slice(0, 25)))
 
 	var activated := 0
 	var preactivated := 0
@@ -720,6 +1036,17 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 					_log_critical("[RTVCodegen] activate %s: fresh load returned null -- skip" % vp)
 					continue
 				fresh.take_over_path(vp)
+				# The non-stale fallback below verifies its fresh load carries
+				# the renames; this branch didn't, so a fresh load that
+				# compiled vanilla (VFS regression) passed silently. Same
+				# check, report-only -- take_over already happened either way.
+				var stale_fresh_ok := false
+				for m in fresh.get_script_method_list():
+					if str(m["name"]).begins_with("_rtv_vanilla_"):
+						stale_fresh_ok = true
+						break
+				if not stale_fresh_ok:
+					_log_critical("[RTVCodegen] activate %s: fresh load lacks _rtv_vanilla_ renames -- rewrite isn't compiling; hooks on this script will not fire" % vp)
 				activated += 1
 				continue
 			preactivated += 1
@@ -768,9 +1095,13 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 			fresh.take_over_path(vp)
 			_log_info("[RTVCodegen] activate %s: fresh script took over vanilla path" % vp)
 		activated += 1
-	var eager_total := filenames.size() - _scripts_with_scene_preloads.size()
+	# Count against the INTERSECTION of packed scripts and the deferral set
+	# (the `deferred` array built above), not the raw dict size: an entry in
+	# _scripts_with_scene_preloads that never made it into `filenames` would
+	# otherwise deflate the denominator and mask a real activation miss.
+	var eager_total := filenames.size() - deferred.size()
 	_log_info("[RTVCodegen] Activated %d/%d rewritten script(s) (%d already live from static-init preload; %d deferred to lazy-compile)" \
-			% [activated, eager_total, preactivated, _scripts_with_scene_preloads.size()])
+			% [activated, eager_total, preactivated, deferred.size()])
 
 	# Step D: persist hook pack path + wrapped-paths list to pass_state so
 	# the next session's _mount_previous_session() picks it up at static
@@ -873,17 +1204,17 @@ func _activate_rewritten_scripts(filenames: Array[String], pack_path: String) ->
 		if critical_set.has(String(f).get_file()):
 			critical_failures.append(f)
 	# Deferred scripts aren't counted against the total here -- they skipped
-	# compile-proof intentionally and will be verified via
-	# _verify_rewrite_active_after_override once lazy-compile fires.
-	var attempted := filenames.size() - _scripts_with_scene_preloads.size()
+	# compile-proof intentionally; the DEFER-VERIFY watchdog above checks
+	# them at 60s once lazy-compile has had a chance to fire.
+	var attempted := filenames.size() - deferred.size()
 	if compile_proof_ok == 0 and attempted > 0:
 		_log_critical("[STABILITY] ALL %d rewrites failed to take effect -- VFS mount, hook pack, or cache eviction is broken. Mods will NOT work this session. Click 'Reset to Vanilla' in the UI or create modloader_disabled in the game folder." % attempted)
 	elif critical_failures.size() > 0:
 		_log_critical("[STABILITY] Hook rewrites missing on critical scripts: %s. Hooks on these scripts will NOT fire this session (likely cache-pinning fallback failure)." % ", ".join(critical_failures))
 	else:
 		var deferred_tag := ""
-		if _scripts_with_scene_preloads.size() > 0:
-			deferred_tag = ", %d deferred to lazy-compile" % _scripts_with_scene_preloads.size()
+		if deferred.size() > 0:
+			deferred_tag = ", %d deferred to lazy-compile" % deferred.size()
 		_log_info("[STABILITY] COMPILE-PROOF summary: %d/%d rewrites active%s%s" \
 				% [compile_proof_ok, attempted,
 					(" (%d pinned-fallback)" % compile_proof_fail.size()) if compile_proof_fail.size() > 0 else "",

--- a/src/hook_pack.gd
+++ b/src/hook_pack.gd
@@ -208,8 +208,10 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	var needed_paths: Dictionary = {}
 	# Per-path per-method mask. Keyed by res_path -> Dictionary[method_name, true].
 	# Populated from _hooked_methods (static [hooks] section + scanned .hook()).
-	# Empty inner dict = all methods (fallback used only for REGISTRY_TARGETS
-	# where the wrap contract is whole-script, not per-method).
+	# Empty inner dict = wrap ALL methods. Two producers read identically:
+	# the user-facing "[hooks] <path> = *" wildcard sentinel (mod_loading.gd
+	# mints {} for it), and REGISTRY_TARGETS below, whose mask is ERASED so
+	# path_mask.get's {} default yields the same whole-script wrap.
 	var hook_mask: Dictionary = {}
 	for path: String in _hooked_methods:
 		# Normalize + validate the declared path. Reject anything outside
@@ -220,9 +222,10 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 		if not vanilla_path_set.has(path):
 			_log_warning("[RTVCodegen] [hooks] declared path '%s' doesn't match any vanilla script -- check for typos or stale paths; entry will no-op" % path)
-			# Still enroll it so the path_mask iteration below logs per-method
-			# "declared method not found" diagnostics against the empty set --
-			# no wrapper will be generated but the logging chain stays consistent.
+			# Still enroll it so the rewrite loop surfaces it a second time:
+			# detokenize fails for the nonexistent path and logs "Empty
+			# detokenized source -- skipped" (the per-method mask check is
+			# never reached for such a path). No wrapper is generated.
 		needed_paths[path] = true
 		hook_mask[path] = (_hooked_methods[path] as Dictionary).duplicate()
 	# Gate Database.gd on explicit [registry] opt-in. REGISTRY_TARGETS are
@@ -453,7 +456,10 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 		if zp.write_file(rewritten.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		# close_file flushes the entry; a deferred I/O error surfaces here,
+		# not in write_file -- unchecked, it would ship a truncated entry.
+		if zp.close_file() != OK:
+			pack_write_failed = true
 		# Self-referencing .gd.remap overrides the PCK's .gd.remap -> .gdc
 		# redirect. Godot's _path_remap reads this BEFORE GDScript loader.
 		var remap_entry := gd_entry + ".remap"
@@ -464,7 +470,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 		var remap_body := "[remap]\npath=\"%s\"\n" % script_path
 		if zp.write_file(remap_body.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 		# Empty .gdc to shadow the PCK's bytecode. Godot's GDScript loader
 		# prefers a sibling .gdc when present at the same base path -- even
 		# after our self-referencing remap redirects to .gd. A zero-byte
@@ -478,7 +485,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 		if zp.write_file(PackedByteArray()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 
 		script_count += 1
 		hook_count += hookable_count * 4  # pre/post/callback/replace per method
@@ -514,7 +522,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 			continue
 		if zp.write_file(fixed_src.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 		if changed:
 			sibling_fixed += 1
 			sibling_total_bodyless += int(af["bodyless"])
@@ -541,7 +550,8 @@ func _generate_hook_pack(defer_activation: bool = false) -> String:
 	if zp.start_file("__modloader_canary__.txt") == OK:
 		if zp.write_file(canary_content.to_utf8_buffer()) != OK:
 			pack_write_failed = true
-		zp.close_file()
+		if zp.close_file() != OK:
+			pack_write_failed = true
 	else:
 		pack_write_failed = true
 

--- a/src/hooks_api.gd
+++ b/src/hooks_api.gd
@@ -307,8 +307,10 @@ func _dispatch(hook_name: String, args: Array) -> void:
 # legacy mods keep running without log spam, but authors get a clear
 # nudge to update their signatures.
 #
-# Priority order matches _dispatch: ascending by `priority` field, ties
-# broken by registration order (Array iteration).
+# Priority order matches _dispatch: ascending by `priority` field. Ties are
+# NOT stable -- sort_custom is not a stable sort, so equal priorities may run
+# in any order. (The previous claim here, "ties broken by registration order",
+# was wrong; hook()'s own docstring and Hooks.md both state it correctly.)
 func _dispatch_post(hook_name: String, args: Array, current_result: Variant) -> Variant:
 	if not _hooks.has(hook_name):
 		return current_result

--- a/src/lifecycle.gd
+++ b/src/lifecycle.gd
@@ -187,6 +187,19 @@ func _run_pass_1() -> void:
 	if FileAccess.file_exists(PASS_STATE_PATH):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(PASS_STATE_PATH))
 		_restore_clean_override_cfg()
+	else:
+		# Pass state can be missing while override.cfg still carries stale mod
+		# [autoload_prepend] entries (e.g. a _write_pass_state save failure in
+		# a prior session, after override.cfg was already written). Gating the
+		# reset purely on pass state would leave Godot trying to load those
+		# mod autoloads on every future launch with all mods disabled. Compare
+		# against the clean baseline so the common no-mods launch does not
+		# rewrite the file every time.
+		var cfg_path := OS.get_executable_path().get_base_dir().path_join("override.cfg")
+		if FileAccess.file_exists(cfg_path):
+			var cur := FileAccess.get_file_as_string(cfg_path)
+			if cur != _clean_override_cfg_content(_read_preserved_cfg_sections(cfg_path)):
+				_restore_clean_override_cfg()
 	if DirAccess.dir_exists_absolute(ProjectSettings.globalize_path(HOOK_PACK_DIR)):
 		_static_wipe_hook_cache()
 		_log_info("[Hooks] Cleaned up unused hook artifacts")
@@ -211,6 +224,12 @@ func _finish_with_existing_mounts() -> void:
 		_write_conflict_report()
 	_emit_frameworks_ready()
 	_delete_heartbeat()
+	# This session came up fine without a restart -- clear any restart_count
+	# left over from a previously crashed restart cycle (only Pass 2 cleared
+	# it before). A stale count of 1 would otherwise survive every hash-match
+	# session, and the next legitimate restart cycle's single crash would put
+	# the counter at MAX_RESTART_COUNT and trip the breaker one crash early.
+	_clear_restart_counter()
 	if not _filescope_mounted.is_empty() or not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var err := get_tree().reload_current_scene()
 		if err != OK:
@@ -229,6 +248,10 @@ func _finish_single_pass() -> void:
 		_write_conflict_report()
 	_emit_frameworks_ready()
 	_delete_heartbeat()
+	# Same rationale as _finish_with_existing_mounts: session finished, so a
+	# leftover restart_count from a crashed cycle is stale. No-op when pass
+	# state was already deleted (_clear_restart_counter skips a missing file).
+	_clear_restart_counter()
 	if not _archive_file_sets.is_empty() or _pending_autoloads.size() > 0:
 		var err := get_tree().reload_current_scene()
 		if err != OK:

--- a/src/main_menu_hook.gd
+++ b/src/main_menu_hook.gd
@@ -50,7 +50,7 @@ func _on_menu_ready() -> void:
 func _inject_mods_button(menu_root: Node) -> void:
 	var buttons := menu_root.get_node_or_null("Main/Buttons")
 	if buttons == null:
-		_log_warning("[ModLoader] Main menu has no Main/Buttons container skipping Mods button injection")
+		_log_warning("[ModLoader] Main menu has no Main/Buttons container -- skipping Mods button injection")
 		return
 	if buttons.get_node_or_null(_MODS_BUTTON_NAME) != null:
 		return

--- a/src/mod_discovery.gd
+++ b/src/mod_discovery.gd
@@ -92,6 +92,9 @@ func _build_archive_entry(mods_dir: String, file_name: String, ext: String) -> D
 	if ext == "pck":
 		_last_mod_txt_status = "pck"
 		_last_mod_txt_files.clear()  # no read_mod_config call to reset it
+		# Same reason: without a read_mod_config call the PREVIOUS mod's
+		# parse-error detail would leak onto this entry's mod_txt_error.
+		_last_mod_txt_error = ""
 	var cfg: ConfigFile = read_mod_config(full_path) if ext != "pck" else null
 	var entry := _entry_from_config(cfg, file_name, full_path, ext)
 	entry["warnings"] = _build_entry_warnings(entry)
@@ -1124,6 +1127,13 @@ func _extract_disposition_param(header_value: String, param: String) -> String:
 func _is_safe_mod_filename(name: String) -> bool:
 	if name.is_empty():
 		return false
+	# get_file() only splits on "/", so a Windows-style "..\evil.zip" passes
+	# the basename check below yet escapes the mods dir when the OS resolves
+	# the backslash. Reject both separators and drive/ADS colons outright,
+	# plus dot-prefixed names ("..zip" and friends are traversal-shaped and
+	# never legitimate mod filenames).
+	if "\\" in name or "/" in name or ":" in name or name.begins_with("."):
+		return false
 	if name != name.get_file():
 		return false
 	return name.get_extension().to_lower() in ["vmz", "zip", "pck"]
@@ -1139,6 +1149,12 @@ func _derive_updated_filename(old_file_name: String, headers: PackedStringArray,
 	if server_name != "":
 		return server_name
 	if new_version.is_empty():
+		return old_file_name
+	# new_version comes from the downloaded archive's own mod.txt -- untrusted.
+	# Spliced into a rename target, a version containing separators ("..\x")
+	# would land the archive outside the mods dir. Renaming is best-effort and
+	# must never block the update, so just keep the old filename.
+	if not new_version.lstrip("vV").is_valid_filename():
 		return old_file_name
 	var ext := old_file_name.get_extension()
 	var stem := old_file_name.get_basename()
@@ -1415,6 +1431,12 @@ func download_new_mod(modworkshop_id: int, version: String = "", allow_rename_on
 			failure["error"] = "Already have a file named " + derived_name
 			return failure
 		var meta_version := str((file_meta as Dictionary).get("version", "")).strip_edges().lstrip("vV")
+		# Server-controlled string headed into an on-disk filename: a version
+		# like "..\x" would traverse out of the mods dir on Windows, and a JSON
+		# null stringifies to "<null>". is_valid_filename() rejects the whole
+		# : / \ ? * " | % < > class; fall through to the mod-id suffix instead.
+		if not meta_version.is_empty() and not meta_version.is_valid_filename():
+			meta_version = ""
 		if meta_version.is_empty():
 			# Last-ditch: append the mod ID so we can at least install
 			# something distinguishable. Better than dropping the apply.

--- a/src/mod_loading.gd
+++ b/src/mod_loading.gd
@@ -4,6 +4,16 @@
 ## [script_overrides] from mod.txt. Runs after mod_discovery has built the
 ## ordered list.
 
+# Attribution side-channel for the hook reconciliation in hook_pack.gd:
+# res_path -> Dictionary[mod_name, true] for every mod that declared a hook
+# on that path (via [hooks] or a scanned .hook() call). _hooked_methods
+# cannot carry this itself -- its inner dict IS the per-method wrap mask and
+# an empty dict is the wildcard sentinel, so the shape can't be extended.
+# Purely diagnostic: never read for wrap decisions. Entries added by
+# hooks_api.add_hook() are not attributed (runtime callers) and report as
+# such in the reconciliation.
+var _hook_declared_by: Dictionary = {}
+
 func load_all_mods(pass_label: String = "") -> void:
 	_pending_autoloads.clear()
 	_loaded_mod_ids.clear()
@@ -18,6 +28,7 @@ func load_all_mods(pass_label: String = "") -> void:
 	_pending_script_overrides.clear()
 	_applied_script_overrides.clear()
 	_hooked_methods.clear()
+	_hook_declared_by.clear()
 	_any_mod_declared_registry = false
 
 	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(TMP_DIR))
@@ -44,6 +55,24 @@ func load_all_mods(pass_label: String = "") -> void:
 					+ "' -- archives '" + candidates[i - 1]["file_name"]
 					+ "' and '" + candidates[i]["file_name"]
 					+ "'. Load order tie broken by archive filename.")
+
+	# Account for every mod found on disk, and name the active profile.
+	#
+	# Without this the log jumps straight from "Found 9 mod(s)" to a two-entry
+	# load order with nothing explaining the other seven. That gap cost a full
+	# triage session once already: the answer turned out to be an inactive test
+	# profile in which the mod under investigation was simply disabled, which
+	# no log line anywhere would have revealed. Disabled mods are a normal,
+	# silent state -- so state it.
+	var found_total: int = _ui_mod_entries.size()
+	var enabled_total: int = int(pick["enabled_count"])
+	var loading_total: int = candidates.size()
+	var blocked_total: int = enabled_total - loading_total
+	var accounting := "Found %d mod(s) -- %d enabled, %d loading" % [found_total, enabled_total, loading_total]
+	if blocked_total > 0:
+		accounting += ", %d blocked by dependencies" % blocked_total
+	accounting += ", %d disabled (profile \"%s\")" % [maxi(0, found_total - enabled_total), _active_profile]
+	_log_info(accounting)
 
 	var header := "=== Load Order" + (" (" + pass_label + ")" if pass_label != "" else "") + " ==="
 	_log_info(header)
@@ -79,8 +108,23 @@ func _merge_hook_calls_into_wrap_mask() -> void:
 		var key := sp.get_file().get_basename().to_lower()
 		if not prefix_to_path.has(key):
 			prefix_to_path[key] = sp
+	# Root-cause guard: when BOTH enumeration sources are empty (PCK parse
+	# failed AND no class_name lookup), no prefix can ever resolve. Without
+	# this, every scanned .hook() call below fires its own misleading
+	# "check spelling" warning; the truth is the loader couldn't enumerate
+	# the game's scripts at all, so say that ONCE and stop.
+	if prefix_to_path.is_empty():
+		var any_hook_calls := false
+		for mod_name: String in _mod_script_analysis:
+			if not ((_mod_script_analysis[mod_name] as Dictionary).get("hook_calls", []) as Array).is_empty():
+				any_hook_calls = true
+				break
+		if any_hook_calls:
+			_log_critical("[Hooks] Game script enumeration is empty -- no .hook() call can be resolved to a vanilla script, so ALL scanned hooks are dropped this session (PCK parse failed or game layout changed). This is a loader/game problem, not a mod problem.")
+		return
 	for mod_name: String in _mod_script_analysis:
 		var analysis: Dictionary = _mod_script_analysis[mod_name]
+		var resolved_count := 0
 		for entry: Dictionary in (analysis.get("hook_calls", []) as Array):
 			var prefix: String = entry["prefix"]
 			var method: String = entry["method"]
@@ -94,6 +138,11 @@ func _merge_hook_calls_into_wrap_mask() -> void:
 						% [mod_name, prefix, method, prefix])
 				continue
 			var path: String = prefix_to_path[prefix]
+			# Attribution for the reconciliation report (diagnostic only).
+			if not _hook_declared_by.has(path):
+				_hook_declared_by[path] = {}
+			(_hook_declared_by[path] as Dictionary)[mod_name] = true
+			resolved_count += 1
 			# Mask keys lowercase (hook_pack.gd compares fe["name"].to_lower()).
 			# Hook names are lowercase by convention but mods occasionally
 			# write mixed case like .hook("Interface-UpdateToolTip-pre", ...);
@@ -110,6 +159,8 @@ func _merge_hook_calls_into_wrap_mask() -> void:
 			if mask.is_empty():
 				continue
 			mask[method.to_lower()] = true
+		if resolved_count > 0:
+			_log_debug("[Hooks] %d scanned .hook() call(s) resolved to vanilla scripts [%s]" % [resolved_count, mod_name])
 
 # One mod, one call: mount its archive, scan + register file claims, then
 # apply its mod.txt sections. SEAM: mod.txt section handlers are the
@@ -217,6 +268,12 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 	# method. Method names are lowercased on write because hook_pack.gd
 	# compares vanilla fn names via .to_lower() against the mask.
 	if cfg != null and cfg.has_section("hooks"):
+		# Per-mod tallies for the ONE summary line below. The per-method /
+		# per-path detail is developer-only (_log_debug): a real mod declares
+		# hundreds of hook points and per-line INFO buried the whole log.
+		var hooks_scripts_declared := 0
+		var hooks_methods_declared := 0
+		var hooks_wildcards := 0
 		for key in cfg.get_section_keys("hooks"):
 			var script_path := str(key).strip_edges()
 			var methods_str := str(cfg.get_value("hooks", key, "")).strip_edges()
@@ -254,28 +311,42 @@ func _process_mod_candidate(c: Dictionary, load_index: int) -> void:
 					_hooked_methods.erase(script_path)
 				_log_warning("  [hooks] %s has no valid method names ('%s') -- entry ignored [%s]" % [script_path, methods_str, mod_name])
 				continue
+			# Valid entry -- record attribution for the reconciliation report
+			# so a lost hook target can name the mod that declared it.
+			if not _hook_declared_by.has(script_path):
+				_hook_declared_by[script_path] = {}
+			(_hook_declared_by[script_path] as Dictionary)[mod_name] = true
+			hooks_scripts_declared += 1
 			if has_wildcard:
+				hooks_wildcards += 1
 				if not specific_methods.is_empty():
 					_log_warning("  [hooks] %s mixes '*' with specific methods (%s); '*' wins, all methods wrapped [%s]" \
 							% [script_path, ", ".join(specific_methods), mod_name])
 				else:
-					_log_info("  Hooks declared: %s :: * (all methods) [%s]" % [script_path, mod_name])
+					_log_debug("  Hooks declared: %s :: * (all methods) [%s]" % [script_path, mod_name])
 				# "*" wins across mods too: drop any methods earlier mods
 				# listed for this path so the empty wrap-all sentinel applies.
 				# Wrap-all is a superset, so those methods stay wrapped.
 				if not script_mask.is_empty():
-					_log_info("  Hooks: '*' widens earlier method list for %s -- all methods wrapped" % script_path)
+					# Cross-mod interaction worth one user-visible line: this
+					# mod's wildcard supersedes another mod's method list.
+					_log_info("  Hooks: '*' from %s widens the earlier method list for %s -- all methods wrapped" % [mod_name, script_path])
 					script_mask.clear()
 				# Leave the inner dict empty; hook_pack.gd treats that as wrap-all.
 				continue
+			hooks_methods_declared += specific_methods.size()
 			if wildcard_already:
 				if not specific_methods.is_empty():
-					_log_info("  Hooks declared: %s :: %s [%s] -- already covered by an earlier wildcard (*), all methods wrapped" \
+					_log_debug("  Hooks declared: %s :: %s [%s] -- already covered by an earlier wildcard (*), all methods wrapped" \
 							% [script_path, ", ".join(specific_methods), mod_name])
 				continue
 			for method_name in specific_methods:
 				script_mask[method_name.to_lower()] = true
-				_log_info("  Hook declared: %s :: %s [%s]" % [script_path, method_name, mod_name])
+				_log_debug("  Hook declared: %s :: %s [%s]" % [script_path, method_name, mod_name])
+		if hooks_scripts_declared > 0:
+			var wc_tag := (", %d wildcard (all methods)" % hooks_wildcards) if hooks_wildcards > 0 else ""
+			_log_info("  Hooks: %d method(s) across %d script(s)%s [%s]" \
+					% [hooks_methods_declared, hooks_scripts_declared, wc_tag, mod_name])
 
 	# [registry] opt-in (v3.0.1). Gates Database.gd wrapping + const-to-dict
 	# transform on explicit mod declaration. Without this, Database.gd stays

--- a/src/modpacks.gd
+++ b/src/modpacks.gd
@@ -1082,7 +1082,10 @@ func _apply_modpack_inner(entry: Dictionary, tabs: TabContainer, progress: Calla
 		# nothing. Abort before mutating anything.
 		var cfg_err := cfg.load(UI_CONFIG_PATH)
 		if cfg_err != OK and cfg_err != ERR_FILE_NOT_FOUND:
-			return {"ok": false, "error": "Cannot read your mod settings file (mod_config.cfg, error %d) -- nothing was changed. Restart the game and try again." % cfg_err}
+			# NOT "nothing was changed": the download phase runs before this
+			# guard, so mod files may already have landed in /mods/ (additive,
+			# harmless). Only profiles/settings are untouched.
+			return {"ok": false, "error": "Cannot read your mod settings file (mod_config.cfg, error %d) -- the modpack was not applied and your profiles are unchanged. Any downloaded mods remain in your mods folder. Restart the game and try again." % cfg_err}
 
 		var src_en := _profile_sec(pre_active, ".enabled")
 		var src_pr := _profile_sec(pre_active, ".priority")
@@ -1242,7 +1245,13 @@ func _materialize_modpack_profile(entry: Dictionary, profile_name: String) -> Di
 # re-applying picks up where they left off.
 func unload_modpack(tabs: TabContainer) -> Dictionary:
 	var cfg := ConfigFile.new()
-	cfg.load(UI_CONFIG_PATH)
+	# A hard read failure leaves cfg EMPTY, which the check below would
+	# misreport as "No modpack is active" -- false and confusing when the
+	# banner clearly shows one. (The empty cfg cannot reach the persist:
+	# active == "" aborts first. This guard exists for the honest message.)
+	var cfg_err := cfg.load(UI_CONFIG_PATH)
+	if cfg_err != OK and cfg_err != ERR_FILE_NOT_FOUND:
+		return {"ok": false, "error": "Cannot read your mod settings file (mod_config.cfg, error %d) -- nothing was unloaded. Restart the game and try again." % cfg_err}
 	var active := str(cfg.get_value("settings", "active_modpack", ""))
 	if active == "":
 		return {"ok": false, "error": "No modpack is active"}

--- a/src/modpacks.gd
+++ b/src/modpacks.gd
@@ -121,11 +121,14 @@ func _is_modpack_managed_profile(profile_name: String) -> bool:
 			or profile_name.begins_with(MODPACK_BACKUP_PREFIX)
 
 # Count the truthy values in a dictionary -- used to tally how many mods a
-# modpack's `enabled` map turns on.
+# modpack's `enabled` map turns on. Values come from third-party profile.json,
+# so type-check before coercing: bool(null) is a runtime constructor error in
+# Godot 4, and a hand-edited pack can carry null/String values.
 func _count_truthy(d: Dictionary) -> int:
 	var count := 0
 	for k in d.keys():
-		if bool(d[k]):
+		var v = d[k]
+		if (v is bool and v) or ((v is int or v is float) and v != 0):
 			count += 1
 	return count
 
@@ -174,7 +177,11 @@ func _validate_modpack(entry: Dictionary) -> Dictionary:
 	if not (parsed_v is Dictionary):
 		return {"ok": false, "error": "This modpack file is damaged (its mod list is unreadable). Get a fresh copy and try again."}
 	var pd: Dictionary = parsed_v
-	if int(pd.get("metroprofile", 0)) != 1:
+	# Type-check before int(): the key can be present-but-null (or a String)
+	# in a hand-edited pack, and int(null) is a runtime constructor error.
+	var mp_raw = pd.get("metroprofile", 0)
+	var mp_ver: int = int(mp_raw) if (mp_raw is int or mp_raw is float) else 0
+	if mp_ver != 1:
 		return {"ok": false, "error": "This modpack was made for a newer version of the mod loader -- update the mod loader and try again"}
 	if not (pd.get("name") is String):
 		return {"ok": false, "error": "This modpack file is damaged (it has no name). Get a fresh copy and try again."}
@@ -399,13 +406,24 @@ func _apply_modpack_overrides(entry: Dictionary, backup_profile: String) -> int:
 
 	reader.close()
 
-	# Persist the manifest. Unload reads this to know what to revert.
+	# Persist the manifest. Unload reads this to know what to revert. A failed
+	# write is LOUD: without a fresh manifest, unload either restores per a
+	# stale manifest from an earlier apply (wrong files) or treats the apply as
+	# "nothing overridden" and wipes the backup slot with the snapshots inside
+	# -- both lose the user's originals. The pre-apply restore point still
+	# covers recovery, so we warn rather than abort.
 	DirAccess.make_dir_recursive_absolute(backup_root)
 	var manifest_path := backup_root.path_join("overrides_manifest.json")
 	var mf := FileAccess.open(manifest_path, FileAccess.WRITE)
 	if mf != null:
-		mf.store_string(JSON.stringify(manifest, "  "))
+		if not mf.store_string(JSON.stringify(manifest, "  ")):
+			_log_warning("[Modpack] FAILED writing overrides manifest " + manifest_path
+					+ " (disk full?) -- Unload may not restore overridden files; use the Restore button if needed")
 		mf.close()
+	else:
+		_log_warning("[Modpack] could NOT write overrides manifest " + manifest_path
+				+ " -- Unload will not restore the " + str(applied)
+				+ " override file(s) just applied; use the Restore button if needed")
 
 	return applied
 
@@ -824,7 +842,10 @@ func _get_missing_mods_for_modpack(entry: Dictionary) -> Array:
 			if installed_id_ver.has(src_id_l + "@" + src_ver):
 				continue
 		var src_data: Dictionary = sources.get(src_key, {}) if sources.get(src_key) is Dictionary else {}
-		var mws_id := int(src_data.get("modworkshop_id", 0))
+		# JSON numbers arrive as float; a hand-edited pack can carry null.
+		# int(null) is a runtime constructor error, so type-check first.
+		var mws_raw = src_data.get("modworkshop_id", 0)
+		var mws_id: int = int(mws_raw) if (mws_raw is int or mws_raw is float) else 0
 		# Version is OPTIONAL and only used when explicit. Earlier revision
 		# fell back to parsing the suffix off the profile_key, but that
 		# silently turned legacy modpacks (which only have modworkshop_id
@@ -832,7 +853,10 @@ func _get_missing_mods_for_modpack(entry: Dictionary) -> Array:
 		# versions that have since been replaced upstream -- mass failures.
 		# Now: only honor the version when the modpack author chose to
 		# include it (modloader-produced modpacks do; legacy ones don't).
-		var version := str(src_data.get("version", ""))
+		# Present-but-null (or non-String) degrades to "" = primary download,
+		# not a bogus "<null>" pin.
+		var ver_raw = src_data.get("version", "")
+		var version: String = str(ver_raw) if ver_raw is String else ""
 		# Cache the source so a missing-mod stub on this profile (or a
 		# future profile referencing the same key) can offer Download
 		# without re-reading the modpack zip.
@@ -1052,7 +1076,13 @@ func _apply_modpack_inner(entry: Dictionary, tabs: TabContainer, progress: Calla
 		# unload, but we capture the current name explicitly for restore_to.
 		var pre_active := _active_profile
 		var cfg := ConfigFile.new()
-		cfg.load(UI_CONFIG_PATH)
+		# A missing file is fine (fresh install; the persist below creates it),
+		# but any other load failure means we'd be working from an EMPTY cfg --
+		# the persist below would then replace every profile the user has with
+		# nothing. Abort before mutating anything.
+		var cfg_err := cfg.load(UI_CONFIG_PATH)
+		if cfg_err != OK and cfg_err != ERR_FILE_NOT_FOUND:
+			return {"ok": false, "error": "Cannot read your mod settings file (mod_config.cfg, error %d) -- nothing was changed. Restart the game and try again." % cfg_err}
 
 		var src_en := _profile_sec(pre_active, ".enabled")
 		var src_pr := _profile_sec(pre_active, ".priority")
@@ -1103,10 +1133,17 @@ func _apply_modpack_inner(entry: Dictionary, tabs: TabContainer, progress: Calla
 		_switch_profile(modpack_profile)
 
 		# 5. Mark active in cfg (after switch, since _switch_profile rewrites
-		# active_profile in cfg too).
-		cfg.load(UI_CONFIG_PATH)
-		cfg.set_value("settings", "active_modpack", sanitized)
-		_persist_ui_cfg(cfg)
+		# active_profile in cfg too). Re-assert only when the reload succeeded:
+		# persisting after a failed load would write a cfg containing ONLY the
+		# active_modpack flag, destroying every profile. The flag is already on
+		# disk from step 1 (and preserved by the step-4 switch), so skipping the
+		# re-assert on a transient read failure is safe.
+		var cfg5_err := cfg.load(UI_CONFIG_PATH)
+		if cfg5_err == OK:
+			cfg.set_value("settings", "active_modpack", sanitized)
+			_persist_ui_cfg(cfg)
+		else:
+			_log_warning("[Modpack] could not re-read mod_config.cfg after profile switch (error %d) -- skipping the active-flag re-assert (already set at step 1)" % cfg5_err)
 
 	# 6. Refresh the Mods tab so the modpack's selection + banner show
 	# (or, in the re-apply path, so any newly-downloaded mods appear).
@@ -1142,7 +1179,13 @@ func _materialize_modpack_profile(entry: Dictionary, profile_name: String) -> Di
 	var pd: Dictionary = parsed_v
 
 	var cfg := ConfigFile.new()
-	cfg.load(UI_CONFIG_PATH)
+	# Same guard as apply step 1: a hard read failure would leave cfg empty and
+	# the persist below would replace the user's whole config with just this
+	# modpack's sections. Missing file is fine (persist creates it).
+	var cfg_err := cfg.load(UI_CONFIG_PATH)
+	if cfg_err != OK and cfg_err != ERR_FILE_NOT_FOUND:
+		reader.close()
+		return {"ok": false, "error": "Cannot read your mod settings file (mod_config.cfg, error %d) -- modpack profile not created. Restart the game and try again." % cfg_err}
 	var en_sec := _profile_sec(profile_name, ".enabled")
 	var pr_sec := _profile_sec(profile_name, ".priority")
 	if cfg.has_section(en_sec):
@@ -1150,12 +1193,19 @@ func _materialize_modpack_profile(entry: Dictionary, profile_name: String) -> Di
 	if cfg.has_section(pr_sec):
 		cfg.erase_section(pr_sec)
 
+	# Values come from third-party profile.json: type-check before bool()/int()
+	# -- both are runtime constructor errors on a present-but-null value, and a
+	# crash HERE is mid-MUTATING (flag set, profile half-written). Junk values
+	# degrade to disabled / default priority instead of aborting the apply.
 	var enabled_dict: Dictionary = pd.get("enabled", {}) if pd.get("enabled") is Dictionary else {}
 	for k in enabled_dict.keys():
-		cfg.set_value(en_sec, str(k), bool(enabled_dict[k]))
+		var ev = enabled_dict[k]
+		var en_on: bool = (ev is bool and ev) or ((ev is int or ev is float) and ev != 0)
+		cfg.set_value(en_sec, str(k), en_on)
 	var priority_dict: Dictionary = pd.get("priority", {}) if pd.get("priority") is Dictionary else {}
 	for k in priority_dict.keys():
-		var pv := int(priority_dict[k])
+		var pv_raw = priority_dict[k]
+		var pv: int = int(pv_raw) if (pv_raw is int or pv_raw is float) else 0
 		cfg.set_value(pr_sec, str(k), clampi(pv, PRIORITY_MIN, PRIORITY_MAX))
 	# dep_ignore ("Load anyway") overrides travel with the pack (the export
 	# writes them into profile.json); materialize them like the profile-import
@@ -1166,7 +1216,9 @@ func _materialize_modpack_profile(entry: Dictionary, profile_name: String) -> Di
 		cfg.erase_section(ig_sec)
 	var dep_ignore_dict: Dictionary = pd.get("dep_ignore", {}) if pd.get("dep_ignore") is Dictionary else {}
 	for k in dep_ignore_dict.keys():
-		if bool(dep_ignore_dict[k]):
+		# Same present-but-null guard as the enabled/priority loops above.
+		var iv = dep_ignore_dict[k]
+		if (iv is bool and iv) or ((iv is int or iv is float) and iv != 0):
 			cfg.set_value(ig_sec, str(k), true)
 	_persist_ui_cfg(cfg)
 
@@ -1281,6 +1333,12 @@ func unload_modpack(tabs: TabContainer) -> Dictionary:
 # {downloaded, failures, cancelled} where failures has the same shape as
 # apply's (still-failed items only).
 func retry_failed_downloads(failures: Array, progress: Callable = Callable()) -> Dictionary:
+	# Same serialization guard as apply_modpack: retry awaits downloads too,
+	# so without it a concurrent Apply click would race on download_new_mod
+	# and the _ui_mod_entries re-scan.
+	if _modpack_apply_in_progress:
+		return {"downloaded": 0, "failures": failures, "cancelled": false}
+	_modpack_apply_in_progress = true
 	var still_failed: Array = []
 	var newly_downloaded: int = 0
 	for i in range(failures.size()):
@@ -1326,6 +1384,7 @@ func retry_failed_downloads(failures: Array, progress: Callable = Callable()) ->
 		var cfg := ConfigFile.new()
 		cfg.load(UI_CONFIG_PATH)
 		_apply_profile_to_entries(cfg, _active_profile)
+	_modpack_apply_in_progress = false
 	return {"downloaded": newly_downloaded, "failures": still_failed, "cancelled": _modpack_apply_cancelled}
 
 

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -108,6 +108,17 @@ func _enumerate_game_scripts() -> Array[String]:
 	# call free without forcing the caller to track lookup state.
 	if not _all_game_script_paths.is_empty():
 		return _all_game_script_paths
+	# Disk cache. The in-memory memo above only survives the session, so
+	# without this EVERY launch re-parses the PCK's 17k-entry directory --
+	# including the "mod state unchanged" fast path, which otherwise does
+	# almost no work. The result is a list of ~176 paths that can only change
+	# when the game itself changes, so stamp it with the exe's mtime (the same
+	# key boot.gd uses to invalidate hook artifacts) and skip the parse.
+	var cached := _load_script_index_cache()
+	if not cached.is_empty():
+		_all_game_script_paths = cached
+		_log_debug("[RTVCodegen] script index: %d path(s) from cache (PCK parse skipped)" % cached.size())
+		return _all_game_script_paths
 	var exe_dir := OS.get_executable_path().get_base_dir()
 	var candidates := ["RTV.pck", OS.get_executable_path().get_file().get_basename() + ".pck"]
 	for cand in candidates:
@@ -118,6 +129,10 @@ func _enumerate_game_scripts() -> Array[String]:
 		if paths.is_empty():
 			continue
 		var scripts: Array[String] = []
+		# Membership via Dictionary, not `in scripts`. The array form is a
+		# linear scan per candidate, so de-duplicating N script paths out of a
+		# 17k-entry directory was quadratic in the number of scripts.
+		var seen: Dictionary = {}
 		for p in paths:
 			# Packed paths lack the res:// prefix; Godot adds it on load.
 			var normalized := p
@@ -131,13 +146,63 @@ func _enumerate_game_scripts() -> Array[String]:
 				canonical = canonical.substr(0, canonical.length() - 6)
 			if canonical.ends_with(".gdc"):
 				canonical = canonical.substr(0, canonical.length() - 4) + ".gd"
-			if canonical.ends_with(".gd") and canonical not in scripts:
+			if canonical.ends_with(".gd") and not seen.has(canonical):
+				seen[canonical] = true
 				scripts.append(canonical)
 		_log_info("[RTVCodegen] parsed %s -- %d total file(s), %d .gd script(s) under res://Scripts/" \
 				% [cand, paths.size(), scripts.size()])
 		_all_game_script_paths = scripts
+		_save_script_index_cache(scripts)
 		return scripts
 	return []
+
+# Script-index disk cache: "<exe mtime>\n<path>\n<path>..." .
+#
+# Stamped with the game executable's mtime so a game update invalidates it
+# automatically -- the same key boot.gd checks to wipe hook artifacts. A
+# mismatched, missing or unreadable stamp simply falls through to a fresh PCK
+# parse, so the cache can never serve a stale script list; the worst case is
+# the cost we were paying before.
+const _SCRIPT_INDEX_CACHE := "user://modloader_hooks/script_index.txt"
+
+func _script_index_stamp() -> String:
+	return str(FileAccess.get_modified_time(OS.get_executable_path()))
+
+func _load_script_index_cache() -> Array[String]:
+	var empty: Array[String] = []
+	var f := FileAccess.open(_SCRIPT_INDEX_CACHE, FileAccess.READ)
+	if f == null:
+		return empty
+	var text := f.get_as_text()
+	f.close()
+	var lines := text.split("\n", false)
+	if lines.size() < 2 or lines[0].strip_edges() != _script_index_stamp():
+		return empty
+	var out: Array[String] = []
+	for i in range(1, lines.size()):
+		var p := lines[i].strip_edges()
+		# Only ever hand back paths of the shape the parser itself produces --
+		# a hand-edited or truncated cache must not widen the wrap surface.
+		if p.begins_with("res://Scripts/") and p.ends_with(".gd"):
+			out.append(p)
+	return out
+
+func _save_script_index_cache(scripts: Array[String]) -> void:
+	DirAccess.make_dir_recursive_absolute(
+		ProjectSettings.globalize_path(_SCRIPT_INDEX_CACHE.get_base_dir()))
+	# Write-then-rename: a truncated index would silently shrink the wrap
+	# surface on the next launch, and every stamp check would still pass.
+	var tmp := _SCRIPT_INDEX_CACHE + ".tmp"
+	var f := FileAccess.open(tmp, FileAccess.WRITE)
+	if f == null:
+		return
+	var wrote := f.store_string(_script_index_stamp() + "\n" + "\n".join(scripts))
+	var werr := f.get_error()
+	f.close()
+	if not wrote or werr != OK:
+		DirAccess.remove_absolute(tmp)
+		return
+	DirAccess.rename_absolute(tmp, _SCRIPT_INDEX_CACHE)
 
 # Collect module-scope `preload("...tscn|scn")` paths from source. Module-scope
 # = line starts at column 0 (no leading whitespace). Such preloads fire at

--- a/src/pck_enumeration.gd
+++ b/src/pck_enumeration.gd
@@ -156,7 +156,11 @@ func _enumerate_game_scripts() -> Array[String]:
 		return scripts
 	return []
 
-# Script-index disk cache: "<exe mtime>\n<path>\n<path>..." .
+# Script-index disk cache: "<exe mtime>\n<path>\n<path>..." . Lines prefixed
+# "!" carry the PCK's zero-byte .gd entries (the _pck_zero_byte_paths side
+# channel _parse_pck_file_list normally populates) -- a cache hit skips that
+# parse, so the cache must restore the side channel too or downstream
+# detokenize/hook-gen misdiagnose zero-byte scripts as "game build mismatch".
 #
 # Stamped with the game executable's mtime so a game update invalidates it
 # automatically -- the same key boot.gd checks to wipe hook artifacts. A
@@ -181,6 +185,15 @@ func _load_script_index_cache() -> Array[String]:
 	var out: Array[String] = []
 	for i in range(1, lines.size()):
 		var p := lines[i].strip_edges()
+		# Zero-byte side channel ("!"-prefixed): restore into
+		# _pck_zero_byte_paths instead of the script list. Same shape filter
+		# as the plain lines (minus the Scripts/ restriction -- the parser
+		# records zero-byte .gd entries anywhere in the PCK).
+		if p.begins_with("!"):
+			var zb := p.substr(1)
+			if zb.begins_with("res://") and zb.ends_with(".gd"):
+				_pck_zero_byte_paths[zb] = true
+			continue
 		# Only ever hand back paths of the shape the parser itself produces --
 		# a hand-edited or truncated cache must not widen the wrap surface.
 		if p.begins_with("res://Scripts/") and p.ends_with(".gd"):
@@ -196,7 +209,13 @@ func _save_script_index_cache(scripts: Array[String]) -> void:
 	var f := FileAccess.open(tmp, FileAccess.WRITE)
 	if f == null:
 		return
-	var wrote := f.store_string(_script_index_stamp() + "\n" + "\n".join(scripts))
+	var body := _script_index_stamp() + "\n" + "\n".join(scripts)
+	# Persist the zero-byte side channel so a cache hit restores it (see the
+	# format comment above). Populated by the _parse_pck_file_list call that
+	# immediately precedes every save, so it reflects THIS parse.
+	for zb: String in _pck_zero_byte_paths:
+		body += "\n!" + zb
+	var wrote := f.store_string(body)
 	var werr := f.get_error()
 	f.close()
 	if not wrote or werr != OK:

--- a/src/registry.gd
+++ b/src/registry.gd
@@ -152,7 +152,9 @@ func _register_aggregator_batch(kind: String, entries: Dictionary) -> Dictionary
 	var results: Dictionary = {}
 	var all_ok := true
 	for id in entries.keys():
-		var sid := String(id)
+		# str(), not String(): a non-String key must not abort the batch (see
+		# remove_many).
+		var sid := str(id)
 		var per: Dictionary
 		match kind:
 			"item":       per = _register_item_bundle(sid, entries[id])
@@ -620,7 +622,10 @@ func register_many(registry: String, entries: Dictionary) -> Dictionary:
 	var results: Dictionary = {}
 	var all_ok := true
 	for id in entries.keys():
-		var ok: bool = register(registry, id, entries[id])
+		# register() takes a String id; a non-String dict key would be a
+		# runtime argument-type error that aborts the batch mid-way (entries
+		# before it committed, the rest never ran). str() isolates it instead.
+		var ok: bool = register(registry, str(id), entries[id])
 		results[id] = ok
 		if not ok:
 			all_ok = false
@@ -632,7 +637,8 @@ func override_many(registry: String, entries: Dictionary) -> Dictionary:
 	var results: Dictionary = {}
 	var all_ok := true
 	for id in entries.keys():
-		var ok: bool = override(registry, id, entries[id])
+		# str(): same batch-abort guard as register_many.
+		var ok: bool = override(registry, str(id), entries[id])
 		results[id] = ok
 		if not ok:
 			all_ok = false
@@ -720,7 +726,10 @@ func remove_many(registry: String, ids: Array) -> Dictionary:
 	var results: Dictionary = {}
 	var all_ok := true
 	for id in ids:
-		var sid := String(id)
+		# str(), not String(): String() is the non-converting constructor and a
+		# non-String id (typo'd int) would be a runtime error that aborts the
+		# batch mid-way -- entries before it committed, the rest never ran.
+		var sid := str(id)
 		var ok: bool = remove(registry, sid)
 		results[sid] = ok
 		if not ok:

--- a/src/registry/inputs.gd
+++ b/src/registry/inputs.gd
@@ -203,6 +203,13 @@ func _remove_input(id: String) -> bool:
 		InputMap.erase_action(id)
 	reg.erase(id)
 	_registry_registered["inputs"] = reg
+	# Drop the id's patch stash with the entry (mirrors _remove_event): the
+	# action is gone from InputMap, so its stashed originals are dead state
+	# and would poison a later re-registration under the same id.
+	var patched: Dictionary = _registry_patched.get("inputs", {})
+	if patched.has(id):
+		patched.erase(id)
+		_registry_patched["inputs"] = patched
 	_log_debug("[Registry] removed input '%s'" % id)
 	return true
 

--- a/src/registry/items.gd
+++ b/src/registry/items.gd
@@ -129,6 +129,14 @@ func _remove_item(id: String) -> bool:
 		return false
 	reg.erase(id)
 	_registry_registered["items"] = reg
+	# Drop the id's patch stash with the entry (mirrors _remove_event): its
+	# first-write-wins originals belong to the item being removed, and leaving
+	# it would poison a later re-registration of the same id -- revert would
+	# write the OLD item's values onto the NEW one.
+	var patched: Dictionary = _registry_patched.get("items", {})
+	if patched.has(id):
+		patched.erase(id)
+		_registry_patched["items"] = patched
 	_log_debug("[Registry] removed item '%s'" % id)
 	return true
 

--- a/src/registry/recipes.gd
+++ b/src/registry/recipes.gd
@@ -260,6 +260,13 @@ func _remove_recipe(id: String) -> bool:
 				push_warning("[Registry] remove('recipes', '%s'): recipe not found in %s; tracking cleared" % [id, category])
 	reg.erase(id)
 	_registry_registered["recipes"] = reg
+	# Drop the handle's patch stash with the entry (mirrors _remove_event).
+	# Ref-keyed stashes ("ref:<iid>") are left alone -- they track the Resource
+	# identity, which outlives the handle.
+	var patched: Dictionary = _registry_patched.get("recipes", {})
+	if patched.has(id):
+		patched.erase(id)
+		_registry_patched["recipes"] = patched
 	_log_debug("[Registry] removed recipe '%s'" % id)
 	return true
 

--- a/src/registry/shared.gd
+++ b/src/registry/shared.gd
@@ -32,20 +32,48 @@ func _looks_like_item_data(res: Resource) -> bool:
 # won't pass. Walks item's script chain looking for a script whose resource
 # path matches the array's declared type.
 #
-# Returns true if either the array is untyped, or the item inherits from the
+# Returns true if either the array is untyped, or the item is accepted by the
 # array's declared type. Lets handlers fail fast with a clear warning rather
-# than letting Godot spit cryptic TypedArray errors.
+# than letting Godot spit cryptic TypedArray errors. This MUST mirror what the
+# engine's own typed-array validation accepts: _array_op_on_resource treats a
+# pass here as "every append will land", so a false positive means the engine
+# silently drops the value at append time while we still report success -- a
+# partial batch returned as a full one.
 func _typed_array_accepts(arr: Array, item: Variant) -> bool:
 	if not arr.is_typed():
 		return true
+	var builtin: int = arr.get_typed_builtin()
+	if builtin != TYPE_OBJECT:
+		# Typed by a built-in Variant type (Array[String], Array[int], ...).
+		# Accept an exact type match plus the strict conversions the engine's
+		# own container validation performs (numeric widening, string-ish
+		# interconversion). Everything else would be rejected by push_back.
+		var t: int = typeof(item)
+		if t == builtin:
+			return true
+		match builtin:
+			TYPE_INT, TYPE_FLOAT:
+				return t == TYPE_INT or t == TYPE_FLOAT or t == TYPE_BOOL
+			TYPE_BOOL:
+				return t == TYPE_INT or t == TYPE_FLOAT
+			TYPE_STRING:
+				return t == TYPE_STRING_NAME or t == TYPE_NODE_PATH
+			TYPE_STRING_NAME, TYPE_NODE_PATH:
+				return t == TYPE_STRING
+		return false
+	if not (item is Object):
+		return false
+	# Native-class constraint (Array[Node], Array[Texture2D], ...; also the
+	# native base of script-typed arrays, e.g. "Resource" for Array[ItemData]).
+	var cls: StringName = arr.get_typed_class_name()
+	if cls != &"" and not (item as Object).is_class(String(cls)):
+		return false
 	# For typed arrays of Objects, get_typed_script() returns the required
 	# script. Walk item's script chain; any match means it's a valid subclass.
 	var required = arr.get_typed_script()
 	if required == null:
-		# Typed by built-in type, not a script class; fall back to duck check.
+		# Typed by native class only; the is_class check above already passed.
 		return true
-	if not (item is Object):
-		return false
 	var s = item.get_script()
 	while s != null:
 		if s == required:

--- a/src/registry/sounds.gd
+++ b/src/registry/sounds.gd
@@ -240,6 +240,12 @@ func _remove_sound(id: String) -> bool:
 	# anything in reg is a plain register.
 	reg.erase(id)
 	_registry_registered["sounds"] = reg
+	# Drop the id's patch stash with the entry (mirrors _remove_event): stale
+	# originals would poison a later re-registration under the same id.
+	var patched: Dictionary = _registry_patched.get("sounds", {})
+	if patched.has(id):
+		patched.erase(id)
+		_registry_patched["sounds"] = patched
 	_log_debug("[Registry] removed sound '%s'" % id)
 	return true
 

--- a/src/registry/traders.gd
+++ b/src/registry/traders.gd
@@ -326,6 +326,12 @@ func _remove_trader_task(id: String) -> bool:
 				push_warning("[Registry] remove('trader_tasks', '%s'): task not found in %s.tasks; tracking cleared" % [id, trader])
 	reg.erase(id)
 	_registry_registered["trader_tasks"] = reg
+	# Drop the handle's patch stash with the entry (mirrors _remove_event).
+	# Ref-keyed stashes are left alone -- they track the Resource identity.
+	var patched: Dictionary = _registry_patched.get("trader_tasks", {})
+	if patched.has(id):
+		patched.erase(id)
+		_registry_patched["trader_tasks"] = patched
 	_log_debug("[Registry] removed trader_task '%s'" % id)
 	return true
 

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -349,7 +349,8 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask: Dictionary = {}) -> String:
 	# method_mask (v3.0.1): Dictionary[method_name, true] restricting which
 	# methods get renamed + wrapped. Empty = wrap every non-static method
-	# (used for REGISTRY_TARGETS where whole-script injection is needed).
+	# (REGISTRY_TARGETS needing whole-script injection, and the user-facing
+	# "[hooks] <path> = *" wildcard sentinel).
 	# Non-empty = wrap only declared methods; matches godot-mod-loader's
 	# per-path method_mask. Other methods stay vanilla, no dispatch
 	# overhead, no rename.
@@ -552,7 +553,9 @@ func _rtv_rewrite_database_constants(source: String) -> String:
 	# comment. Captures the name and the full preload expression verbatim so
 	# we don't disturb whitespace/quoting.
 	var re := RegEx.new()
-	re.compile('^const\\s+(\\w+)\\s*=\\s*(preload\\s*\\(\\s*"[^"]+"\\s*\\))\\s*$')
+	# Detokenized source never carries comments (the tokenizer drops them),
+	# but the plain-text fallback path in _detokenize_script can.
+	re.compile('^const\\s+(\\w+)\\s*=\\s*(preload\\s*\\(\\s*"[^"]+"\\s*\\))\\s*(?:#.*)?$')
 	for line: String in lines:
 		var m := re.search(line)
 		if m != null:
@@ -1072,9 +1075,12 @@ func _rtv_inject_aispawner_registry(indent: String) -> String:
 	return out
 
 # Rewrite bare `super(` / `super (` in a line to `super.<method>(`. Preserves
-# the rest of the line verbatim. Skips `super.<something>(` (already explicit),
-# and skips occurrences inside strings or comments by stopping at the first
-# `#` or quote. Called per-line within a renamed method's body.
+# the rest of the line verbatim. Skips `super.<something>(` (already explicit)
+# and anything at/after the first `#` (comment heuristic). String literals are
+# NOT tracked: a "super(" inside a string before any `#` would be rewritten,
+# altering that string's text (never code structure). Detokenized vanilla input
+# makes this a non-case; add real quote tracking if a script ever hits it.
+# Called per-line within a renamed method's body.
 func _rewrite_bare_super(line: String, method_name: String) -> String:
 	# Strip inline comment/string content before matching to avoid false hits.
 	# Simple heuristic: search the part of the line before the first # (not in

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -240,7 +240,24 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 
 	for line_num in lines.size():
 		var line: String = lines[line_num]
+		# Top-level lines only (column 0, no leading indent). EVERYTHING this
+		# pass records -- extends, class_name, vars, funcs -- is module-scope
+		# syntax. Two reasons to skip indented lines up front:
+		#   1. Correctness: an inner class's own indented `extends X` /
+		#      `class_name` / `func` would otherwise clobber or pollute the
+		#      script-level record. For funcs specifically, a wrap-mask
+		#      (especially the wildcard "*") would then emit a top-level
+		#      dispatch wrapper for a method that only exists inside the
+		#      inner class -- a rewritten script that cannot compile.
+		#   2. Startup cost: indented body lines are ~80% of a script; the
+		#      per-line strip_edges + two regex searches they used to get
+		#      (extends + class_name ran on EVERY line) were pure overhead,
+		#      repeated across every wrapped script on every generation.
+		if line.begins_with("\t") or line.begins_with(" "):
+			continue
 		var trimmed := line.strip_edges()
+		if trimmed.is_empty():
+			continue
 
 		var m_ext := _rtv_re_extends.search(trimmed)
 		if m_ext != null:
@@ -250,38 +267,42 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 		if m_cn != null:
 			script["class_name"] = m_cn.get_string(1)
 
-		# Top-level declarations only (column 0, no leading indent). Inner-class
-		# members are indented; capturing an inner-class `func` / `static func`
-		# here would register a method that is NOT on the script's own top-level
-		# interface. A wrap-mask -- especially the wildcard "*" -- would then emit
-		# a dispatch wrapper for it at column 0, producing a rewritten vanilla
-		# script that cannot compile (the wrapper references a method that only
-		# exists inside the inner class). var_names already had this guard.
-		if not line.begins_with("\t") and not line.begins_with(" "):
-			var m_var := _rtv_re_var.search(trimmed)
-			if m_var != null:
-				(script["var_names"] as Array).append(m_var.get_string(1))
+		var m_var := _rtv_re_var.search(trimmed)
+		if m_var != null:
+			(script["var_names"] as Array).append(m_var.get_string(1))
 
-			var m_sfunc := _rtv_re_static_func.search(trimmed)
-			if m_sfunc != null:
-				var sig_s := _rtv_scan_signature(trimmed, m_sfunc.get_end(0))
-				if not sig_s.is_empty():
-					func_starts.append([
-						line_num, m_sfunc.get_string(1), sig_s["params"],
-						_rtv_extract_param_names(sig_s["params"]), true,
-						sig_s["return_type"],
-					])
-				continue
+		var m_sfunc := _rtv_re_static_func.search(trimmed)
+		if m_sfunc != null:
+			var sig_s := _rtv_scan_signature(trimmed, m_sfunc.get_end(0))
+			if not sig_s.is_empty():
+				func_starts.append([
+					line_num, m_sfunc.get_string(1), sig_s["params"],
+					_rtv_extract_param_names(sig_s["params"]), true,
+					sig_s["return_type"],
+				])
+			else:
+				# Parse-internal detail; the user-facing consequence (a
+				# declared hook that can't fire) is warned about in
+				# _rtv_rewrite_vanilla_source's mask validation.
+				_log_debug("[RTVCodegen] %s: static func %s at line %d: signature unparseable (multi-line or malformed) -- invisible to the wrap surface" \
+						% [filename, m_sfunc.get_string(1), line_num + 1])
+			continue
 
-			var m_func := _rtv_re_func.search(trimmed)
-			if m_func != null:
-				var sig_f := _rtv_scan_signature(trimmed, m_func.get_end(0))
-				if not sig_f.is_empty():
-					func_starts.append([
-						line_num, m_func.get_string(1), sig_f["params"],
-						_rtv_extract_param_names(sig_f["params"]), false,
-						sig_f["return_type"],
-					])
+		var m_func := _rtv_re_func.search(trimmed)
+		if m_func != null:
+			var sig_f := _rtv_scan_signature(trimmed, m_func.get_end(0))
+			if not sig_f.is_empty():
+				func_starts.append([
+					line_num, m_func.get_string(1), sig_f["params"],
+					_rtv_extract_param_names(sig_f["params"]), false,
+					sig_f["return_type"],
+				])
+			else:
+				# Parse-internal detail (dev-mode only). If a mod declared
+				# a hook on this method, the mask validation in
+				# _rtv_rewrite_vanilla_source emits the user-facing warning.
+				_log_debug("[RTVCodegen] %s: func %s at line %d: signature unparseable (multi-line or malformed) -- NOT hookable, will not be wrapped" \
+						% [filename, m_func.get_string(1), line_num + 1])
 
 	# Second pass: extract function bodies to detect await + return-with-value.
 	for idx in func_starts.size():
@@ -303,7 +324,27 @@ func _rtv_parse_script(filename: String, source: String) -> Dictionary:
 		for i in range(body_start, body_end):
 			if i >= lines.size():
 				break
-			var body_line := lines[i].strip_edges()
+			var raw_body := lines[i]
+			var body_line := raw_body.strip_edges()
+			if body_line.is_empty():
+				continue
+			# A top-level (unindented) line between this func and the next one
+			# is NOT part of this body -- it's module scope (e.g. Database.gd's
+			# const preload block sits after _ready) or an inner `class` header
+			# whose indented methods would otherwise be scanned as OUR body.
+			# Stop here: an `await` past this point would falsely mark the
+			# method a coroutine, the wrapper would gain `await`, and every
+			# caller of the wrapped method would then fail at PARSE time
+			# ("must be called with await") -- the exact 3.3.0 bug class.
+			# Column-0 comments inside a body are legal GDScript; skip those.
+			if raw_body[0] != "\t" and raw_body[0] != " ":
+				if body_line.begins_with("#"):
+					continue
+				break
+			# Comment lines can contain the words "await" / "return" without
+			# meaning either; never let them set the flags.
+			if body_line.begins_with("#"):
+				continue
 			if "await " in body_line:
 				is_coroutine = true
 			# "return <something>" (not bare "return").
@@ -364,6 +405,31 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 		if apply_mask and not method_mask.has(fe["name"].to_lower()):
 			continue
 		hookable.append(fe)
+
+	# LOUD mask validation: every declared hook method must correspond to a
+	# non-static vanilla method, or the mod's hook silently never fires --
+	# the "declared a hook, nothing happened, no log" failure mode. (When the
+	# WHOLE mask misses, _generate_hook_pack already warns and skips; this
+	# covers the partial case where some declared methods match and the rest
+	# would previously vanish without a trace.)
+	if apply_mask:
+		var _mask_nonstatic: Dictionary = {}
+		var _mask_static: Dictionary = {}
+		for fe in parsed["functions"]:
+			if fe["is_static"]:
+				_mask_static[str(fe["name"]).to_lower()] = true
+			else:
+				_mask_nonstatic[str(fe["name"]).to_lower()] = true
+		for mk in method_mask:
+			if _mask_nonstatic.has(mk):
+				continue
+			if _mask_static.has(mk):
+				_log_warning("[RTVCodegen] Hook on %s::%s will NEVER fire: it is a static function, and static functions cannot be hooked." \
+						% [parsed.get("filename", "?"), mk])
+			else:
+				_log_warning("[RTVCodegen] Hook on %s::%s will NEVER fire: no such method in vanilla. Check the spelling, or the game update renamed/removed it." \
+						% [parsed.get("filename", "?"), mk])
+
 	if hookable.is_empty():
 		return source
 
@@ -431,6 +497,7 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 	# and `super.OtherMethod()` are already explicit and pass through untouched.
 	var lines: PackedStringArray = src.split("\n")
 	var current_hooked_method: String = ""
+	var renamed_methods: Dictionary = {}
 	for i in lines.size():
 		var line: String = lines[i]
 		# Top-level line (no indent): may open or close a method block.
@@ -446,6 +513,7 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 					if hookable_names.has(method_name):
 						lines[i] = "func _rtv_vanilla_" + method_name + line.substr(name_end)
 						current_hooked_method = method_name
+						renamed_methods[method_name] = true
 			continue
 		# Indented line: inside some block. If inside a renamed method, rewrite
 		# bare super( / super ( to super.<orig_name>( so it still resolves.
@@ -454,6 +522,20 @@ func _rtv_rewrite_vanilla_source(source: String, parsed: Dictionary, method_mask
 		if not ("super" in line):
 			continue
 		lines[i] = _rewrite_bare_super(line, current_hooked_method)
+
+	# Rename invariant: every hookable method MUST have been renamed to
+	# _rtv_vanilla_<name> by the pass above (renamed_methods records each
+	# rename as it happens -- an O(1) check instead of re-scanning every
+	# line per method). If the rename missed one (formatting drift between
+	# the parse and the rename scan -- e.g. extra spaces in the
+	# declaration), the wrapper appended below DUPLICATES the still-
+	# unrenamed vanilla method and the whole rewritten script fails to
+	# compile, taking every hook on this script down with it. Scream at
+	# generation time, with the cause, instead of a bare engine parse error.
+	for fe in hookable:
+		if not renamed_methods.has(fe["name"]):
+			_log_critical("[RTVCodegen] %s: internal rename failure on method '%s' -- the rewritten script will fail to compile and ALL hooks on this script are disabled. Please report this modloader bug (include game version)." \
+					% [parsed.get("filename", "?"), str(fe["name"])])
 
 	# Pass 1.5: function-body prelude injection. Some registries need a
 	# check at the TOP of a specific vanilla function body (e.g., Loader's
@@ -560,6 +642,11 @@ func _rtv_rewrite_database_constants(source: String) -> String:
 			continue
 		out_lines.append(line)
 	if entries.is_empty():
+		# Not survivable silently: the registry appendix appended later
+		# references _rtv_vanilla_scenes, which only this transform declares.
+		# Without it the rewritten Database.gd fails to compile, killing
+		# Database hooks AND the scenes registry in one stroke.
+		_log_critical("[RTVCodegen] Database.gd: vanilla const layout changed (no 'const X = preload(...)' found) -- the scenes registry and Database hooks will NOT work. Update the modloader.")
 		return source
 	# Inject the dict var right after the extends/script-annotation preamble.
 	# Safe place: before any function. Walk until we find the first `func ` or
@@ -605,6 +692,14 @@ func _rtv_rewrite_loader_shelters(source: String) -> String:
 		lines[i] = m.get_string(1) + "var shelters " + m.get_string(2)
 		changed = true
 	if not changed:
+		# `shelters` stays const, so the appended add_shelter()/registry
+		# appends will fail at runtime. Only user-impacting when a mod
+		# actually uses the registry/B_Loader surface -- which is gated by
+		# _any_mod_declared_registry.
+		if _any_mod_declared_registry:
+			_log_critical("[RTVCodegen] Loader.gd: vanilla 'const shelters' declaration not found (game update?) -- mod shelters/maps will NOT work. Update the modloader.")
+		else:
+			_log_debug("[RTVCodegen] Loader.gd: 'const shelters' not found; const-to-var transform skipped (inert, no [registry] declared)")
 		return source
 	return "\n".join(lines)
 
@@ -615,16 +710,16 @@ func _rtv_rewrite_loader_shelters(source: String) -> String:
 func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, rename_prefix: String, indent_unit: String = "\t") -> PackedStringArray:
 	match filename:
 		"Loader.gd":
-			return _rtv_inject_prelude(lines, rename_prefix + "LoadScene", _rtv_loader_loadscene_prelude(), false, indent_unit)
+			return _rtv_inject_prelude(lines, rename_prefix + "LoadScene", _rtv_loader_loadscene_prelude(), false, indent_unit, filename)
 		"FishPool.gd":
-			return _rtv_inject_prelude(lines, rename_prefix + "_ready", _rtv_fishpool_ready_prelude(), false, indent_unit)
+			return _rtv_inject_prelude(lines, rename_prefix + "_ready", _rtv_fishpool_ready_prelude(), false, indent_unit, filename)
 		"AI.gd":
-			return _rtv_inject_prelude(lines, rename_prefix + "SelectWeapon", _rtv_ai_selectweapon_prelude(), false, indent_unit)
+			return _rtv_inject_prelude(lines, rename_prefix + "SelectWeapon", _rtv_ai_selectweapon_prelude(), false, indent_unit, filename)
 		"Compiler.gd":
 			# Spawn's prelude assigns to vanilla's `spawnTarget` local, which
 			# is declared on the first body line. Insert after the run of
 			# leading var decls so spawnTarget is in scope.
-			return _rtv_inject_prelude(lines, rename_prefix + "Spawn", _rtv_compiler_spawn_prelude(), true, indent_unit)
+			return _rtv_inject_prelude(lines, rename_prefix + "Spawn", _rtv_compiler_spawn_prelude(), true, indent_unit, filename)
 		_:
 			return lines
 
@@ -638,7 +733,7 @@ func _rtv_apply_prelude_injections(filename: String, lines: PackedStringArray, r
 # `var ...` and blank lines at the top of the body, rather than directly
 # under the signature. Use this when the prelude needs to reference a
 # local declared by vanilla (e.g. Compiler.Spawn's `spawnTarget`).
-func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_lines: PackedStringArray, after_var_decls: bool = false, indent_unit: String = "\t") -> PackedStringArray:
+func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_lines: PackedStringArray, after_var_decls: bool = false, indent_unit: String = "\t", context_file: String = "") -> PackedStringArray:
 	var needle := "func " + func_name + "("
 	var sig_target := -1
 	for i in lines.size():
@@ -647,7 +742,24 @@ func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_li
 			sig_target = i
 			break
 	if sig_target < 0:
-		_log_info("[RTVCodegen] prelude injection: func %s not found (was it not parsed as hookable?)" % func_name)
+		# Two very different situations land here:
+		#   (a) A mod declared [registry], so this script was wrapped whole-
+		#       script and the target method SHOULD have been renamed. Its
+		#       absence means the registry feature this prelude feeds is dead
+		#       (game update removed/changed the method, or its signature
+		#       failed to parse). That is user-impacting: registrations
+		#       silently stop applying. CRITICAL.
+		#   (b) No mod declared [registry]: the script entered the wrap
+		#       surface via [hooks]/.hook() with a per-method mask that does
+		#       not include this method, so it was never renamed. The prelude
+		#       is inert scaffolding in that session -- nothing a user or mod
+		#       author needs to act on. Dev-mode debug only.
+		if _any_mod_declared_registry:
+			_log_critical("[RTVCodegen] %s: registry code for %s could not be installed (method missing from the wrapped script -- game update?). Mod content registered against it will NOT appear." \
+					% [context_file, func_name])
+		else:
+			_log_debug("[RTVCodegen] %s: prelude target %s not in this script's hook mask and no [registry] declared -- prelude skipped (inert this session)" \
+					% [context_file, func_name])
 		return lines
 	var insert_after := sig_target
 	if after_var_decls:
@@ -670,6 +782,9 @@ func _rtv_inject_prelude(lines: PackedStringArray, func_name: String, prelude_li
 				j += 1
 				continue
 			break
+		if insert_after == sig_target:
+			_log_warning("[RTVCodegen] %s: %s no longer starts with the expected 'var' declarations (game update?) -- the injected registry code may not compile; registry features on this script may not work." \
+					% [context_file, func_name])
 	var result := PackedStringArray()
 	for i in lines.size():
 		result.append(lines[i])
@@ -836,6 +951,7 @@ func _rtv_rewrite_aispawner_agent_assignments(source: String) -> String:
 	# preloaded name) with optional trailing comment/whitespace.
 	var re := RegEx.new()
 	re.compile('^(\\s*)agent\\s*=\\s*(\\w+)\\s*(#.*)?$')
+	var rewrites := 0
 	for i in lines.size():
 		var line: String = lines[i]
 		var m := re.search(line)
@@ -847,6 +963,15 @@ func _rtv_rewrite_aispawner_agent_assignments(source: String) -> String:
 		if name in ["true", "false", "null"]:
 			continue
 		lines[i] = "%sagent = _rtv_resolve_ai_type(zone, %s)" % [indent, name]
+		rewrites += 1
+	if rewrites == 0:
+		# The ai_types override resolver was not wired into any assignment;
+		# registered AI overrides would silently never spawn. Only user-
+		# impacting when the registry surface is actually in use.
+		if _any_mod_declared_registry:
+			_log_critical("[RTVCodegen] AISpawner.gd: vanilla 'agent = <name>' assignments not found (game update?) -- AI type overrides will NOT work. Update the modloader.")
+		else:
+			_log_debug("[RTVCodegen] AISpawner.gd: no 'agent = <name>' assignments matched; ai_types resolver not wired (inert, no [registry] declared)")
 	return "\n".join(lines)
 
 # FishPool._ready() prelude: appends mod-registered species to the local

--- a/src/rewriter.gd
+++ b/src/rewriter.gd
@@ -1571,7 +1571,21 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%sif _repl.size() > 0:\n" % I1
 		out += "%svar _prev_skip = _lib._skip_super\n" % I2
 		out += "%s_lib._skip_super = false\n" % I2
-		out += "%svar _replret = await _repl[0].callv(%s)\n" % [I2, args_array]
+		# Gated on is_coro via `aw`, NOT unconditional. In GDScript any function
+		# whose body contains `await` IS a coroutine -- so an unconditional
+		# await here turned every wrapped vanilla method into a coroutine, and
+		# every existing caller then failed at PARSE time with "Function X is a
+		# coroutine, so it must be called with await". Runtime cost was nil
+		# (awaiting a non-coroutine Callable returns immediately); the damage
+		# was entirely the coroutine marking, and it scaled with the wrap
+		# surface -- 384 hook points across 35 scripts in the reported case.
+		#
+		# This does not change the hook contract. docs/wiki/Hooks.md has always
+		# told authors to suspend inside a replace callback ONLY when the
+		# vanilla method they replaced is itself a coroutine -- the wrapper
+		# just failed to enforce it, and marked every wrapped method as a
+		# coroutine to no benefit. Coroutine targets keep full async support.
+		out += "%svar _replret = %s_repl[0].callv(%s)\n" % [I2, aw, args_array]
 		out += "%svar _did_skip = _lib._skip_super\n" % I2
 		out += "%s_lib._skip_super = _prev_skip\n" % I2
 		out += "%sif _did_skip:\n" % I2
@@ -1624,7 +1638,10 @@ func _rtv_dispatch_inline_src(fe: Dictionary, prefix: String, indent: String = "
 		out += "%sif _repl.size() > 0:\n" % I1
 		out += "%svar _prev_skip = _lib._skip_super\n" % I2
 		out += "%s_lib._skip_super = false\n" % I2
-		out += "%sawait _repl[0].callv(%s)\n" % [I2, args_array]
+		# Void path -- same gating and same contract as the value-returning
+		# branch above; see the comment there for why this must not be an
+		# unconditional await.
+		out += "%s%s_repl[0].callv(%s)\n" % [I2, aw, args_array]
 		out += "%svar _did_skip = _lib._skip_super\n" % I2
 		out += "%s_lib._skip_super = _prev_skip\n" % I2
 		out += "%sif !_did_skip:\n" % I2

--- a/src/setup.gd
+++ b/src/setup.gd
@@ -70,6 +70,11 @@ func _setup_run_entry(entry: Variant) -> Dictionary:
 	var arr: Array = entry
 	if arr.is_empty():
 		return {"verb": "<empty>", "ok": false, "error": "entry is empty"}
+	# String() is the non-converting constructor: a non-String verb (e.g. a
+	# stray int) would be a runtime error that aborts the WHOLE plan mid-run
+	# instead of isolating to this entry per the contract above.
+	if not (arr[0] is String or arr[0] is StringName):
+		return {"verb": "<malformed>", "ok": false, "error": "verb (1st element) must be a String"}
 	var verb: String = String(arr[0])
 	# SEAM: new verbs = one match arm here + a schema line in the header
 	# docstring above (+ a _bind_* helper if it wraps a _many form).
@@ -92,6 +97,8 @@ func _setup_run_entry(entry: Variant) -> Dictionary:
 			# remove takes an Array of ids, not a {id: ...} dict.
 			if arr.size() != 3:
 				return {"verb": verb, "ok": false, "error": "expected [\"remove\", reg, [ids]]"}
+			if not (arr[1] is String or arr[1] is StringName):
+				return {"verb": verb, "ok": false, "error": "registry name (2nd element) must be a String"}
 			if not (arr[2] is Array):
 				return {"verb": verb, "ok": false, "error": "expected ids Array as 3rd arg"}
 			var rm: Dictionary = remove_many(String(arr[1]), arr[2])
@@ -126,6 +133,10 @@ func _setup_run_entry(entry: Variant) -> Dictionary:
 func _setup_dispatch_many(verb: String, arr: Array, many_fn: Callable) -> Dictionary:
 	if arr.size() != 3:
 		return {"verb": verb, "ok": false, "error": "expected [\"%s\", reg, {id: payload}]" % verb}
+	# Non-String reg would be a String()-constructor runtime error that kills
+	# the whole plan; reject per-entry instead (same rationale as the verb check).
+	if not (arr[1] is String or arr[1] is StringName):
+		return {"verb": verb, "ok": false, "error": "registry name (2nd element) must be a String"}
 	if not (arr[2] is Dictionary):
 		return {"verb": verb, "ok": false, "error": "expected payload dict as 3rd arg"}
 	var res: Dictionary = many_fn.call(String(arr[1]), arr[2])
@@ -137,6 +148,11 @@ func _setup_dispatch_many(verb: String, arr: Array, many_fn: Callable) -> Dictio
 func _setup_dispatch_array_op(verb: String, arr: Array) -> Dictionary:
 	if arr.size() < 4 or arr.size() > 5:
 		return {"verb": verb, "ok": false, "error": "expected [\"%s\", reg, field, {id: values}, allow_duplicates?]" % verb}
+	# Same String()-constructor guard as _setup_dispatch_many.
+	if not (arr[1] is String or arr[1] is StringName):
+		return {"verb": verb, "ok": false, "error": "registry name (2nd element) must be a String"}
+	if not (arr[2] is String or arr[2] is StringName):
+		return {"verb": verb, "ok": false, "error": "field name (3rd element) must be a String"}
 	if not (arr[3] is Dictionary):
 		return {"verb": verb, "ok": false, "error": "expected payload dict as 4th arg"}
 	var reg: String = String(arr[1])

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -138,7 +138,14 @@ func _load_ui_config() -> void:
 			# bad in this branch, so there is nothing good left to lose, and it
 			# matches the recovery branch above.
 			if FileAccess.file_exists(UI_CONFIG_PATH):
-				DirAccess.copy_absolute(UI_CONFIG_PATH, UI_CONFIG_PATH + ".corrupt")
+				if DirAccess.copy_absolute(UI_CONFIG_PATH, UI_CONFIG_PATH + ".corrupt") == OK:
+					# The unreadable file is preserved as .corrupt; REMOVE the
+					# live copy so the fresh-Default save below is not refused
+					# by _load_ui_cfg_for_write's unreadable-file guard. Without
+					# this, the save silently no-ops here AND every later save
+					# this session refuses too -- the user's toggles would never
+					# persist again until they deleted the file by hand.
+					DirAccess.remove_absolute(UI_CONFIG_PATH)
 			_save_ui_config()
 			return
 
@@ -560,11 +567,23 @@ func _get_ui_cfg_value(section: String, key: String, default: Variant) -> Varian
 #
 # Returns null in that case; callers skip the write and keep the change
 # in-memory for the session.
+#
+# The refusal must not stay console-only: a player whose config goes
+# unreadable mid-session (file lock, sync tool, disk fault) would otherwise
+# toggle mods all evening and only discover at next launch that nothing
+# stuck. Tell them ONCE, in the launcher, that changes are session-only.
+# Next boot self-heals via _load_ui_config's .bak/.corrupt recovery.
+var _ui_cfg_refusal_notified := false
+
 func _load_ui_cfg_for_write() -> ConfigFile:
 	var cfg := ConfigFile.new()
 	var err := cfg.load(UI_CONFIG_PATH)
 	if err != OK and err != ERR_FILE_NOT_FOUND:
 		_log_warning("mod_config.cfg exists but could not be read (error %d) -- refusing to overwrite it. This change is not saved." % err)
+		if not _ui_cfg_refusal_notified and _ui_window != null and is_instance_valid(_ui_window):
+			_ui_cfg_refusal_notified = true
+			_show_error_dialog("Settings cannot be saved",
+					"Your settings file (mod_config.cfg) cannot be read right now, so changes made in this session will not be saved. Your existing profiles are untouched. Restart the game to recover.")
 		return null
 	return cfg
 

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -444,8 +444,13 @@ func _preserve_stored_profile_key(key: String, live_keys: Dictionary, installed_
 	return true
 
 func _save_ui_config() -> void:
-	var cfg := ConfigFile.new()
-	cfg.load(UI_CONFIG_PATH)
+	# Only the ACTIVE profile's sections are rebuilt from live state below --
+	# every other profile is carried over from the loaded file. So an
+	# unreadable cfg here does not just lose this save, it silently deletes
+	# every other profile the user has. Refuse rather than rewrite.
+	var cfg := _load_ui_cfg_for_write()
+	if cfg == null:
+		return
 
 	# Drop legacy flat sections if they linger after migration.
 	if cfg.has_section("enabled"):
@@ -543,9 +548,30 @@ func _get_ui_cfg_value(section: String, key: String, default: Variant) -> Varian
 # Write a single value into mod_config.cfg via the backup-then-save path.
 # Mirrors the load (result ignored) / set / _persist_ui_cfg dance the accessors
 # shared; a missing file loads empty and is created on save.
-func _set_ui_cfg_value(section: String, key: String, value: Variant) -> void:
+# Load mod_config.cfg for a PARTIAL write (set a key or two, then persist).
+#
+# _persist_ui_cfg rewrites the whole file, so a caller that persists a
+# ConfigFile which failed to load replaces every profile with just the handful
+# of keys it set -- silent, total loss of the user's mod setup. A MISSING file
+# is fine and expected (fresh install): ConfigFile.load returns
+# ERR_FILE_NOT_FOUND and the empty cfg is the correct starting point. Any other
+# error means the file is there but unreadable (lock, corruption), and writing
+# over it would destroy state we cannot see.
+#
+# Returns null in that case; callers skip the write and keep the change
+# in-memory for the session.
+func _load_ui_cfg_for_write() -> ConfigFile:
 	var cfg := ConfigFile.new()
-	cfg.load(UI_CONFIG_PATH)
+	var err := cfg.load(UI_CONFIG_PATH)
+	if err != OK and err != ERR_FILE_NOT_FOUND:
+		_log_warning("mod_config.cfg exists but could not be read (error %d) -- refusing to overwrite it. This change is not saved." % err)
+		return null
+	return cfg
+
+func _set_ui_cfg_value(section: String, key: String, value: Variant) -> void:
+	var cfg := _load_ui_cfg_for_write()
+	if cfg == null:
+		return
 	cfg.set_value(section, key, value)
 	_persist_ui_cfg(cfg)
 
@@ -667,10 +693,16 @@ func _switch_profile(name: String) -> void:
 	if old != VANILLA_PROFILE and old != name:
 		_snapshot_mcm_to(old)
 	_active_profile = name
-	var cfg := ConfigFile.new()
-	cfg.load(UI_CONFIG_PATH)
-	cfg.set_value("settings", "active_profile", _active_profile)
-	_persist_ui_cfg(cfg)
+	var cfg := _load_ui_cfg_for_write()
+	if cfg != null:
+		cfg.set_value("settings", "active_profile", _active_profile)
+		_persist_ui_cfg(cfg)
+	else:
+		# Unreadable cfg: do not rewrite it (that would drop every profile),
+		# but still read what we can so the in-memory apply below behaves as
+		# it always did.
+		cfg = ConfigFile.new()
+		cfg.load(UI_CONFIG_PATH)
 	_apply_profile_to_entries(cfg, _active_profile)
 	if name != VANILLA_PROFILE:
 		if _has_mcm_snapshot(name):
@@ -4403,10 +4435,11 @@ func build_mods_tab(tabs: TabContainer) -> Control:
 		# Written straight through rather than via _save_ui_config: this is a
 		# display preference, and the full save rewrites profile state we have
 		# no reason to touch here.
-		var scfg := ConfigFile.new()
-		scfg.load(UI_CONFIG_PATH)
-		scfg.set_value("settings", "ui_scale", sv)
-		_persist_ui_cfg(scfg)
+		var scfg := _load_ui_cfg_for_write()
+		if scfg != null:
+			scfg.set_value("settings", "ui_scale", sv)
+			_persist_ui_cfg(scfg)
+		# Apply regardless -- an unsaved scale should still take effect now.
 		_apply_ui_scale(_ui_window, sv)
 	)
 

--- a/src/ui.gd
+++ b/src/ui.gd
@@ -6489,6 +6489,33 @@ func _browse_render_mod_row(mod_data: Dictionary, install_entry: Variant, on_get
 # parent PanelContainer -- no image asset needed, and FS_META + COL_TEXT_DIM
 # keeps it as quiet as the rest of the meta text. Safe to call after awaits
 # (guards the rect and its parent) and idempotent per cell.
+# Decode an image buffer by SNIFFING its magic bytes rather than trying every
+# decoder in turn.
+#
+# The old try-webp-then-jpg-then-png chain pushed nine engine ERROR lines into
+# the console for every buffer that was not an image -- an HTML error page, a
+# 404 body, a truncated download. Those lines are indistinguishable from real
+# failures at a glance, so a perfectly healthy launch log read as catastrophic
+# and genuine errors got buried in the noise.
+#
+# Returns null when the buffer is not a format we support; every caller already
+# treats that as "load failed".
+func _decode_image_buffer(bytes: PackedByteArray) -> Image:
+	if bytes.size() < 12:
+		return null
+	var img := Image.new()
+	# PNG: 89 'P' 'N' 'G'
+	if bytes[0] == 0x89 and bytes[1] == 0x50 and bytes[2] == 0x4E and bytes[3] == 0x47:
+		return img if img.load_png_from_buffer(bytes) == OK else null
+	# JPEG: FF D8 FF
+	if bytes[0] == 0xFF and bytes[1] == 0xD8 and bytes[2] == 0xFF:
+		return img if img.load_jpg_from_buffer(bytes) == OK else null
+	# WebP: "RIFF" <4-byte size> "WEBP"
+	if bytes[0] == 0x52 and bytes[1] == 0x49 and bytes[2] == 0x46 and bytes[3] == 0x46 \
+			and bytes[8] == 0x57 and bytes[9] == 0x45 and bytes[10] == 0x42 and bytes[11] == 0x50:
+		return img if img.load_webp_from_buffer(bytes) == OK else null
+	return null
+
 func _set_thumb_failed(rect: TextureRect, failed: bool) -> void:
 	if not is_instance_valid(rect):
 		return
@@ -6613,10 +6640,8 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 			var bytes := f.get_buffer(f.get_length())
 			f.close()
 			if bytes.size() > 0:
-				var img := Image.new()
-				if img.load_webp_from_buffer(bytes) == OK \
-						or img.load_jpg_from_buffer(bytes) == OK \
-						or img.load_png_from_buffer(bytes) == OK:
+				var img := _decode_image_buffer(bytes)
+				if img != null:
 					var disk_tex := ImageTexture.create_from_image(img)
 					_thumb_texture_cache_store(fn, disk_tex)
 					_set_thumb_ready(rect, disk_tex)
@@ -6655,11 +6680,8 @@ func _browse_load_thumbnail_async(rect: TextureRect, image_record: Dictionary) -
 		_set_thumb_failed(rect, true)
 		return
 
-	var img := Image.new()
-	var ok := img.load_webp_from_buffer(body) == OK \
-			or img.load_jpg_from_buffer(body) == OK \
-			or img.load_png_from_buffer(body) == OK
-	if not ok:
+	var img := _decode_image_buffer(body)
+	if img == null:
 		_set_thumb_failed(rect, true)
 		return
 

--- a/tests/codegen/FixtureDefaults.gd
+++ b/tests/codegen/FixtureDefaults.gd
@@ -1,0 +1,45 @@
+extends Node
+# Synthetic codegen fixture -- exercises signature shapes the vanilla RTV
+# corpus does not contain (the 4.6.1 game ships no default parameter values
+# at all). Compiled pristine as a baseline, then rewritten + recompiled by
+# tests/codegen/runner.gd. Keep every func declaration on a single line with
+# " -> " return-annotation spacing: the harness asserts the wrapper
+# reproduces the declaration line byte-for-byte.
+
+var counter := 0
+
+static func StaticHelper(x: int = 2) -> int:
+	return x * 2
+
+class Inner:
+	func InnerOnly(a := 1) -> int:
+		return a
+
+func PlainVoid() -> void:
+	counter += 1
+
+func ImplicitVoid():
+	counter += 1
+
+func SyncValue() -> String:
+	return "shelter"
+
+func DefaultsSimple(count: int = 3, label: String = "x") -> int:
+	return count + label.length()
+
+func DefaultsTricky(offset: Vector2 = Vector2(1, 2), tags: Array = ["a, (b)", "c"], data: Dictionary = {"k": 1}) -> Vector2:
+	return offset + Vector2(tags.size(), data.size())
+
+func UntypedDefaults(a = 5, b = "s"):
+	return [a, b]
+
+func TypedArrayValue() -> Array[String]:
+	return ["a"]
+
+func CoroutineValue(ticks: int = 1) -> int:
+	await Engine.get_main_loop().process_frame
+	return ticks * 2
+
+func CoroutineVoid() -> void:
+	await Engine.get_main_loop().process_frame
+	counter += 1

--- a/tests/codegen/FixtureDispatch.gd
+++ b/tests/codegen/FixtureDispatch.gd
@@ -1,0 +1,50 @@
+## FixtureDispatch.gd -- synthetic vanilla-shaped script for the runtime
+## dispatch harness (tests/codegen/dispatch_runner.gd, driven by
+## check_dispatch.sh). NOT part of the shipped loader. check_codegen.sh's
+## Fixture*.gd glob copies this file into its project too, but it is not in
+## runner.gd's FIXTURES table, so the compile-only harness never touches it.
+##
+## Every method body records what actually executed into the Array stored
+## at Engine meta "RTVDispatchLog", so the runner can assert on real
+## execution order after the REAL rewriter wraps these methods.
+##
+## Shape notes (each method exists to exercise one wrapper template path):
+##   Add           sync value return       -> non-void template
+##   Note          void                    -> void template
+##   WithDefaults  defaulted parameter     -> default passthrough
+##   CoroValue     real coroutine (await)  -> is_coro template variant
+##   Outer/Inner   nested wrapped calls    -> _caller save/restore
+## _rec is static ON PURPOSE: static funcs are outside the wrap surface,
+## so the recorder itself can never be renamed or dispatched through.
+extends Node
+
+static func _rec(tag: String) -> void:
+	if Engine.has_meta("RTVDispatchLog"):
+		(Engine.get_meta("RTVDispatchLog") as Array).append(tag)
+
+func Add(a: int, b: int) -> int:
+	_rec("vanilla:Add:%d:%d" % [a, b])
+	return a + b
+
+func Note(msg: String) -> void:
+	_rec("vanilla:Note:" + msg)
+
+func WithDefaults(a: int, b: int = 7) -> int:
+	_rec("vanilla:WithDefaults:%d:%d" % [a, b])
+	return a + b
+
+func CoroValue(x: int) -> int:
+	_rec("vanilla:CoroValue:start:%d" % x)
+	await (Engine.get_main_loop() as SceneTree).process_frame
+	_rec("vanilla:CoroValue:end:%d" % x)
+	return x * 10
+
+func Outer(peer: Node) -> int:
+	_rec("vanilla:Outer:start")
+	var inner_val: int = peer.Inner()
+	_rec("vanilla:Outer:end")
+	return inner_val + 1
+
+func Inner() -> int:
+	_rec("vanilla:Inner")
+	return 5

--- a/tests/codegen/FixtureLegacy.gd
+++ b/tests/codegen/FixtureLegacy.gd
@@ -1,0 +1,18 @@
+extends Node
+# Synthetic codegen fixture -- Godot-3-era / sloppy syntax that Godot 4's
+# parser rejects outright. The PRISTINE file deliberately does NOT compile
+# (baseline=false in runner.gd's fixture table); the rewriter's
+# _rtv_autofix_legacy_syntax pass must repair it (onready var -> @onready,
+# export var -> @export, `pass` injected into bodyless blocks) and the
+# REWRITTEN output must compile.
+
+onready var late_node = get_node_or_null("Missing")
+export var tunable = 4
+
+func BodylessBranch(value: int) -> int:
+	if value > 0:
+	return value
+
+func EmptyLoop() -> void:
+	for i in range(3):
+	tunable += 1

--- a/tests/codegen/FixtureSub.gd
+++ b/tests/codegen/FixtureSub.gd
@@ -1,0 +1,14 @@
+extends "res://Scripts/FixtureDefaults.gd"
+# Synthetic codegen fixture -- an extends-by-path subclass with bare super()
+# calls, the pattern _rewrite_bare_super must rewrite once the enclosing
+# method is renamed (a bare super() inside _rtv_vanilla_<name> would look for
+# _rtv_vanilla_<name> on the parent, which does not exist -- Gotcha #2 in
+# the GDScript-rewrite gotchas memory). Processed AFTER FixtureDefaults.gd,
+# so this also proves a subclass compiles against the REWRITTEN parent.
+
+func PlainVoid() -> void:
+	super()
+	counter += 2
+
+func DefaultsSimple(count: int = 3, label: String = "x") -> int:
+	return super(count, label) + 1

--- a/tests/codegen/dispatch_runner.gd
+++ b/tests/codegen/dispatch_runner.gd
@@ -1,0 +1,459 @@
+## dispatch_runner.gd -- RUNTIME dispatch harness. NOT part of the shipped
+## loader. Executed by check_dispatch.sh inside a THROWAWAY Godot project
+## assembled under the system temp dir; never run it against this repo or
+## against the Road to Vostok install.
+##
+## What it proves that check_codegen.sh cannot: the generated hook wrappers
+## BEHAVE. A wrapper can compile perfectly and still dispatch the wrong
+## callback, in the wrong order, with the wrong arguments, or fail to
+## suppress vanilla. This harness:
+##   1. loads the NEUTERED modloader copy (static-init boot line replaced
+##      by {} -- same recipe as check_codegen.sh, asserted on prep),
+##   2. registers it through the REAL registration path
+##      (_register_rtv_modlib_meta -> Engine.meta "RTVModLib"),
+##   3. runs the REAL rewriter (_rtv_parse_script +
+##      _rtv_rewrite_vanilla_source, empty mask) over FixtureDispatch.gd,
+##   4. compiles the rewritten output and attaches it to real Nodes in the
+##      tree,
+##   5. registers hooks through the REAL public API
+##      (Engine.get_meta("RTVModLib").hook(...)),
+##   6. CALLS the wrapped methods and asserts on the recorded execution
+##      log (fixture bodies append to the Array at Engine meta
+##      "RTVDispatchLog").
+##
+## Contract under test is docs/wiki/Hooks.md (the "Hook names" table,
+## "Replace hooks", "Post hooks and result mutation", "Priorities and
+## dispatch order") plus src/hooks_api.gd. Test ids:
+##   T1  -pre fires before vanilla, with the vanilla arguments
+##   T2  replace: runs before vanilla; without skip_super() vanilla runs
+##       and vanilla's return wins; with skip_super() vanilla is suppressed
+##       and the callback's return is the result (value + void templates)
+##   T3  -post (non-void): trailing _result arg; non-null replaces the
+##       result, null passes through; legacy 2-arg form observes only;
+##       multiple post hooks chain in ascending priority
+##   T4  -callback is deferred until after the method returned
+##   T5  full ordering: pre -> replace-or-vanilla -> post -> deferred, and
+##       ascending priority within the pre stage
+##   T6  replace slot is single-owner: second registration returns -1 and
+##       the first owner still runs
+##   T7  unhook(id) stops that callback, leaves others intact
+##   T8  _lib._caller is the dispatching node and is restored around
+##       NESTED wrapped calls (wrapped method calling a wrapped method on
+##       another node), including for the outer method's post stage
+##   T9  re-entrancy: a hook callback calling the SAME wrapped method on
+##       the SAME instance does not recurse into dispatch, and the hook
+##       STILL fires on the next call (a leaked guard key would silently
+##       disable it -- the exact regression --prove reintroduces)
+##   T10 two instances of one wrapped script dispatch independently, even
+##       when one instance's hook calls into the other instance
+##   T11 a coroutine vanilla method still awaits and returns its value,
+##       with pre/post dispatch intact
+##   T12 defaulted parameters flow through when omitted at the call site
+extends SceneTree
+
+const FIXTURE_PATH := "res://Scripts/FixtureDispatch.gd"
+const WRAPPER_MARKER := "# --- Metro mod loader inline hook dispatch wrappers ---"
+## Frames before the watchdog declares a hang (a lost await / never-resumed
+## coroutine). Headless frames are ~instant; a clean run needs well under 20.
+const MAX_FRAMES := 2000
+
+var _started := false
+var _done := false
+var _frames := 0
+var _failures: PackedStringArray = []
+var _checks := 0
+var _log: Array = []
+var _ml = null          # neutered modloader instance
+var _lib = null         # Engine.get_meta("RTVModLib") -- same object, via the real lookup
+var _node_a: Node = null
+var _node_b: Node = null
+var _t0 := 0
+
+func _process(_delta: float) -> bool:
+	_frames += 1
+	if not _started:
+		_started = true
+		_t0 = Time.get_ticks_msec()
+		_run()
+	elif not _done and _frames > MAX_FRAMES:
+		printerr("[dispatch] FAIL watchdog: harness did not finish within %d frames -- a coroutine never resumed" % MAX_FRAMES)
+		quit(1)
+		return true
+	return false
+
+func _run() -> void:
+	print("[dispatch] harness start")
+	if _setup():
+		await _run_tests()
+	_teardown()
+	_finish()
+
+func _finish() -> void:
+	_done = true
+	var ms := Time.get_ticks_msec() - _t0
+	if _failures.is_empty():
+		print("[dispatch] PASS: %d assertion(s) across T1..T12, %d frame(s), %d ms in-engine" % [_checks, _frames, ms])
+		quit(0)
+	else:
+		printerr("[dispatch] FAILED: %d of %d assertion(s) (%d ms in-engine); first: %s" % [_failures.size(), _checks, ms, _failures[0]])
+		quit(1)
+
+# --- assertion helpers -------------------------------------------------------
+
+func _fail(id: String, msg: String) -> void:
+	_failures.append(id + ": " + msg)
+	printerr("[dispatch] FAIL " + id + ": " + msg)
+
+func _expect(cond: bool, id: String, msg: String) -> bool:
+	_checks += 1
+	if not cond:
+		_fail(id, msg)
+	return cond
+
+func _expect_eq(got, want, id: String, what: String) -> bool:
+	_checks += 1
+	if not is_same(typeof(got), typeof(want)) or got != want:
+		_fail(id, "%s: got %s, want %s" % [what, str(got), str(want)])
+		return false
+	return true
+
+## Compare the execution log captured since the last clear against an exact
+## expected sequence. Exactness is the point: extra, missing or reordered
+## entries are all dispatch bugs.
+func _expect_log(id: String, expected: Array) -> bool:
+	_checks += 1
+	if _log != expected:
+		_fail(id, "execution order mismatch:\n    got:  %s\n    want: %s" % [str(_log), str(expected)])
+		return false
+	return true
+
+func _wait_frames(n: int) -> void:
+	for i in n:
+		await process_frame
+
+func _unhook_all(ids: Array) -> void:
+	for id in ids:
+		if int(id) != -1:
+			_lib.unhook(int(id))
+	_log.clear()
+
+# --- setup -------------------------------------------------------------------
+
+func _setup() -> bool:
+	var ml_script: GDScript = load("res://modloader_neutered.gd")
+	if ml_script == null:
+		_fail("setup", "could not load res://modloader_neutered.gd -- check_dispatch.sh prep failed")
+		return false
+	_ml = ml_script.new()
+	# Belt and braces (same as codegen runner): the static-init boot line was
+	# replaced by {}. If boot code ran anyway, refuse to continue.
+	var mounted = _ml.get("_filescope_mounted")
+	if not (mounted is Dictionary) or not (mounted as Dictionary).is_empty():
+		_fail("setup", "_filescope_mounted is not an empty Dictionary -- static-init boot code RAN; the neutering failed")
+		return false
+
+	# Real registration path, then the real lookup mods use.
+	_ml._register_rtv_modlib_meta()
+	_lib = Engine.get_meta("RTVModLib")
+	if not _expect(_lib == _ml, "setup", "Engine.get_meta('RTVModLib') is not the registered loader instance"):
+		return false
+
+	# The fixture bodies record into this shared Array.
+	Engine.set_meta("RTVDispatchLog", _log)
+
+	# Run the REAL rewriter over the pristine fixture, wrap-all mask.
+	var f := FileAccess.open(FIXTURE_PATH, FileAccess.READ)
+	if f == null:
+		_fail("setup", "fixture missing at " + FIXTURE_PATH)
+		return false
+	var raw := f.get_as_text()
+	f.close()
+	var parsed: Dictionary = _ml._rtv_parse_script("FixtureDispatch.gd", raw)
+	var coro_seen := false
+	for fe in parsed["functions"]:
+		if fe["name"] == "CoroValue" and bool(fe["is_coroutine"]):
+			coro_seen = true
+	if not _expect(coro_seen, "setup", "parser did not mark CoroValue a coroutine -- fixture or parser drifted"):
+		return false
+	var rewritten: String = _ml._rtv_rewrite_vanilla_source(raw, parsed, {})
+	if not _expect(WRAPPER_MARKER in rewritten, "setup", "rewritten fixture lacks the wrapper marker"):
+		return false
+	if not _expect("\"fixturedispatch-add\"" in rewritten, "setup", "wrapper hook_base 'fixturedispatch-add' not emitted -- prefix derivation drifted"):
+		return false
+
+	var wf := FileAccess.open(FIXTURE_PATH, FileAccess.WRITE)
+	wf.store_string(rewritten)
+	wf.close()
+	var scr = ResourceLoader.load(FIXTURE_PATH, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if scr == null or not (scr as Script).can_instantiate():
+		_fail("setup", "REWRITTEN fixture does not compile (see SCRIPT ERROR lines above)")
+		return false
+
+	_node_a = (scr as GDScript).new()
+	_node_a.name = "A"
+	_node_b = (scr as GDScript).new()
+	_node_b.name = "B"
+	root.add_child(_node_a)
+	root.add_child(_node_b)
+	return true
+
+func _teardown() -> void:
+	if _node_a != null:
+		_node_a.queue_free()
+	if _node_b != null:
+		_node_b.queue_free()
+	if _ml != null:
+		if Engine.has_meta("RTVModLib"):
+			Engine.remove_meta("RTVModLib")
+		_ml.free()
+
+# --- tests -------------------------------------------------------------------
+
+func _run_tests() -> void:
+	_t1_pre()
+	_t2_replace()
+	_t3_post()
+	await _t4_deferred()
+	await _t5_ordering()
+	_t6_replace_single_owner()
+	_t7_unhook()
+	_t8_caller_nested()
+	_t9_reentrancy()
+	_t10_two_instances()
+	await _t11_coroutine()
+	_t12_defaults()
+
+func _t1_pre() -> void:
+	var id: int = _lib.hook("fixturedispatch-add-pre", func(x, y): _log.append("pre:add:%d:%d" % [x, y]))
+	_expect(id != -1, "T1", "hook() returned -1 for a -pre registration")
+	var r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T1", "Add(2,3) return value with only a pre hook")
+	_expect_log("T1", ["pre:add:2:3", "vanilla:Add:2:3"])
+	_unhook_all([id])
+
+func _t2_replace() -> void:
+	# 2a: value template, no skip_super -> callback runs FIRST, vanilla still
+	# runs, and VANILLA's return wins (callback's 999 is discarded).
+	var id: int = _lib.hook("fixturedispatch-add", func(x, y):
+		_log.append("repl:%d:%d:caller=%s" % [x, y, str(_lib._caller.name)])
+		return 999)
+	var r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T2a", "without skip_super vanilla's return value must win")
+	_expect_log("T2a", ["repl:2:3:caller=A", "vanilla:Add:2:3"])
+	_unhook_all([id])
+
+	# 2b: value template, skip_super -> vanilla suppressed, callback's return
+	# becomes the result. This is the assertion --prove mutation A must break.
+	id = _lib.hook("fixturedispatch-add", func(_x, _y):
+		_lib.skip_super()
+		_log.append("replskip")
+		return 999)
+	r = _node_a.Add(2, 3)
+	_expect_eq(r, 999, "T2b", "with skip_super the replace callback's return must be the result")
+	_expect_log("T2b", ["replskip"])
+	_unhook_all([id])
+
+	# 2c: void template, no skip -> vanilla still runs after the callback.
+	id = _lib.hook("fixturedispatch-note", func(_m): _log.append("vrepl"))
+	_node_a.Note("q")
+	_expect_log("T2c", ["vrepl", "vanilla:Note:q"])
+	_unhook_all([id])
+
+	# 2d: void template, skip_super -> vanilla suppressed.
+	id = _lib.hook("fixturedispatch-note", func(_m):
+		_lib.skip_super()
+		_log.append("vreplskip"))
+	_node_a.Note("q")
+	_expect_log("T2d", ["vreplskip"])
+	_unhook_all([id])
+
+func _t3_post() -> void:
+	# 3a: trailing-_result form, non-null return replaces the result. This is
+	# the assertion --prove mutation B must break.
+	var id: int = _lib.hook("fixturedispatch-add-post", func(_x, _y, res): return res + 100)
+	var r = _node_a.Add(2, 3)
+	_expect_eq(r, 105, "T3a", "post hook returning non-null must replace the result")
+	_unhook_all([id])
+
+	# 3b: null return is the pass-through sentinel; callback still sees the
+	# running result.
+	id = _lib.hook("fixturedispatch-add-post", func(_x, _y, res):
+		_log.append("post_saw:%s" % str(res))
+		return null)
+	r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T3b", "post hook returning null must leave the result untouched")
+	_expect_log("T3b", ["vanilla:Add:2:3", "post_saw:5"])
+	_unhook_all([id])
+
+	# 3c: legacy 2-arg form (vanilla args only) still runs as an observer;
+	# its return is ignored. (The one-shot deprecation warning it triggers is
+	# expected console noise.)
+	id = _lib.hook("fixturedispatch-add-post", func(x, y):
+		_log.append("legacy:%d:%d" % [x, y])
+		return 12345)
+	r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T3c", "legacy 2-arg post hook must not affect the result")
+	_expect_log("T3c", ["vanilla:Add:2:3", "legacy:2:3"])
+	_unhook_all([id])
+
+	# 3d: multiple post hooks chain in ascending priority; each sees the
+	# previous transformation. p50 doubles, p100 adds 1: (2+3)*2+1 = 11.
+	# The reversed order would give (2+3+1)*2 = 12.
+	var ida: int = _lib.hook("fixturedispatch-add-post", func(_x, _y, res): return res * 2, 50)
+	var idb: int = _lib.hook("fixturedispatch-add-post", func(_x, _y, res): return res + 1, 100)
+	r = _node_a.Add(2, 3)
+	_expect_eq(r, 11, "T3d", "post hooks must chain in ascending priority order")
+	_unhook_all([ida, idb])
+
+func _t4_deferred() -> void:
+	var id: int = _lib.hook("fixturedispatch-note-callback", func(m): _log.append("cb:" + str(m)))
+	_node_a.Note("hi")
+	_expect_log("T4-immediate", ["vanilla:Note:hi"])
+	await _wait_frames(2)
+	_expect_log("T4-deferred", ["vanilla:Note:hi", "cb:hi"])
+	_unhook_all([id])
+
+func _t5_ordering() -> void:
+	# Register the pre hooks in DESCENDING priority order so a pass can only
+	# come from actual priority sorting, not registration order.
+	var ids: Array = [
+		_lib.hook("fixturedispatch-add-pre", func(_x, _y): _log.append("pre20"), 20),
+		_lib.hook("fixturedispatch-add-pre", func(_x, _y): _log.append("pre10"), 10),
+		_lib.hook("fixturedispatch-add", func(_x, _y):
+			_log.append("repl")
+			return 0),
+		_lib.hook("fixturedispatch-add-post", func(_x, _y, _res):
+			_log.append("post")
+			return null),
+		_lib.hook("fixturedispatch-add-callback", func(x, y): _log.append("cb:%d:%d" % [x, y])),
+	]
+	var r = _node_a.Add(1, 1)
+	_expect_eq(r, 2, "T5", "no skip_super: vanilla's return survives the full pipeline")
+	_expect_log("T5-immediate", ["pre10", "pre20", "repl", "vanilla:Add:1:1", "post"])
+	await _wait_frames(2)
+	_expect_log("T5-deferred", ["pre10", "pre20", "repl", "vanilla:Add:1:1", "post", "cb:1:1"])
+	_unhook_all(ids)
+
+func _t6_replace_single_owner() -> void:
+	var id1: int = _lib.hook("fixturedispatch-add", func(_x, _y):
+		_log.append("owner1")
+		return 0)
+	var id2: int = _lib.hook("fixturedispatch-add", func(_x, _y):
+		_log.append("owner2")
+		return 0)
+	_expect(id1 != -1, "T6", "first replace registration must succeed")
+	_expect_eq(id2, -1, "T6", "second replace registration return code")
+	_expect_eq(_lib.get_replace_owner("fixturedispatch-add"), id1, "T6", "get_replace_owner")
+	_expect(_lib.has_replace("fixturedispatch-add"), "T6", "has_replace must be true while owned")
+	var r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T6", "Add() result with an occupied replace slot (no skip)")
+	_expect_log("T6", ["owner1", "vanilla:Add:2:3"])
+	_unhook_all([id1, id2])
+	_expect(not _lib.has_replace("fixturedispatch-add"), "T6", "has_replace must be false after unhook")
+
+func _t7_unhook() -> void:
+	var ida: int = _lib.hook("fixturedispatch-add-pre", func(_x, _y): _log.append("keepme_NOT"), 10)
+	var idb: int = _lib.hook("fixturedispatch-add-pre", func(_x, _y): _log.append("survivor"), 20)
+	_lib.unhook(ida)
+	_node_a.Add(1, 1)
+	_expect_log("T7", ["survivor", "vanilla:Add:1:1"])
+	_unhook_all([idb])
+
+func _t8_caller_nested() -> void:
+	# A.Outer(B) -> vanilla Outer body calls B.Inner() (a nested wrapped call
+	# on a DIFFERENT node). _caller must read A in Outer's pre, B in Inner's
+	# pre, and A AGAIN in Outer's post (the wrapper re-sets it after the body).
+	var ids: Array = [
+		_lib.hook("fixturedispatch-outer-pre", func(_peer): _log.append("pre:outer:caller=" + str(_lib._caller.name))),
+		_lib.hook("fixturedispatch-inner-pre", func(): _log.append("pre:inner:caller=" + str(_lib._caller.name))),
+		_lib.hook("fixturedispatch-outer-post", func(_peer, _res):
+			_log.append("post:outer:caller=" + str(_lib._caller.name))
+			return null),
+	]
+	var r = _node_a.Outer(_node_b)
+	_expect_eq(r, 6, "T8", "Outer(B) return value through nested wrapped dispatch")
+	_expect_log("T8", [
+		"pre:outer:caller=A",
+		"vanilla:Outer:start",
+		"pre:inner:caller=B",
+		"vanilla:Inner",
+		"vanilla:Outer:end",
+		"post:outer:caller=A",
+	])
+	_expect(_lib._caller == null, "T8", "_caller must be restored to its pre-dispatch value (null) after the call")
+	_unhook_all(ids)
+
+func _t9_reentrancy() -> void:
+	# A pre hook that calls the SAME wrapped method on the SAME instance. The
+	# re-entry guard must route the nested call straight to vanilla (no
+	# recursive dispatch), and -- the leak check -- the guard key must be
+	# RELEASED afterward so the hook still fires on the NEXT call. --prove
+	# mutation C removes the key erase; the second half of this test is what
+	# catches it.
+	var reent := func(x, y):
+		_log.append("pre:add:%d:%d" % [x, y])
+		if x == 2:
+			var nested = _node_a.Add(1, 1)
+			_log.append("nested_returned:" + str(nested))
+	var id: int = _lib.hook("fixturedispatch-add-pre", reent)
+	var r = _node_a.Add(2, 3)
+	_expect_eq(r, 5, "T9", "outer Add(2,3) return value with a re-entrant pre hook")
+	_expect_log("T9-first", [
+		"pre:add:2:3",
+		"vanilla:Add:1:1",
+		"nested_returned:2",
+		"vanilla:Add:2:3",
+	])
+	_log.clear()
+	var r2 = _node_a.Add(4, 4)
+	_expect_eq(r2, 8, "T9", "Add(4,4) return value on the call AFTER re-entrancy")
+	_expect_log("T9-second", ["pre:add:4:4", "vanilla:Add:4:4"])
+	_unhook_all([id])
+
+func _t10_two_instances() -> void:
+	# The guard is keyed per instance: while A's dispatch is in flight, a hook
+	# calling the same method on B must get B's FULL dispatch (pre fires for
+	# B too), with _caller correct for each.
+	var cross := func(x, y):
+		_log.append("pre:%s:%d:%d" % [str(_lib._caller.name), x, y])
+		if _lib._caller == _node_a:
+			_node_b.Add(9, 9)
+	var id: int = _lib.hook("fixturedispatch-add-pre", cross)
+	var r = _node_a.Add(1, 2)
+	_expect_eq(r, 3, "T10", "A.Add(1,2) return value")
+	_expect_log("T10", [
+		"pre:A:1:2",
+		"pre:B:9:9",
+		"vanilla:Add:9:9",
+		"vanilla:Add:1:2",
+	])
+	_expect(_lib._caller == null, "T10", "_caller restored to null after cross-instance dispatch")
+	_unhook_all([id])
+
+func _t11_coroutine() -> void:
+	var ids: Array = [
+		_lib.hook("fixturedispatch-corovalue-pre", func(x): _log.append("pre:cv:%d" % x)),
+		_lib.hook("fixturedispatch-corovalue-post", func(_x, res):
+			_log.append("post_saw:" + str(res))
+			return res + 1),
+	]
+	var r = await _node_a.CoroValue(4)
+	_expect_eq(r, 41, "T11", "await CoroValue(4): vanilla 40, +1 from the post hook")
+	_expect_log("T11", [
+		"pre:cv:4",
+		"vanilla:CoroValue:start:4",
+		"vanilla:CoroValue:end:4",
+		"post_saw:40",
+	])
+	_unhook_all(ids)
+
+func _t12_defaults() -> void:
+	var id: int = _lib.hook("fixturedispatch-withdefaults-pre", func(a, b): _log.append("pre:wd:%d:%d" % [a, b]))
+	var r = _node_a.WithDefaults(3)
+	_expect_eq(r, 10, "T12", "WithDefaults(3) with the omitted default (7) applied")
+	_expect_log("T12-omitted", ["pre:wd:3:7", "vanilla:WithDefaults:3:7"])
+	_log.clear()
+	r = _node_a.WithDefaults(3, 1)
+	_expect_eq(r, 4, "T12", "WithDefaults(3,1) with the default overridden")
+	_expect_log("T12-explicit", ["pre:wd:3:1", "vanilla:WithDefaults:3:1"])
+	_unhook_all([id])

--- a/tests/codegen/runner.gd
+++ b/tests/codegen/runner.gd
@@ -1,0 +1,501 @@
+## runner.gd -- codegen compile-check harness. NOT part of the shipped
+## loader. Executed by check_codegen.sh inside a THROWAWAY Godot project
+## assembled under the system temp dir; never run it against this repo or
+## against the Road to Vostok install.
+##
+## What it does, per fixture (a real vanilla script copied from the
+## decompiled game source, or a synthetic Fixture*.gd from this directory):
+##   1. BASELINE: the pristine source must compile in the harness project.
+##      If it doesn't, the harness environment is broken (missing stub /
+##      class) -- that is a fixture problem, never a rewriter problem.
+##   2. REWRITE: run the real _rtv_parse_script + _rtv_rewrite_vanilla_source
+##      from the built modloader (static-init neutralized by check_codegen.sh)
+##      with an empty mask (wrap every non-static method), and where the
+##      fixture declares one, ALSO with a per-method mask (the partial-rename
+##      path v3.0.1 modlists actually take).
+##   3. OUTPUT PROPERTIES (asserted on the text, independent of compilation):
+##      - the vanilla body survives verbatim under func _rtv_vanilla_<name>
+##      - the appended wrapper reproduces the original declaration line
+##        byte-for-byte (params, defaults, return annotation)
+##      - a wrapper for a NON-coroutine vanilla method contains no `await`
+##        (the 3.3.0 bug class: any `await` marks the wrapper a coroutine
+##        and breaks every caller at parse time), and a wrapper for a real
+##        coroutine keeps its `await`
+##      - static funcs and inner-class methods are never renamed or wrapped
+##      - masked rewrites rename exactly the masked set and nothing else
+##   4. COMPILE: the rewritten source replaces the fixture on disk and is
+##      recompiled at its canonical res://Scripts/ path with the real
+##      GDScript compiler (CACHE_MODE_IGNORE, same load the game performs).
+##   5. CALLER: a generated stub that CALLS every wrapped method without
+##      `await` (assigning value returns to typed locals) is compiled. A
+##      wrapper that silently became a coroutine parses fine in isolation
+##      and only fails at its call sites ("Function X() is a coroutine, so
+##      it must be called with await") -- this step is what would have
+##      caught 3.3.0 at build time.
+##
+## ADDING A FIXTURE: see the header of check_codegen.sh.
+extends SceneTree
+
+## Fixture table. "file" is a res://Scripts/ basename. Optional keys:
+##   baseline=false  pristine source is INTENTIONALLY invalid Godot 4 syntax
+##                   (legacy-autofix fixture): skip the pristine compile and
+##                   the body-verbatim check; the REWRITTEN output must still
+##                   compile because _rtv_autofix_legacy_syntax repairs it.
+##   mask=[...]      also run the rewrite with this per-method mask and
+##                   assert only the masked methods were renamed + wrapped.
+const FIXTURES: Array[Dictionary] = [
+	# Synthetic fixtures (from tests/codegen/, copied in by check_codegen.sh).
+	{"file": "FixtureDefaults.gd", "mask": ["DefaultsTricky", "CoroutineValue"]},
+	{"file": "FixtureSub.gd"},                     # extends-by-path + bare super()
+	{"file": "FixtureLegacy.gd", "baseline": false},
+	# Real vanilla scripts (copied from the decompiled game source).
+	{"file": "Loader.gd", "mask": ["ValidateShelter", "LoadScene", "FadeIn"]},
+	{"file": "Database.gd"},     # const->dict declaration transform + _get() appendix
+	{"file": "AISpawner.gd"},    # agent-assignment rewrite + Zone resolver appendix
+	{"file": "AI.gd"},           # SelectWeapon prelude + loadouts appendix
+	{"file": "FishPool.gd"},     # _ready prelude
+	{"file": "Compiler.gd"},     # Spawn prelude (after_var_decls insertion)
+	{"file": "Camera.gd"},       # class_name script
+	{"file": "Character.gd"},    # large gameplay script, several coroutines
+	{"file": "Menu.gd", "mask": ["_ready"]},  # matches _seed_core_hooks reality
+	{"file": "Bed.gd"},          # small await-heavy interactable
+]
+
+## Methods whose body the rewriter legitimately modifies (prelude injection /
+## declaration transforms) -- excluded from the byte-verbatim body check ONLY.
+## The wrapper + coroutine assertions still apply to them. Bodies containing
+## bare super() are skipped automatically (the super rewrite is intentional).
+const BODY_MODIFIED := {
+	"Loader.gd": ["LoadScene"],
+	"Compiler.gd": ["Spawn"],
+	"FishPool.gd": ["_ready"],
+	"AI.gd": ["SelectWeapon"],
+	"AISpawner.gd": ["_ready"],
+}
+
+const WRAPPER_MARKER := "# --- Metro mod loader inline hook dispatch wrappers ---"
+
+const BUILTIN_TYPES := ["int", "float", "bool", "String", "StringName", "NodePath",
+	"Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i", "Color",
+	"Rect2", "Rect2i", "Basis", "Quaternion", "Transform2D", "Transform3D", "AABB",
+	"Plane", "Dictionary", "Array", "Callable", "Signal", "RID", "Variant",
+	"PackedByteArray", "PackedStringArray", "PackedInt32Array", "PackedInt64Array",
+	"PackedFloat32Array", "PackedFloat64Array", "PackedVector2Array",
+	"PackedVector3Array", "PackedColorArray"]
+
+var _failures: PackedStringArray = []
+var _done := false
+var _global_classes: Dictionary = {}
+# Coverage booleans -- the fixture set must keep exercising every shape.
+var _saw_sync_value := false
+var _saw_void := false
+var _saw_coroutine := false
+var _saw_defaults := false
+var _saw_validateshelter := false
+
+func _process(_delta: float) -> bool:
+	if _done:
+		return true
+	_done = true
+	_run()
+	return true
+
+func _run() -> void:
+	var t0 := Time.get_ticks_msec()
+	print("[codegen] harness start")
+	for gc in ProjectSettings.get_global_class_list():
+		_global_classes[String(gc["class"])] = true
+	var ml_script: GDScript = load("res://modloader_neutered.gd")
+	if ml_script == null:
+		_fail("harness", "could not load res://modloader_neutered.gd -- check_codegen.sh prep failed")
+		_finish(t0)
+		return
+	var ml = ml_script.new()
+	# Belt and braces: check_codegen.sh replaced the _mount_previous_session()
+	# initializer with {}. If boot code ran anyway, refuse to continue.
+	var mounted = ml.get("_filescope_mounted")
+	if not (mounted is Dictionary) or not (mounted as Dictionary).is_empty():
+		_fail("harness", "_filescope_mounted is not an empty Dictionary -- static-init boot code RAN; the neutering failed")
+		ml.free()
+		_finish(t0)
+		return
+	for fx in FIXTURES:
+		_check_fixture(ml, fx)
+	ml.free()
+	if not _saw_sync_value:
+		_fail("coverage", "no fixture exercised a synchronous value-returning method")
+	if not _saw_void:
+		_fail("coverage", "no fixture exercised a void method")
+	if not _saw_coroutine:
+		_fail("coverage", "no fixture exercised a coroutine method")
+	if not _saw_defaults:
+		_fail("coverage", "no fixture exercised default parameter values")
+	if not _saw_validateshelter:
+		_fail("coverage", "Loader.gd::ValidateShelter (the known-good 3.3.0 fixture) was not checked")
+	_finish(t0)
+
+func _finish(t0: int) -> void:
+	var ms := Time.get_ticks_msec() - t0
+	if _failures.is_empty():
+		print("[codegen] PASS: %d fixture(s), all rewritten outputs + caller stubs compile (%d ms in-engine)" % [FIXTURES.size(), ms])
+		quit(0)
+	else:
+		printerr("[codegen] FAILED: %d problem(s) (%d ms in-engine); first: %s" % [_failures.size(), ms, _failures[0]])
+		quit(1)
+
+func _fail(where: String, msg: String) -> void:
+	_failures.append(where + ": " + msg)
+	printerr("[codegen] FAIL " + where + ": " + msg)
+
+# --- fixture pipeline -------------------------------------------------------
+
+func _check_fixture(ml, fx: Dictionary) -> void:
+	var fname: String = fx["file"]
+	var path := "res://Scripts/" + fname
+	var want_baseline: bool = fx.get("baseline", true)
+	var fails_before := _failures.size()
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		_fail(fname, "fixture file missing at " + path)
+		return
+	var raw := f.get_as_text()
+	f.close()
+	var pristine := raw.replace("\r\n", "\n").replace("\r", "\n")
+	var plines: PackedStringArray = pristine.split("\n")
+
+	if want_baseline:
+		var base = ResourceLoader.load(path)
+		if base == null or not (base as Script).can_instantiate():
+			_fail(fname, "BASELINE: the PRISTINE vanilla source does not compile in the harness project. Fix the harness environment (missing preload stub / class cache entry / autoload) or pick another fixture -- this is NOT a rewriter bug.")
+			return
+
+	var parsed: Dictionary = ml._rtv_parse_script(fname, raw)
+	var nonstatic: Array = []
+	for fe in parsed["functions"]:
+		if not fe["is_static"]:
+			nonstatic.append(fe)
+	if nonstatic.is_empty():
+		_fail(fname, "fixture has no hookable (non-static) methods -- replace it with a script that has some")
+		return
+
+	# Masked rewrite first (wrap-all output is written to disk LAST so later
+	# fixtures that depend on this script see the wrap-all version).
+	if fx.has("mask"):
+		_check_masked(ml, fx, fname, path, raw, plines, parsed, nonstatic)
+
+	var rewritten: String = ml._rtv_rewrite_vanilla_source(raw, parsed, {})
+	if rewritten == raw:
+		_fail(fname, "wrap-all rewrite returned the source unchanged -- nothing was wrapped")
+		return
+	var rlines: PackedStringArray = rewritten.split("\n")
+	var marker_idx := _find_line(rlines, WRAPPER_MARKER, 0)
+	if marker_idx < 0:
+		_fail(fname, "wrapper marker comment missing from rewritten output")
+		return
+
+	for fe in nonstatic:
+		_check_method(fname, fe, plines, rlines, marker_idx, fx)
+
+	# Static funcs must never be renamed or wrapped.
+	for fe in parsed["functions"]:
+		if not fe["is_static"]:
+			continue
+		var sdecl := _decl_line(plines, fe)
+		if sdecl != "" and _find_line(rlines, "func _rtv_vanilla_" + sdecl.trim_prefix("static func "), 0) >= 0:
+			_fail(fname, "static func %s was renamed/wrapped -- static methods must stay untouched" % fe["name"])
+
+	if not _compile_at_path(fname, path, rewritten, "COMPILE (wrap-all)"):
+		return
+	_check_caller(fname, path, nonstatic, plines)
+	if _failures.size() == fails_before:
+		print("[codegen] OK %s: %d method(s) wrapped; rewritten output + caller stub compile" % [fname, nonstatic.size()])
+
+# Overwrite the fixture on disk with generated source and recompile it at its
+# canonical res:// path, bypassing the cache -- the same load the game does.
+func _compile_at_path(fname: String, path: String, source: String, stage: String) -> bool:
+	var wf := FileAccess.open(path, FileAccess.WRITE)
+	if wf == null:
+		_fail(fname, stage + ": cannot overwrite fixture file for the compile step")
+		return false
+	wf.store_string(source)
+	wf.close()
+	var scr = ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if scr == null or not (scr as Script).can_instantiate():
+		_fail(fname, stage + ": generated output does NOT compile (see the SCRIPT ERROR lines above for file/line)")
+		return false
+	return true
+
+# --- per-method output properties -------------------------------------------
+
+# The wrapper signature the emitter is contractually required to produce:
+# original name, the params verbatim, the return annotation when the vanilla
+# declaration has one. Whitespace is normalized (" -> T", single ":"), which
+# is also what _rtv_dispatch_inline_src's callers depend on.
+func _expected_wrapper_sig(fe: Dictionary) -> String:
+	var annot := ""
+	var rt = fe["return_type"]
+	if rt != null and not String(rt).is_empty():
+		annot = " -> " + String(rt)
+	return "func %s(%s)%s:" % [fe["name"], fe["params"], annot]
+
+func _decl_line(plines: PackedStringArray, fe: Dictionary) -> String:
+	var ln: int = int(fe["line_number"]) - 1
+	if ln < 0 or ln >= plines.size():
+		return ""
+	return plines[ln]
+
+func _check_method(fname: String, fe: Dictionary, plines: PackedStringArray, rlines: PackedStringArray, marker_idx: int, fx: Dictionary) -> void:
+	var name: String = fe["name"]
+	var decl := _decl_line(plines, fe)
+	if not decl.begins_with("func "):
+		_fail(fname, "%s: parsed line_number %d does not hold its declaration" % [name, fe["line_number"]])
+		return
+	# 1. Vanilla body preserved under the renamed declaration.
+	var renamed_decl := "func _rtv_vanilla_" + decl.substr(5)
+	var renamed_idx := _find_line(rlines, renamed_decl, 0)
+	if renamed_idx < 0:
+		_fail(fname, "%s: renamed vanilla body 'func _rtv_vanilla_%s(...)' not found in the rewritten output" % [name, name])
+		return
+	# 2. Wrapper preserves the signature: same name, the params VERBATIM from
+	# the pristine declaration, and the same return annotation. (Not a raw
+	# byte-compare of the whole decl line: the decompiled corpus carries
+	# spacing artifacts like '-> void :' which the emitter normalizes.)
+	# Tie the parsed params back to the pristine text first, so the expected
+	# signature cannot drift from what vanilla actually declares.
+	if not (("(" + String(fe["params"]) + ")") in decl):
+		_fail(fname, "%s: parsed params '%s' are not a verbatim slice of the declaration '%s'" % [name, str(fe["params"]), decl])
+		return
+	var expected_sig := _expected_wrapper_sig(fe)
+	var wrap_idx := _find_line(rlines, expected_sig, marker_idx)
+	if wrap_idx < 0:
+		_fail(fname, "%s: no wrapper with signature '%s' after the wrapper marker -- params, defaults and return annotation must be preserved" % [name, expected_sig])
+		return
+	# 3. Coroutine discipline. Ground truth: does the PRISTINE body await?
+	var pbody := _body_block(plines, int(fe["line_number"]) - 1)
+	var wbody := _body_block(rlines, wrap_idx)
+	var pbody_text := "\n".join(pbody)
+	var wbody_text := "\n".join(wbody)
+	var vanilla_is_coro := "await " in pbody_text
+	if vanilla_is_coro:
+		if not ("await " in wbody_text):
+			_fail(fname, "%s: vanilla method is a coroutine but its wrapper contains no 'await' -- the wrapper would return before the body resolves" % name)
+	else:
+		if "await" in wbody_text:
+			_fail(fname, "%s: wrapper for a NON-coroutine method contains 'await' -- that alone marks the wrapped method a coroutine, and every existing caller then fails at parse time ('must be called with await'). This is the 3.3.0 bug class." % name)
+	# 4. Body-verbatim preservation (skipped for legitimately modified bodies).
+	var modified: Array = BODY_MODIFIED.get(fname, [])
+	var skip: bool = (name in modified) or ("super" in pbody_text) or (not fx.get("baseline", true))
+	if not skip:
+		var rbody := _body_block(rlines, renamed_idx)
+		if "\n".join(rbody) != pbody_text:
+			_fail(fname, "%s: body under _rtv_vanilla_%s differs from the vanilla body" % [name, name])
+	# Coverage bookkeeping.
+	if vanilla_is_coro:
+		_saw_coroutine = true
+	elif bool(fe["has_return_value"]):
+		_saw_sync_value = true
+	else:
+		_saw_void = true
+	if "=" in String(fe["params"]):
+		_saw_defaults = true
+	if fname == "Loader.gd" and name == "ValidateShelter":
+		if vanilla_is_coro or not bool(fe["has_return_value"]):
+			_fail(fname, "ValidateShelter is expected to be a synchronous value-returning method; the parser disagrees -- parser regression?")
+		else:
+			_saw_validateshelter = true
+
+# --- masked rewrite ---------------------------------------------------------
+
+func _check_masked(ml, fx: Dictionary, fname: String, path: String, raw: String, plines: PackedStringArray, parsed: Dictionary, nonstatic: Array) -> void:
+	var mask: Dictionary = {}
+	for m in fx["mask"]:
+		mask[String(m).to_lower()] = true
+	var masked: String = ml._rtv_rewrite_vanilla_source(raw, parsed, mask)
+	if masked == raw:
+		_fail(fname, "MASKED: mask %s matched no methods -- fixture mask is stale" % [str(fx["mask"])])
+		return
+	var mlines: PackedStringArray = masked.split("\n")
+	var mmarker := _find_line(mlines, WRAPPER_MARKER, 0)
+	if mmarker < 0:
+		_fail(fname, "MASKED: wrapper marker missing")
+		return
+	for fe in nonstatic:
+		var name: String = fe["name"]
+		var decl := _decl_line(plines, fe)
+		if decl == "":
+			continue
+		var renamed := "func _rtv_vanilla_" + decl.substr(5)
+		if mask.has(name.to_lower()):
+			if _find_line(mlines, renamed, 0) < 0:
+				_fail(fname, "MASKED: %s is in the mask but was not renamed" % name)
+			if _find_line(mlines, _expected_wrapper_sig(fe), mmarker) < 0:
+				_fail(fname, "MASKED: %s is in the mask but has no wrapper with the original signature" % name)
+		else:
+			if _find_line(mlines, renamed, 0) >= 0:
+				_fail(fname, "MASKED: %s is NOT in the mask but was renamed -- masked-out methods must stay vanilla" % name)
+			var d := _find_line(mlines, decl, 0)
+			if d < 0 or d > mmarker:
+				_fail(fname, "MASKED: %s is NOT in the mask but its vanilla declaration is gone from the body" % name)
+	_compile_at_path(fname, path, masked, "COMPILE (masked)")
+
+# --- caller stub ------------------------------------------------------------
+
+# Generate and compile a stub that CALLS every wrapped method the way real
+# game code and mods do: no `await` on methods whose vanilla body is not a
+# coroutine, with value returns assigned to locals (typed when the return
+# annotation is resolvable from the caller's scope). A wrapper that silently
+# became a coroutine compiles fine on its own; only this file catches it.
+func _check_caller(fname: String, path: String, nonstatic: Array, plines: PackedStringArray) -> void:
+	var body := PackedStringArray()
+	var n := 0
+	for fe in nonstatic:
+		var name: String = fe["name"]
+		var args = _caller_args(String(fe["params"]))  # String or null
+		if args == null:
+			print("[codegen] note: %s::%s left out of the caller stub (parameter type not resolvable from caller scope)" % [fname, name])
+			continue
+		var pbody_text := "\n".join(_body_block(plines, int(fe["line_number"]) - 1))
+		var is_coro := "await " in pbody_text
+		var rt = fe["return_type"]  # String or null
+		var has_value: bool = bool(fe["has_return_value"]) and (rt == null or String(rt) != "void")
+		var call := "t.%s(%s)" % [name, args]
+		n += 1
+		if is_coro:
+			if has_value:
+				body.append("\tvar r%d = await %s" % [n, call])
+			else:
+				body.append("\tawait " + call)
+		else:
+			if has_value and rt != null and _type_resolvable(String(rt)):
+				body.append("\tvar r%d: %s = %s" % [n, String(rt), call])
+			elif has_value:
+				body.append("\tvar r%d = %s" % [n, call])
+			else:
+				body.append("\t" + call)
+	if body.is_empty():
+		body.append("\tpass")
+	var lines := PackedStringArray()
+	lines.append("# Generated caller stub for the REWRITTEN " + fname + " -- compile-only, never run.")
+	lines.append("# Calls every wrapped method WITHOUT await unless the vanilla body is a real")
+	lines.append("# coroutine. If a wrapper silently became a coroutine, these calls fail with")
+	lines.append("# 'Function X() is a coroutine, so it must be called with \"await\"' -- the")
+	lines.append("# exact parse-time breakage 3.3.0 shipped to every mod.")
+	lines.append("const TargetScript = preload(\"" + path + "\")")
+	lines.append("")
+	lines.append("func _rtv_codegen_probe(t: TargetScript) -> void:")
+	lines.append_array(body)
+	var caller_path := "res://callers/Caller_" + fname
+	var wf := FileAccess.open(caller_path, FileAccess.WRITE)
+	if wf == null:
+		_fail(fname, "CALLER: cannot write " + caller_path)
+		return
+	wf.store_string("\n".join(lines) + "\n")
+	wf.close()
+	var scr = ResourceLoader.load(caller_path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if scr == null or not (scr as Script).can_instantiate():
+		_fail(fname, "CALLER: calling the wrapped methods without await does not compile -- a wrapper likely became a coroutine, or the signature/return annotation drifted (see SCRIPT ERROR lines above; stub kept at %s)" % caller_path)
+
+# Placeholder argument list for the REQUIRED (non-defaulted) parameters.
+# Returns null when a parameter type cannot be satisfied from caller scope.
+func _caller_args(params: String):
+	if params.strip_edges().is_empty():
+		return ""
+	var args := PackedStringArray()
+	for part in _split_params_top_level(params):
+		var p := String(part).strip_edges()
+		if p.is_empty():
+			continue
+		if "=" in p:
+			break  # first defaulted param: this and everything after is omittable
+		var t := ""
+		var colon := p.find(":")
+		if colon >= 0:
+			t = p.substr(colon + 1).strip_edges()
+		var ph := _placeholder_for_type(t)
+		if ph == "":
+			return null
+		args.append(ph)
+	return ", ".join(args)
+
+func _placeholder_for_type(t: String) -> String:
+	if t.is_empty() or t == "Variant":
+		return "null"
+	if t.begins_with("Array"):
+		return "[]"
+	match t:
+		"int":
+			return "0"
+		"float":
+			return "0.0"
+		"bool":
+			return "false"
+		"String":
+			return "\"\""
+		"StringName":
+			return "&\"\""
+		"Dictionary":
+			return "{}"
+	if t in BUILTIN_TYPES:
+		return t + "()"
+	if ClassDB.class_exists(t) or _global_classes.has(t):
+		return "null"  # object parameters accept null
+	return ""  # unresolvable (script-local enum / inner class) -- skip the probe
+
+func _type_resolvable(t: String) -> bool:
+	if t.begins_with("Array["):
+		return _type_resolvable(t.trim_prefix("Array[").trim_suffix("]"))
+	return t in BUILTIN_TYPES or ClassDB.class_exists(t) or _global_classes.has(t)
+
+# Top-level comma split (commas inside (), [], {} or string literals belong
+# to a default value). Deliberately reimplemented here rather than calling
+# the loader's _rtv_split_params_top_level: the harness must not trust the
+# code under test to slice its own inputs.
+func _split_params_top_level(params: String) -> Array:
+	var parts: Array = []
+	var depth := 0
+	var in_str := ""
+	var escaped := false
+	var start := 0
+	for i in params.length():
+		var c := params[i]
+		if in_str != "":
+			if escaped:
+				escaped = false
+			elif c == "\\":
+				escaped = true
+			elif c == in_str:
+				in_str = ""
+		elif c == "\"" or c == "'":
+			in_str = c
+		elif c == "(" or c == "[" or c == "{":
+			depth += 1
+		elif c == ")" or c == "]" or c == "}":
+			depth -= 1
+		elif c == "," and depth == 0:
+			parts.append(params.substr(start, i - start))
+			start = i + 1
+	parts.append(params.substr(start))
+	return parts
+
+# --- text helpers -----------------------------------------------------------
+
+func _find_line(lines: PackedStringArray, exact: String, from_idx: int) -> int:
+	for i in range(maxi(from_idx, 0), lines.size()):
+		if lines[i] == exact:
+			return i
+	return -1
+
+# The indented block under a declaration line: every following line that is
+# blank or indented, stopping at the first top-level line (trailing blanks
+# stripped). Matches how the rewriter itself scopes bodies, but computed
+# independently here.
+func _body_block(lines: PackedStringArray, decl_idx: int) -> PackedStringArray:
+	var out := PackedStringArray()
+	for i in range(decl_idx + 1, lines.size()):
+		var ln := lines[i]
+		if not ln.is_empty() and ln[0] != "\t" and ln[0] != " ":
+			break
+		out.append(ln)
+	while out.size() > 0 and out[out.size() - 1].strip_edges().is_empty():
+		out.remove_at(out.size() - 1)
+	return out


### PR DESCRIPTION
Finishes 3.3.1. Everything is `fix:`, `test:`, `docs:` or `build:` -- no `feat:`, no breaking changes, so release-please should still cut **3.3.1**.

## The one that matters: 3.3.0 broke mods

The dispatch wrapper emitted an **unconditional `await`** on the replacement-hook call. In GDScript any function whose body contains `await` is a coroutine -- so the wrapper for a plain synchronous vanilla method became a coroutine, and every existing caller failed at **parse time**:

```
Parse Error: Function "ValidateShelter()" is a coroutine,
             so it must be called with "await".
```

The script holding that call then fails to load entirely. In the reported case `LobbyUI.gd` never parsed, so the lobby node was never added and the Co-op Online button simply did not exist. Blast radius scaled with the wrap surface: MCM alone declares 4 hook points and nothing visibly breaks; MCM + RTVCoop declares 384 across 35 scripts.

Runtime cost was always zero -- awaiting a non-coroutine returns immediately. The entire harm was the parse-time coroutine marking.

**A second, latent instance of the same bug** was found in the body-range scan: method bodies were scanned up to the next *top-level* `func`, so an `await` in module scope or an inner class marked the *preceding* method a coroutine. It had not fired yet on current vanilla -- it was waiting for a game update.

This does not change the hook contract. The docs already told authors to suspend in a replace callback only when the vanilla method is itself a coroutine; the wrapper failed to enforce it. Notably the commit that shipped the bug **also edited Hooks.md to document it as intended behavior, in two places** -- which is why the fix initially read as a contract change.

## Verification, because a declaration of safety is what failed last time

Three gates, ~6s, wired into `./check.sh`:

| Gate | What it proves |
|---|---|
| `check.sh` | the 25.5k-line build parses and type-checks (real Godot, headless) |
| `check_codegen.sh` | the real rewriter over real vanilla scripts -- 13 fixtures, 234 methods -- with **generated caller stubs** that invoke each wrapped method *without* `await` |
| `check_dispatch.sh` | 48 runtime assertions: pre/replace/post/deferred ordering, `skip_super`, single-owner replace, `unhook`, `_caller` across nested calls, re-entrancy, two instances, coroutines, defaults |

The caller stub is the load-bearing detail: **a wrapper that silently became a coroutine compiles fine on its own** and only fails at its call sites. Compiling the rewrites alone would have passed 3.3.0.

Every harness has a `--prove` self-test that reintroduces a real regression and requires the harness to fail; each exits 1 with "the harness is a rubber stamp -- do not trust it" if it ever passes.

## Also fixed

**Security / data loss.** A Windows path traversal in download filenames (`get_file()` only splits on `/`, so `filename="..\evil.zip"` escaped the mods dir). Unchecked `ConfigFile.load` before a full rewrite could delete every profile. A failed `override.cfg` promote plus a failed restore could leave no `override.cfg` at all -- which means the loader never loads again and cannot self-heal.

**Silent failures made loud.** A declared hook that will never fire now says so. An end-of-generation reconciliation proves declared == wrapped and names every loss with its reason, instead of reporting counts nobody could reconcile.

**User-facing.** Dev-mode folder mods mount like the zip you ship (breaking change for folder mods -- see release notes). Wrong autoload paths are visible before launch. UI scale is an explicit setting instead of a DPI guess that compounded with the game's own canvas stretch. Every thumbnail cell is captioned. Offline downloads no longer report `HTTP 0`.

**Startup is faster than `development`**: a 17,729-entry PCK directory parse removed from every launch after the first, a per-launch diagnostic `load()` per wrapped script made dev-only, ~28,000 needless regex calls per generation removed, and a quadratic dedup replaced.

## Known, deliberate

- Overlapping calls to the same **coroutine** method on the same node skip hooks -- the re-entrancy guard is held across the `await`. Documented with workarounds; fixing it properly needs a design change.
- The DEFER-VERIFY watchdog can false-alarm if a mod *fully replaces* a deferred vanilla script without extending it. Report-only, cannot break loading. Worth covering in the smoke test.

Smoke-tested in game: MCM + RTVCoop, Co-op button back, MCM's `Menu.gd` override live.
